### PR TITLE
Cannot load a serialized Mock object

### DIFF
--- a/lib/rspec/mocks/mock.rb
+++ b/lib/rspec/mocks/mock.rb
@@ -38,6 +38,7 @@ module RSpec
 
       # @private
       def respond_to?(message, incl_private=false)
+        return false if message == :yaml_initialize
         __mock_proxy.null_object? && message != :to_ary ? true : super
       end
 

--- a/spec/rspec/mocks/serialization_spec.rb
+++ b/spec/rspec/mocks/serialization_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 module RSpec
   module Mocks
+    describe Mock do
+      it 'should be unserializable' do
+        YAML.load(subject.to_yaml).should be_a(Mock)
+      end
+    end
+
     class SerializableStruct < Struct.new(:foo, :bar); end
 
     class SerializableMockProxy


### PR DESCRIPTION
Trying to load a YAML serialized `Mock` object fails:

``` ruby
> require 'yaml'
> require 'rspec/mocks'
> YAML.load(RSpec::Mocks::Mock.new.to_yaml)
NoMethodError: undefined method `[]' for nil:NilClass
        from ./lib/rspec/mocks/error_generator.rb:8:in `initialize'
        from ./lib/rspec/mocks/proxy.rb:35:in `new'
        from ./lib/rspec/mocks/proxy.rb:35:in `initialize'
        from ./lib/rspec/mocks/methods.rb:128:in `new'
        from ./lib/rspec/mocks/methods.rb:128:in `__mock_proxy'
        from ./lib/rspec/mocks/mock.rb:41:in `respond_to?'
        from /usr/local/rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/yaml.rb:133:in `transfer'
        from /usr/local/rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/yaml.rb:133:in `node_import'
        from /usr/local/rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/yaml.rb:133:in `load'
        from /usr/local/rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/yaml.rb:133:in `load'
        from (irb):7
```

It looks like the `@options` instance variable is coming out as nil, causing an error in `ErrorGenerator#initialize`
