### PR TITLE
Add failing spec demonstrating a regression in rspec-mocks.

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -34,7 +34,15 @@ module RSpec
       def build_child(expected_from, expected_received_count, opts={}, &implementation)
         child = clone
         child.expected_from = expected_from
-        child.implementation = implementation if implementation
+
+        if implementation
+          child.implementation = implementation
+
+          # A new block implementation is given, so the old multi-return
+          # implementation needs to be disabled
+          child.instance_variable_set(:@consecutive, false)
+        end
+
         child.expected_received_count = expected_received_count
         child.clear_actual_received_count!
         new_gen = error_generator.clone

--- a/spec/rspec/mocks/block_return_value_spec.rb
+++ b/spec/rspec/mocks/block_return_value_spec.rb
@@ -7,6 +7,14 @@ describe "a double declaration with a block handed to:" do
       obj.should_receive(:foo) { 'bar' }
       obj.foo.should eq('bar')
     end
+
+    it "works when a multi-return stub has already been set" do
+      obj = Object.new
+      return_value = Object.new
+      obj.stub(:foo).and_return(return_value, nil)
+      obj.should_receive(:foo) { return_value }
+      obj.foo.should be(return_value)
+    end
   end
 
   describe "stub" do


### PR DESCRIPTION
I intend to fix this later but want to just push it for now while I've got a failing test case.

This PR isn't ready to merge...I'm just doing this to open an issue.
