### PR TITLE
and_raise should support intentionally raising an ArgumentError

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -179,14 +179,7 @@ module RSpec
         @order_group.handle_order_constraint self
 
         begin
-          begin
-            raise(@exception_to_raise) unless @exception_to_raise.nil?
-          rescue ArgumentError => e
-            raise e.exception(<<-MESSAGE)
-'and_raise' can only accept an Exception class if an instance can be constructed with no arguments.
-#{@exception_to_raise.to_s}'s initialize method requires #{@exception_to_raise.instance_method(:initialize).arity} arguments, so you have to supply an instance instead.
-MESSAGE
-          end
+          raise_exception unless @exception_to_raise.nil?
           Kernel::throw(*@args_to_throw) unless @args_to_throw.empty?
 
           default_return_val = if !@method_block.nil?
@@ -206,6 +199,19 @@ MESSAGE
           end
         ensure
           @actual_received_count += 1
+        end
+      end
+
+      # @private
+      def raise_exception
+        if !@exception_to_raise.respond_to?(:instance_method) ||
+            @exception_to_raise.instance_method(:initialize).arity <= 0
+          raise(@exception_to_raise)
+        else
+          raise ArgumentError.new(<<-MESSAGE)
+'and_raise' can only accept an Exception class if an instance can be constructed with no arguments.
+#{@exception_to_raise.to_s}'s initialize method requires #{@exception_to_raise.instance_method(:initialize).arity} arguments, so you have to supply an instance instead.
+MESSAGE
         end
       end
 

--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -217,6 +217,14 @@ module RSpec
         }.should raise_error(RuntimeError, "error message")
       end
 
+      it "raises instance of submitted ArgumentError" do
+        error = ArgumentError.new("error message")
+        @mock.should_receive(:something).and_raise(error)
+        lambda {
+          @mock.something
+        }.should raise_error(ArgumentError, "error message")
+      end
+
       it "fails with helpful message if submitted Exception requires constructor arguments" do
         class ErrorWithNonZeroArgConstructor < RuntimeError
           def initialize(i_take_an_argument)


### PR DESCRIPTION
Prior to rspec-mocks 2.9.0, a trivial test like this would pass:

``` ruby
it "should raise an ArgumentError" do
  error = ArgumentError.new("error message")
  @mock.should_receive(:something).and_raise(error)
  lambda {
    @mock.something
  }.should raise_error(ArgumentError, "error message")
end
```

As of 2.9.0, this now fails with the rather cryptic message: 

```
expected ArgumentError with "error message", got #<NoMethodError: undefined method `instance_method' for #<ArgumentError: error message>>
```

This appears to be a side effect of changes to introduce a friendlier error message when and_raise is called with an Exception class that doesn't have a zero-arg constructor. This fix explicitly checks for that case instead of trying to rescue all ArgumentErrors.
