### PR TITLE
Allow specs to be run on ruby 1.8.6

### DIFF
--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -151,9 +151,11 @@ module RSpec
         }.to raise_error(RSpec::Mocks::MockExpectationError, /Double \"test double\" received :something but passed block failed with: expected false to be true/)
       end
 
-      it "passes block to expectation block" do
+      it "passes block to expectation block", :ruby => '> 1.8.6' do
         a = nil
-        @mock.should_receive(:something) { |&block| a = block }
+        # We eval this because Ruby 1.8.6's syntax parser barfs on { |&block| ... }
+        # and prevents the entire spec suite from running.
+        eval("@mock.should_receive(:something) { |&block| a = block }")
         b = lambda { }
         @mock.something(&b)
         a.should == b

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,4 +38,15 @@ RSpec.configure do |config|
   config.color_enabled = true
   config.extend(Macros)
   config.include(RSpec::Mocks::Methods)
+
+  config.filter_run_excluding :ruby => lambda {|version|
+    case version.to_s
+    when "!jruby"
+      RUBY_ENGINE != "jruby"
+    when /^> (.*)/
+      !(RUBY_VERSION.to_s > $1)
+    else
+      !(RUBY_VERSION.to_s =~ /^#{version.to_s}/)
+    end
+  }
 end


### PR DESCRIPTION
Currently, the specs barf with a syntax error on 1.8.6.  This fixes it.
