### PR TITLE
Document stubbing with methods / return values passed as a hash

### DIFF
--- a/features/method_stubs/simple_return_value.feature
+++ b/features/method_stubs/simple_return_value.feature
@@ -49,6 +49,15 @@ Feature: stub with a simple return value
             receiver.message.should eq(:return_value)
           end
         end
+
+        context "specified with a hash" do
+          it "returns the specified value for each method" do
+            receiver = double("receiver")
+            receiver.stub(:message => :return_value, :another_message => :a_different_return_value)
+            receiver.message.should eq(:return_value)
+            receiver.another_message.should eq(:a_different_return_value)
+          end
+        end
       end
       """
     When I run `rspec example_spec.rb`


### PR DESCRIPTION
I found that this is valid syntax, but not documented anywhere:

``` ruby
receiver.stub(:message => :return_value, :message_2 => :return_value_2)
```

So the attached patch adds an item to the `method_stubs/simple_return_value` feature to document such usage.
