### PR TITLE
Expectations on a SimpleDelegator

### DIFF
--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -2,6 +2,8 @@ require 'rspec/mocks/framework'
 require 'rspec/mocks/version'
 require 'rspec/mocks/example_methods'
 
+require 'delegate'
+
 module RSpec
   module Mocks
     class << self
@@ -27,6 +29,7 @@ module RSpec
 
       def add_extensions
         Object.class_eval { include RSpec::Mocks::Methods }
+        Delegator.class_eval { include RSpec::Mocks::Methods }
         Class.class_eval  { include RSpec::Mocks::AnyInstance }
         $_rspec_mocks_extensions_added = true
       end

--- a/spec/rspec/mocks/partial_mock_spec.rb
+++ b/spec/rspec/mocks/partial_mock_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'delegate'
 
 module RSpec
   module Mocks
@@ -44,6 +45,17 @@ module RSpec
       it "should_receive mocks out the method" do
         @object.should_receive(:foobar).with(:test_param).and_return(1)
         @object.foobar(:test_param).should equal(1)
+      end
+      
+      it "should_receive mocks out the method (on a SimpleDelegator)" do
+        @delegator_object = Class.new(SimpleDelegator) do
+          def foobar(*params)
+            2
+          end
+        end.new(@object)
+        
+        @delegator_object.should_receive(:foobar).with(:test_param).and_return(1)
+        @delegator_object.foobar(:test_param).should equal(1)
       end
     
       it "should_receive handles a hash" do


### PR DESCRIPTION
BasicObject could also be used in add_extensions but I avoided that because of the discussions in rspec/rspec-expectations#114
