### PR TITLE
Issue #123 

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -28,6 +28,13 @@ module RSpec
       end
 
       # @private
+      def raise_missing_default_stub_error(expectation,*args)
+        expected_args = format_args(*expectation.expected_args)
+        actual_args = args.collect {|a| format_args(*a)}.join(", ")
+        __raise "#{intro} received #{expectation.message.inspect} with unexpected arguments\n Please stub a default value first if message might be received with other args as well. \n"
+      end
+
+      # @private
       def raise_similar_message_args_error(expectation, *args)
         expected_args = format_args(*expectation.expected_args)
         actual_args = args.collect {|a| format_args(*a)}.join(", ")

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -129,6 +129,8 @@ module RSpec
         elsif stub = find_almost_matching_stub(message, *args)
           stub.advise(*args)
           raise_unexpected_message_args_error(stub, *args)
+        elsif expectation = find_almost_matching_satisfied_expectation(message,*args)
+           raise_missing_default_stub_error(expectation, *args) if not null_object?
         elsif @object.is_a?(Class)
           @object.superclass.__send__(message, *args, &block)
         else
@@ -144,6 +146,11 @@ module RSpec
       # @private
       def raise_unexpected_message_error(method_name, *args)
         @error_generator.raise_unexpected_message_error method_name, *args
+      end
+
+      # @private
+      def raise_missing_default_stub_error(expectation, *args)
+        @error_generator.raise_missing_default_stub_error(expectation, *args)
       end
 
       private
@@ -163,6 +170,10 @@ module RSpec
 
       def find_almost_matching_expectation(method_name, *args)
         method_double[method_name].expectations.find {|expectation| expectation.matches_name_but_not_args(method_name, *args) && !expectation.called_max_times?}
+      end
+
+      def find_almost_matching_satisfied_expectation(method_name, *args)
+       method_double[method_name].expectations.find {|expectation| expectation.matches_name_but_not_args(method_name, *args) }
       end
 
       def find_matching_method_stub(method_name, *args)

--- a/spec/rspec/mocks/bug_report_123_spec.rb
+++ b/spec/rspec/mocks/bug_report_123_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'with'  do
+  it "should ask the user to stub a default value first if the message might be received with other args as well" do
+    obj = Object.new
+    obj.should_receive(:foobar).with(1)
+    obj.foobar(1)
+    lambda{ obj.foobar(2) }.should raise_error(RSpec::Mocks::MockExpectationError, /Please stub a default value first if message might be received with other args as well./)
+  end
+end


### PR DESCRIPTION
Improved error message when user forgets to stub a method  with default behavior. Based on this definition of 'with'.

"Constrains a stub or message expectation to invocations with specific arguments. With a stub, if the message might be received with other args as well,  you should stub a default value first, and then stub or mock the same message using `with` to constrain to specific arguments."
