### PR TITLE
[typo] underscore-ize 'ducktype' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ double.should_receive(:msg).with(1, kind_of(Numeric), "b") #2nd argument can any
 double.should_receive(:msg).with(1, boolean(), "b") #2nd argument can true or false
 double.should_receive(:msg).with(1, /abc/, "b") #2nd argument can be any String matching the submitted Regexp
 double.should_receive(:msg).with(1, anything(), "b") #2nd argument can be anything at all
-double.should_receive(:msg).with(1, ducktype(:abs, :div), "b")
+double.should_receive(:msg).with(1, duck_type(:abs, :div), "b")
                     #2nd argument can be object that responds to #abs and #div
 ```
 


### PR DESCRIPTION
`:%s/ducktype/duck_type/g`
