### PR TITLE
Add new feature for receive_counts on mocks

### DIFF
--- a/features/message_expectations/receive_counts.feature
+++ b/features/message_expectations/receive_counts.feature
@@ -1,8 +1,5 @@
 Feature: receive counts
 
-  The implicit expectation is that the message passed to should_receive()
-  will be called x number of times.
-
   Scenario: expect a message once
     Given a file named "spec/account_spec.rb" with:
       """


### PR DESCRIPTION
Adding a new cucumber feature to cover:
- .once
- .twice
- exactly(n).times
- at_least(:once)
- at_least(n).times
- at_most(:once)
- at_most(n).times
