### PR TITLE
Simple fix for "warning: `*' interpreted as argument prefix"

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -40,7 +40,7 @@ module RSpec
         new_gen = error_generator.clone
         new_gen.opts = opts
         child.error_generator = new_gen
-        child.clone_args_to_yield *@args_to_yield
+        child.clone_args_to_yield(*@args_to_yield)
         child
       end
       


### PR DESCRIPTION
This commit contains a simple fix to silence a warning produced when rspec is run with `ruby -w`.
