### PR TITLE
Explained why `before(:all)` won't work for stubs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ While this is a good thing when you really need it, you probably don't really
 need it! Take care to specify only the things that matter to the behavior of
 your code.
 
+## Use `before(:each)`, not `before(:all)`
+
+Stubs in `before(:all)` are not supported. The reason is that all stubs and mocks get cleared out after each example, so any stub that is set in `before(:all)` would work in the first example that happens to run in that group, but not for any others.
+
+Instead of `before(:all)`, use `before(:each)`.
+
 ## Further Reading
 
 There are many different viewpoints about the meaning of mocks and stubs. If


### PR DESCRIPTION
Added the explanation that @dchelimsky gave here: https://github.com/rspec/rspec-mocks/issues/92
