### PR TITLE
Use __send__ method instead of send 

### DIFF
--- a/lib/rspec/mocks/any_instance/chain.rb
+++ b/lib/rspec/mocks/any_instance/chain.rb
@@ -17,7 +17,7 @@ module RSpec
 
         def playback!(instance)
           messages.inject(instance) do |_instance, message|
-            _instance.send(*message.first, &message.last)
+            _instance.__send__(*message.first, &message.last)
           end
         end
 

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -140,7 +140,7 @@ module RSpec
           @klass.class_eval(<<-EOM, __FILE__, __LINE__)
             def #{method_name}(*args, &blk)
               self.class.__recorder.playback!(self, :#{method_name})
-              self.send(:#{method_name}, *args, &blk)
+              self.__send__(:#{method_name}, *args, &blk)
             end
           EOM
         end

--- a/lib/rspec/mocks/extensions/marshal.rb
+++ b/lib/rspec/mocks/extensions/marshal.rb
@@ -7,7 +7,7 @@ module Marshal
       mp = object.instance_variable_get(:@mock_proxy)
       return dump_without_mocks(*args.unshift(object)) unless mp.is_a?(::RSpec::Mocks::Proxy)
 
-      object.send(:remove_instance_variable, :@mock_proxy)
+      object.__send__(:remove_instance_variable, :@mock_proxy)
 
       begin
         dump_without_mocks(*args.unshift(object.dup))

--- a/lib/rspec/mocks/extensions/psych.rb
+++ b/lib/rspec/mocks/extensions/psych.rb
@@ -7,7 +7,7 @@ if defined?(Psych) && Psych.respond_to?(:dump)
         mp = object.instance_variable_get(:@mock_proxy)
         return dump_without_mocks(object, *args) unless mp.is_a?(::RSpec::Mocks::Proxy)
 
-        object.send(:remove_instance_variable, :@mock_proxy)
+        object.__send__(:remove_instance_variable, :@mock_proxy)
 
         begin
           dump_without_mocks(object, *args)

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -110,7 +110,7 @@ module RSpec
           stub.advise(*args)
           raise_unexpected_message_args_error(stub, *args)
         elsif @object.is_a?(Class)
-          @object.superclass.send(method_name, *args, &block)
+          @object.superclass.__send__(method_name, *args, &block)
         else
           @object.__send__(:method_missing, method_name, *args, &block)
         end


### PR DESCRIPTION
Use `__send__` method instead of `send` method, to cover cases when target object `send` method is overridden to expose business api.
See issue #72: https://github.com/rspec/rspec-mocks/issues/72
