### PR TITLE
Fixing blocks not being passed to stubs

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -457,11 +457,10 @@ MESSAGE
       end
 
       def invoke_return_block(*args, &block)
-        args << block unless block.nil?
         # Ruby 1.9 - when we set @return_block to return values
         # regardless of arguments, any arguments will result in
         # a "wrong number of arguments" error
-        @return_block.arity == 0 ? @return_block.call : @return_block.call(*args)
+        @return_block.arity == 0 ? @return_block.call(&block) : @return_block.call(*args, &block)
       end
 
       def clone_args_to_yield(*args)

--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -185,6 +185,24 @@ module RSpec
         @mock.rspec_verify
       end
 
+      it "passes block to stub block with an argument", :ruby => '> 1.8.6' do
+        a = nil
+        eval("@mock.stub(:something){|something_else, &block| a = block}")
+        b = lambda { }
+        @mock.something(nil, &b)
+        a.should eq b
+        @mock.rspec_verify
+      end
+
+      it "passes block to stub block without an argurment", :ruby => '>1.8.6' do
+        a = nil
+        eval("@mock.stub(:something){|&block| a = block}")
+        b = lambda { }
+        @mock.something(&b)
+        a.should eq b
+        @mock.rspec_verify
+      end
+
       it "fails right away when method defined as never is received" do
         @mock.should_receive(:not_expected).never
         expect { @mock.not_expected }.


### PR DESCRIPTION
This looks related to https://github.com/rspec/rspec-mocks/issues/18 but for stubs instead of expectations:

``` ruby
a = nil
instance = mock
instance.stub(:a_method){|&block| a = block}
b = lambda { }
instance.a_method(&b)
```

a is nil
