### PR TITLE
Fix Message expectation count when method is stubbed - Issue #28

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -24,6 +24,7 @@ module RSpec
         @order_group = expectation_ordering
         @at_least = nil
         @at_most = nil
+        @exactly = nil
         @args_to_yield = []
         @failed_fast = nil
         @args_to_yield_were_cloned = false
@@ -286,13 +287,13 @@ module RSpec
   
       def once(&block)
         @method_block = block if block
-        @expected_received_count = 1
+        set_expected_received_count :exactly, 1
         self
       end
   
       def twice(&block)
         @method_block = block if block
-        @expected_received_count = 2
+        set_expected_received_count :exactly, 2
         self
       end
   
@@ -307,10 +308,19 @@ module RSpec
         return false
       end
       
+      def actual_received_count_matters?
+        @at_least || @at_most || @exactly
+      end
+
+      def increase_actual_received_count!
+        @actual_received_count += 1
+      end
+
       protected
         def set_expected_received_count(relativity, n)
           @at_least = (relativity == :at_least)
           @at_most = (relativity == :at_most)
+          @exactly = (relativity == :exactly)
           @expected_received_count = case n
             when Numeric
               n
@@ -324,7 +334,7 @@ module RSpec
         def clear_actual_received_count!
           @actual_received_count = 0
         end
-      
+
     end
     
     class NegativeMessageExpectation < MessageExpectation

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -96,6 +96,7 @@ module RSpec
         stub = find_matching_method_stub(method_name, *args)
 
         if (stub && expectation && expectation.called_max_times?) || (stub && !expectation)
+          expectation.increase_actual_received_count! if expectation && expectation.actual_received_count_matters?
           if expectation = find_almost_matching_expectation(method_name, *args)
             expectation.advise(*args) unless expectation.expected_messages_received?
           end

--- a/spec/rspec/mocks/multiple_return_value_spec.rb
+++ b/spec/rspec/mocks/multiple_return_value_spec.rb
@@ -35,6 +35,15 @@ module RSpec
           %Q|(Mock "mock").message(any args)\n    expected: 3 times\n    received: 4 times|
         )
       end
+
+      it "doesn't complain when there are too many calls but method is stubbed too" do
+        @mock.stub(:message).and_return :stub_result
+        @mock.message.should == @return_values[0]
+        @mock.message.should == @return_values[1]
+        @mock.message.should == @return_values[2]
+        @mock.message.should == :stub_result
+        expect { @mock.rspec_verify }.to_not raise_error(RSpec::Mocks::MockExpectationError)
+      end
     end
 
     describe "a Mock expectation with multiple return values with a specified count equal to the number of values" do
@@ -72,6 +81,19 @@ module RSpec
           %Q|(Mock "mock").message(any args)\n    expected: 3 times\n    received: 4 times|
         )
       end
+
+      it "complains when there are too many calls and method is stubbed too" do
+        third = Object.new
+        @mock.stub(:message).and_return :stub_result
+        @mock.message.should == @return_values[0]
+        @mock.message.should == @return_values[1]
+        @mock.message.should == @return_values[2]
+        @mock.message.should == :stub_result
+        expect { @mock.rspec_verify }.to raise_error(
+          RSpec::Mocks::MockExpectationError, 
+          %Q|(Mock "mock").message(any args)\n    expected: 3 times\n    received: 4 times|
+        )
+      end
     end
 
     describe "a Mock expectation with multiple return values specifying at_least less than the number of values" do
@@ -94,6 +116,26 @@ module RSpec
           %Q|(Mock "mock").message(no args)\n    expected: 2 times\n    received: 1 time|
         )
       end
+
+      context "when method is stubbed too" do
+        before { @mock.stub(:message).and_return :stub_result }
+
+        it "uses the stub return value for subsequent calls" do
+          @mock.message.should equal(11)
+          @mock.message.should equal(22)
+          @mock.message.should equal(:stub_result)
+          @mock.rspec_verify
+        end
+
+        it "fails when called less than the specified number" do
+          @mock.message.should equal(11)
+          expect { @mock.rspec_verify }.to raise_error(
+            RSpec::Mocks::MockExpectationError, 
+            %Q|(Mock "mock").message(no args)\n    expected: 2 times\n    received: 1 time|
+          )
+        end
+      end
+
     end
 
     describe "a Mock expectation with multiple return values with a specified count larger than the number of values" do
@@ -126,6 +168,22 @@ module RSpec
           RSpec::Mocks::MockExpectationError, 
           %Q|(Mock "mock").message(any args)\n    expected: 3 times\n    received: 4 times|
         )
+      end
+
+      context "when method is stubbed too" do
+        before { @mock.stub(:message).and_return :stub_result }
+
+        it "fails when called greater than the specified number" do
+          @mock.message.should equal(11)
+          @mock.message.should equal(22)
+          @mock.message.should equal(22)
+          @mock.message.should equal(:stub_result)
+          expect { @mock.rspec_verify }.to raise_error(
+            RSpec::Mocks::MockExpectationError, 
+            %Q|(Mock "mock").message(any args)\n    expected: 3 times\n    received: 4 times|
+          )
+        end
+
       end
     end
   end


### PR DESCRIPTION
This is a bug fix for Issue #28
