### PR TITLE
Issue #120

### DIFF
--- a/lib/rspec/mocks/methods.rb
+++ b/lib/rspec/mocks/methods.rb
@@ -135,6 +135,10 @@ module RSpec
           mp
         end
       end
+      
+      def __remove_mock_proxy
+        @mock_proxy = nil
+      end
 
       def format_chain(*chain, &blk)
         if Hash === chain.last

--- a/spec/rspec/mocks/any_instance/issue_120.rb
+++ b/spec/rspec/mocks/any_instance/issue_120.rb
@@ -7,7 +7,7 @@ module RSpec
         Object.any_instance.stub(:some_method)
         o = Object.new
         o.some_method
-        o.dup.some_method
+        lambda { o.dup.some_method }.should_not raise_error(SystemStackError)
       end
     end
   end


### PR DESCRIPTION
Invoking a stubbed method on a dup of an instance of a class stubbed using any_instance causes an infinite loop.
