### PR TITLE
respond_to? returns true for :to_ary, but call of :to_ary raises NoMethodError

### DIFF
--- a/lib/rspec/mocks/mock.rb
+++ b/lib/rspec/mocks/mock.rb
@@ -35,7 +35,7 @@ module RSpec
       alias_method :to_str, :to_s
 
       def respond_to?(sym, incl_private=false)
-        __mock_proxy.null_object? ? true : super unless sym == :to_ary
+        __mock_proxy.null_object? && sym != :to_ary ? true : super 
       end
 
     private

--- a/spec/rspec/mocks/to_ary_spec.rb
+++ b/spec/rspec/mocks/to_ary_spec.rb
@@ -7,10 +7,19 @@ describe "a double receiving to_ary" do
         obj.to_ary.should be_nil
       end.to raise_error(NoMethodError)
     end
+    
+    it "doesn't respond" do
+      obj.should_not be_respond_to(:to_ary)
+    end
 
     it "can be overridden with a stub" do
       obj.stub(:to_ary) { :non_nil_value }
       obj.to_ary.should be(:non_nil_value)
+    end
+    
+    it "responds when overriden" do
+      obj.stub(:to_ary) { :non_nil_value }
+      obj.should be_respond_to(:to_ary)
     end
 
     it "supports Array#flatten" do


### PR DESCRIPTION
fixed bug, when respond_to? returns true for method :to_ary, and then, when this method calls, raise NoMethodError. For example, at this point: https://github.com/rails/rails/blob/v3.0.8/activesupport/lib/active_support/core_ext/array/wrap.rb#L43
