### PR TITLE
Alternative implementation (preferred) than Pull Request 176

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -107,10 +107,10 @@ module RSpec
       # @note
       #
       #   When you pass an exception class, the MessageExpectation will raise
-      #   an instance of it, creating it with `new` and it will pass the message
-      #   as parameter. If the exception class initializer requires more than one 
-      #   parameters, you must pass in an instance and not the class, otherwise this
-      #   mthod will raise an ArgumentError exception
+      #   an instance of it, creating it with `new` and when message was passed, then it 
+      #   will pass the message as parameter. If the exception class initializer requires 
+      #   more than one parameters, you must pass in an instance and not the class, otherwise 
+      #   this method will raise an ArgumentError exception
       #
       # @example
       #
@@ -118,14 +118,11 @@ module RSpec
       #   car.stub(:go).and_raise(OutOfGas)
       #   car.stub(:go).and_raise(OutOfGas, "OutOfGas: Need to walk")
       #   car.stub(:go).and_raise(OutOfGas.new(2, :oz))
-      def and_raise(exception=RuntimeError, message = "")
-        if !exception.respond_to?(:instance_method) || exception.instance_method(:initialize).arity <= 1
-            @exception_to_raise = (exception.instance_of? Class) ? exception.new(message) : exception
+      def and_raise(exception=RuntimeError, message = nil)
+        if exception.instance_of? Class
+          @exception_to_raise = (message.nil?) ? exception.new : exception.new(message)
         else
-          raise ArgumentError.new(<<-MESSAGE)
-'and_raise' can only accept an Exception class if an instance can be constructed with none or one arguments.
-#{@exception_to_raise.to_s}'s initialize method requires #{exception.instance_method(:initialize).arity} arguments, so you have to supply an instance instead.
-MESSAGE
+          @exception_to_raise = exception
         end
       end
 


### PR DESCRIPTION
This is the alternative implementation that I mentioned in Pull Request 176.

I would personally prefer this implementation over the other one. It is simpler and is effectively no additional LOC over the original implementation and only one parameter and one additional (inline) if.

But the main reason for preferring this implementation is that it fails earlier. When you pass an Exception class to the and_raise that cannot be created, then it will raise an ArgumentError in and_raise and not in raise_exception (when it would be used). This makes debugging this a lot easier.

This does change the behavior of RSpec from late failure to early failure (which I consider a positive change)
