### PR TITLE
Raise RuntimeError instead of Exception by default in and_raise to match Ruby's default

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -115,7 +115,7 @@ module RSpec
       #   car.stub(:go).and_raise
       #   car.stub(:go).and_raise(OutOfGas)
       #   car.stub(:go).and_raise(OutOfGas.new(2, :oz))
-      def and_raise(exception=Exception)
+      def and_raise(exception=RuntimeError)
         @exception_to_raise = exception
       end
 

--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -215,7 +215,12 @@ module RSpec
       end
 
       it "raises when told to" do
-        @double.should_receive(:something).and_raise(RuntimeError)
+        @double.should_receive(:something).and_raise(StandardError)
+        expect { @double.something }.to raise_error(StandardError)
+      end
+
+      it "raises RuntimeError by default" do
+        @double.should_receive(:something).and_raise
         expect { @double.something }.to raise_error(RuntimeError)
       end
 


### PR DESCRIPTION
The default exception raised by `raise` is RuntimeError, yet RSpec's `and_raise` raises Exception by default. This means that simple examples like this fail:

``` ruby
def exceptions_test(obj)
  obj.some_method
rescue
end

describe do
  it do
    obj = double("foo")
    obj.stub(:some_method).and_raise
    -> { exceptions_test(obj) }.should_not raise_error
  end
end
```

with

```
Failure/Error: -> { exceptions_test(obj) }.should_not raise_error
  expected no Exception, got #<Exception: Exception>
```

This isn't what I would expect given that no exception classes are explicitly specified anywhere, so they behavior (I would think) would be consistent and the test should pass.

This also stems from the fact that Exception is the root of Ruby's exception hierarchy, and shouldn't be rescued from without good reason. Having it be the default for `and_raise` may encourage rescuing from Exception unnecessarily to make the test pass.
