### PR TITLE
Initializing message expectation args to match any args(refer comment on issue #103)

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -4,7 +4,7 @@ module RSpec
     class MessageExpectation
       # @private
       attr_reader :message
-      attr_writer :expected_received_count, :method_block, :expected_from
+      attr_writer :expected_received_count, :method_block, :expected_from, :args_expectation
       protected :expected_received_count=, :method_block=, :expected_from=
       attr_accessor :error_generator
       protected :error_generator, :error_generator=
@@ -45,6 +45,7 @@ module RSpec
         new_gen.opts = opts
         child.error_generator = new_gen
         child.clone_args_to_yield(*@args_to_yield)
+        child.args_expectation = ArgumentExpectation.new(ArgumentMatchers::AnyArgsMatcher.new)
         child
       end
 

--- a/spec/rspec/mocks/stubbed_message_expectations_spec.rb
+++ b/spec/rspec/mocks/stubbed_message_expectations_spec.rb
@@ -21,6 +21,16 @@ module RSpec
         double.rspec_reset
       end
     end
-    
+
+    describe "Example with stubbed with args and expectation with no args" do
+      it "matches any args even if previously stubbed with arguments" do
+        double = double("mock")
+        double.stub(:foo).with(3).and_return("stub")
+        double.should_receive(:foo).at_least(:once).and_return("expectation")
+        double.foo
+        double.rspec_verify
+      end
+    end
+
   end
 end


### PR DESCRIPTION
If an expectation is created after a stub for the same method this will ensure that the expectation is initialized to match any args rather than the args the stub expects
Not sure which file to put the spec in though
