### PR TITLE
allow chained method stubs during double creation

### DIFF
--- a/features/method_stubs/simple_return_value.feature
+++ b/features/method_stubs/simple_return_value.feature
@@ -52,10 +52,10 @@ Feature: stub with a simple return value
           it "returns the specified value" do
             collaborator = double("collaborator",
               :message_1 => :value_1,
-              :message_2 => :value_2
+              'message_2.message_3' => :value_2
             )
             collaborator.message_1.should eq(:value_1)
-            collaborator.message_2.should eq(:value_2)
+            collaborator.message_2.message_3.should eq(:value_2)
           end
         end
       end

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -95,7 +95,7 @@ module RSpec
 
       def assign_stubs(stubs)
         stubs.each_pair do |message, response|
-          stub(message).and_return(response)
+          stub_chain(message) { response }
         end
       end
     end

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -4,9 +4,14 @@ describe "double" do
   it "is an alias for stub and mock" do
     double().should be_a(RSpec::Mocks::Mock)
   end
-  
+
   it "uses 'Double' in failure messages" do
     double = double('name')
     expect {double.foo}.to raise_error(/Double "name" received/)
+  end
+
+  it "allows stubbing of chained methods" do
+    obj = double(:obj, 'foo.bar' => 'baz')
+    obj.foo.bar.should == 'baz'
   end
 end


### PR DESCRIPTION
Simple change to allow this:

``` ruby
foo = double(:foo, "bar.baz" => "chained")
foo.bar.baz # => "chained"
```
