### PR TITLE
Fix confusing error message.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@ Bug fixes
   (Andy Lindeman)
 * Methods stubbed with `any_instance` are unstubbed after the test finishes.
   (Andy Lindeman)
+* Fix confusing error message when calling a mocked class method an
+  extra time with the wrong arguments (Myron Marston).
 
 Deprecations:
 

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -175,7 +175,11 @@ module RSpec
       end
 
       def find_almost_matching_expectation(method_name, *args)
-        method_double[method_name].expectations.find {|expectation| expectation.matches_name_but_not_args(method_name, *args) && !expectation.called_max_times?}
+        method_double[method_name].expectations.find do |expectation|
+          expectation.matches_name_but_not_args(method_name, *args) && !expectation.called_max_times?
+        end || method_double[method_name].expectations.find do |expectation|
+          expectation.matches_name_but_not_args(method_name, *args)
+        end
       end
 
       def find_matching_method_stub(method_name, *args)

--- a/spec/rspec/mocks/partial_mock_spec.rb
+++ b/spec/rspec/mocks/partial_mock_spec.rb
@@ -93,6 +93,17 @@ module RSpec
           %Q|(nil).foobar(any args)\n    expected: 1 time\n    received: 0 times|
         )
       end
+
+      MockableClass = Class.new
+
+      it "includes the class name in the error when mocking a class method that is called an extra time with the wrong args" do
+        MockableClass.should_receive(:bar).with(1)
+        MockableClass.bar(1)
+
+        expect {
+          MockableClass.bar(2)
+        }.to raise_error(RSpec::Mocks::MockExpectationError, /MockableClass/)
+      end
     end
     
     describe "Partially mocking an object that defines ==, after another mock has been defined" do


### PR DESCRIPTION
When a class method was mocked and it was called an extra time with the wrong arguments, the error being raised was:

"NoMethodError: undefined method `bar' for Object:Class"

...which was very confusing.
