### PR TITLE
Use the null object, rather than re-assigning another double

### DIFF
--- a/features/method_stubs/as_null_object.feature
+++ b/features/method_stubs/as_null_object.feature
@@ -27,7 +27,6 @@ Feature: as_null_object
         end
 
         it "supports Array#flatten" do
-          null_object = double('foo')
           [null_object].flatten.should eq([null_object])
         end
       end


### PR DESCRIPTION
Tiny fix to something I spotted in the Relish docs. 
The features still passed afterwards when I tried them (1.8.7).
