### PR TITLE
Provide a default value (Mock.new) for stub_const.

### DIFF
--- a/features/stubbing_constants/stub_defined_constant.feature
+++ b/features/stubbing_constants/stub_defined_constant.feature
@@ -15,6 +15,11 @@ Feature: Stub Defined Constant
           FOO.should eq(5)
         end
 
+        it "can stub undefined constant BAR defaulting the value to a stub" do
+          stub_const("BAR")
+          BAR.should be_a_kind_of(RSpec::Mocks::Mock)
+        end
+
         it "restores the stubbed constant when the example completes" do
           FOO.should eq(7)
         end

--- a/features/stubbing_constants/stub_undefined_constant.feature
+++ b/features/stubbing_constants/stub_undefined_constant.feature
@@ -14,6 +14,11 @@ Feature: Stub Undefined Constant
           FOO.should eq(5)
         end
 
+        it "can stub undefined constant BAR defaulting the value to a stub" do
+          stub_const("BAR")
+          BAR.should be_kind_of(RSpec::Mocks::Mock)
+        end
+
         it "undefines the constant when the example completes" do
           expect { FOO }.to raise_error(NameError)
         end

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -78,7 +78,7 @@ module RSpec
       #   stub_const("CardDeck", Class.new, :transfer_nested_constants => [:SUITS])
       #   CardDeck::SUITS # => our suits array
       #   CardDeck::NUM_CARDS # => uninitialized constant error
-      def stub_const(constant_name, value, options = {})
+      def stub_const(constant_name, value=Mock.new, options = {})
         ConstantStubber.stub(constant_name, value, options)
       end
 

--- a/spec/rspec/mocks/stub_const_spec.rb
+++ b/spec/rspec/mocks/stub_const_spec.rb
@@ -59,6 +59,10 @@ module RSpec
         it 'returns the stubbed value' do
           stub_const(const_name, 7).should eq(7)
         end
+
+        it 'provides a default stub value' do
+          stub_const(const_name).should be_a_kind_of(RSpec::Mocks::Mock)
+        end
       end
 
       shared_examples_for "unloaded constant stubbing" do |const_name|
@@ -95,6 +99,10 @@ module RSpec
           stub = Module.new
           stub_const(const_name, stub, :transfer_nested_constants => true)
           stub.constants.should eq([])
+        end
+
+        it 'provides a default stub value' do
+          stub_const(const_name).should be_a_kind_of(RSpec::Mocks::Mock)
         end
       end
 
@@ -259,6 +267,13 @@ module RSpec
           it("indicates it was previously defined") { const.should be_previously_defined }
           it("indicates it has been stubbed")       { const.should be_stubbed }
           it("exposes its original value")          { const.original_value.should eq(:m) }
+
+          context 'with no explict stubbed value' do
+            before { stub_const("TestClass::M") }
+            let(:const) { Constant.original("TestClass::M") }
+
+            it("provides a default stub") { const.should be_stubbed }
+          end
         end
 
         context 'for a previously undefined stubbed constant' do
@@ -269,6 +284,13 @@ module RSpec
           it("indicates it was not previously defined") { const.should_not be_previously_defined }
           it("indicates it has been stubbed")           { const.should be_stubbed }
           it("returns nil for the original value")      { const.original_value.should be_nil }
+
+          context 'with no explict stubbed value' do
+            before { stub_const("TestClass::M") }
+            let(:const) { Constant.original("TestClass::M") }
+
+            it("provides a default stub") { const.should be_stubbed }
+          end
         end
 
         context 'for a previously undefined unstubbed constant' do


### PR DESCRIPTION
Currently you are required to provide a value for the stubbed constant,
but there are times that I don't actually care what it is because I'm
just going to stub the usage of the constant anyhow. For example:

``` ruby
stub_const('DeathStar', stub)
Starship.stub(:status) { :operational }
```

This allows you to

``` ruby
stub_const('DeathStar')
Starship.stub(:status) { :operational }

  # or
stub_const('DeathStar').stub(:status) { :operational }
```
