### PR TITLE
Psych fix

### DIFF
--- a/lib/rspec/mocks/extensions/psych.rb
+++ b/lib/rspec/mocks/extensions/psych.rb
@@ -1,0 +1,21 @@
+module Psych
+  class << self
+    def dump_with_mocks(object, *args)
+      return dump_without_mocks(object, *args) unless object.instance_variable_defined?(:@mock_proxy)
+
+      mp = object.instance_variable_get(:@mock_proxy)
+      return dump_without_mocks(object, *args) unless mp.is_a?(::RSpec::Mocks::Proxy)
+
+      object.send(:remove_instance_variable, :@mock_proxy)
+
+      begin
+        dump_without_mocks(object, *args)
+      ensure
+        object.instance_variable_set(:@mock_proxy,mp)
+      end
+    end
+
+    alias_method :dump_without_mocks, :dump
+    alias_method :dump, :dump_with_mocks
+  end
+end

--- a/lib/rspec/mocks/serialization.rb
+++ b/lib/rspec/mocks/serialization.rb
@@ -1,4 +1,5 @@
 require 'rspec/mocks/extensions/marshal'
+require 'rspec/mocks/extensions/psych' if defined?(::Psych)
 
 module RSpec
   module Mocks
@@ -8,14 +9,15 @@ module RSpec
       end
 
       module YAML
-        def to_yaml(*a)
-          return super(*a) unless instance_variable_defined?(:@mock_proxy)
+        def to_yaml(options = {})
+          return nil if defined?(::Psych) && options[:nodump]
+          return super(options) unless instance_variable_defined?(:@mock_proxy)
 
           mp = @mock_proxy
           remove_instance_variable(:@mock_proxy)
 
           begin
-            super(*a)
+            super(options)
           ensure
             @mock_proxy = mp
           end


### PR DESCRIPTION
Our fix for YAML serialization works fine when you use syck (the YAML engine on 1.8, and the default on 1.9 unless you compile with a special option), but I found that it didn't work for Psych.  This fixes it.
