### PR TITLE
and_raise has an additional message argument

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -19,6 +19,7 @@ module RSpec
         @argument_list_matcher = ArgumentListMatcher.new(ArgumentMatchers::AnyArgsMatcher.new)
         @consecutive = false
         @exception_to_raise = nil
+        @exception_to_raise_message = ""
         @args_to_throw = []
         @order_group = expectation_ordering
         @at_least = @at_most = @exactly = nil
@@ -115,8 +116,9 @@ module RSpec
       #   car.stub(:go).and_raise
       #   car.stub(:go).and_raise(OutOfGas)
       #   car.stub(:go).and_raise(OutOfGas.new(2, :oz))
-      def and_raise(exception=RuntimeError)
+      def and_raise(exception=RuntimeError, message = "")
         @exception_to_raise = exception
+        @exception_to_raise_message = message
       end
 
       # @overload and_throw(symbol)
@@ -188,10 +190,14 @@ module RSpec
       def raise_exception
         if !@exception_to_raise.respond_to?(:instance_method) ||
             @exception_to_raise.instance_method(:initialize).arity <= 0
-          raise(@exception_to_raise)
+          if @exception_to_raise.instance_of? Class
+            raise(@exception_to_raise, @exception_to_raise_message)
+          else
+            raise(@exception_to_raise)
+          end
         else
           raise ArgumentError.new(<<-MESSAGE)
-'and_raise' can only accept an Exception class if an instance can be constructed with no arguments.
+'and_raise' can only accept an Exception class if an instance can be constructed with none or one arguments.
 #{@exception_to_raise.to_s}'s initialize method requires #{@exception_to_raise.instance_method(:initialize).arity} arguments, so you have to supply an instance instead.
 MESSAGE
         end

--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -240,9 +240,16 @@ module RSpec
         }.should raise_error(ArgumentError, "error message")
       end
 
-      it "fails with helpful message if submitted Exception requires constructor arguments" do
+      it "raises instance of submitted ArgumentError when passed in as class with message" do
+        @double.should_receive(:something).and_raise(ArgumentError, "error message")
+        lambda {
+          @double.something
+        }.should raise_error(ArgumentError, "error message")
+      end
+
+      it "fails with helpful message if submitted Exception requires more than one constructor arguments" do
         class ErrorWithNonZeroArgConstructor < RuntimeError
-          def initialize(i_take_an_argument)
+          def initialize(i_take_an_argument, and_an_additional_one)
           end
         end
 


### PR DESCRIPTION
Added a "message" argument to and_raise and also allow classes to be passed with one message argument. Decided to implement it after the discussion on the rspec list. Feel free to decline it or implement it different.

(an alternative implementation I made was to let and_raise create the instance. The advantage of this is that when the Exception class passed is invalid then the and_raise will fail and not the raise_exception. If this is preferred, then I can also make a pull request with that change)
