### PR TITLE
Improved detection of matchers in argument lists.

### DIFF
--- a/lib/rspec/mocks/argument_expectation.rb
+++ b/lib/rspec/mocks/argument_expectation.rb
@@ -26,7 +26,7 @@ module RSpec
       end
       
       def is_matcher?(obj)
-        !null_object?(obj) & obj.respond_to?(:matches?) & obj.respond_to?(:failure_message_for_should)
+        !null_object?(obj) & obj.respond_to?(:matches?) & [:failure_message_for_should, :failure_message].any? { |m| obj.respond_to?(m) }
       end
 
       def args_match?(*args)

--- a/spec/rspec/mocks/argument_expectation_spec.rb
+++ b/spec/rspec/mocks/argument_expectation_spec.rb
@@ -3,12 +3,23 @@ require 'spec_helper'
 module RSpec
   module Mocks
     describe ArgumentExpectation do
+      
       it "considers an object that responds to #matches? and #failure_message_for_should to be a matcher" do
         argument_expecatation = RSpec::Mocks::ArgumentExpectation.new
         obj = double("matcher")
         obj.stub(:respond_to?).with(:__rspec_double_acting_as_null_object?).and_return(false)
         obj.stub(:respond_to?).with(:matches?).and_return(true)
         obj.stub(:respond_to?).with(:failure_message_for_should).and_return(true)
+        argument_expecatation.is_matcher?(obj).should be_true
+      end
+      
+      it "considers an object that responds to #matches? and #failure_message to be a matcher for backward compatibility" do
+        argument_expecatation = RSpec::Mocks::ArgumentExpectation.new
+        obj = double("matcher")
+        obj.stub(:respond_to?).with(:__rspec_double_acting_as_null_object?).and_return(false)
+        obj.stub(:respond_to?).with(:matches?).and_return(true)
+        obj.stub(:respond_to?).with(:failure_message_for_should).and_return(false)
+        obj.stub(:respond_to?).with(:failure_message).and_return(true)
         argument_expecatation.is_matcher?(obj).should be_true
       end
 
@@ -18,6 +29,7 @@ module RSpec
         obj.stub(:respond_to?).with(:__rspec_double_acting_as_null_object?).and_return(false)
         obj.stub(:respond_to?).with(:matches?).and_return(true)
         obj.stub(:respond_to?).with(:failure_message_for_should).and_return(false)
+        obj.stub(:respond_to?).with(:failure_message).and_return(false)
         argument_expecatation.is_matcher?(obj).should be_false
       end
     end


### PR DESCRIPTION
It is quite likely to have an object responding to `#matches?` and `#description` that is _not_ a matcher. All Mongoid models for instance respond to `#matches?` — as soon as you add a field called `#description` you are caught.

The following leads to an error:
`view.should_receive(:my_helper_path).with(record)`

So I changed the implementation to check for `#failure_message_for_should` instead of `#description`. This seems to be closer to the definition of a matcher anyway.

See corresponding docs:

> rspec-expecations provides a number of useful Matchers we use to compose
> expectations. A Matcher is any object that responds to the following:
> 
>  matches?(actual)
>  failure_message_for_should
> 
> These methods are also part of the matcher protocol, but are optional:
> 
> does_not_match?(actual)
> failure_message_for_should_not
> description #optional
