### PR TITLE
#stub to return self

### DIFF
--- a/features/method_stubs/multiple_values.feature
+++ b/features/method_stubs/multiple_values.feature
@@ -1,0 +1,19 @@
+Feature: multiple values on an explicit receiver returns the receiver
+
+  You can return the stubbed object when using a hash 
+  in order to stubs within a single statement.
+  
+  Scenario: and_self
+    Given a file named "multiple_values_spec.rb" with:
+      """
+      describe "with a hash" do
+        let(:object){ Object.new }
+        let(:stubbed){ object.stub(:foo => "bar") }
+
+        it "works" do
+          stubbed.should eql(object)
+        end
+      end
+      """
+    When I run `rspec multiple_values_spec.rb`
+    Then the output should contain "1 example, 0 failures"

--- a/lib/rspec/mocks/methods.rb
+++ b/lib/rspec/mocks/methods.rb
@@ -31,6 +31,7 @@ module RSpec
       def stub(message_or_hash, opts={}, &block)
         if Hash === message_or_hash
           message_or_hash.each {|message, value| stub(message).and_return value }
+          self
         else
           __mock_proxy.add_stub(caller(1)[0], message_or_hash.to_sym, opts, &block)
         end

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -72,9 +72,14 @@ module RSpec
             instance.bar.should eq('bar')
           end
           
-          it "adheres to the contract of multiple method stubbing withou any instance" do
-            Object.new.stub(:foo => 'foo', :bar => 'bar').should eq(:foo => 'foo', :bar => 'bar')
-            klass.any_instance.stub(:foo => 'foo', :bar => 'bar').should eq(:foo => 'foo', :bar => 'bar')
+          it "adheres to the contract of multiple method stubbing without any instance" do
+            object = Object.new
+            object.stub(:foo => 'foo', :bar => 'bar').should eql(object)
+          end
+          
+          it "returns the given stubs with any instance" do
+            any = klass.any_instance
+            any.stub(:foo => 'foo', :bar => 'bar').should eq(:foo => 'foo', :bar => 'bar')
           end
           
           context "allows a chain of methods to be stubbed using #stub_chain" do

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -77,6 +77,10 @@ module RSpec
         @instance.msg1.should eq(1)
         @instance.msg2.should eq(2)
       end
+      
+      it "returns the receiver when handling multiple stubbed methods" do
+        @instance.stub(:msg1 => 1, :msg2 => 2).should eql(@instance)
+      end
 
       describe "#rspec_reset" do
         it "removes stubbed methods that didn't exist" do


### PR DESCRIPTION
It would be nice if this would work:

```
  let(:city) { Factory.build(:city) }
  let(:product){ Factory.build(:product).stub(:city => city) }
```

The use-case for this came up when we wanted to rely on FactoryGirl to provide the basic attributes of an object, but when we wanted to stub a particular method that was not a simple attribute. 

If #stub returned self this should work (haven't check this).

Thoughts?
