### PR TITLE
Fix stub_const for case that const_missing defines target nested constant

### DIFF
--- a/lib/rspec/mocks/mutate_const.rb
+++ b/lib/rspec/mocks/mutate_const.rb
@@ -28,6 +28,12 @@ module RSpec
       #   - C.constants(false) #=> []
       if Module.method(:const_defined?).arity == 1
         def const_defined_on?(mod, const_name)
+          begin
+            mod.const_get(const_name)
+          rescue NameError
+            return false
+          end
+
           mod.const_defined?(const_name)
         end
 
@@ -44,6 +50,12 @@ module RSpec
         end
       else
         def const_defined_on?(mod, const_name)
+          begin
+            mod.const_get(const_name)
+          rescue NameError
+            return false
+          end
+
           mod.const_defined?(const_name, false)
         end
 

--- a/spec/rspec/mocks/mutate_const_spec.rb
+++ b/spec/rspec/mocks/mutate_const_spec.rb
@@ -12,9 +12,26 @@ class TestClass
   end
 end
 
+class TestConstMissingClass
+  def self.const_missing(name)
+    if name == :Missing
+      klass = Class.new do
+        def foo
+          :bar
+        end
+      end
+      const_set :Missing, klass
+      return klass
+    else
+      super
+    end
+  end
+end
+
 class TestSubClass < TestClass
   P = :p
 end
+
 
 module RSpec
   module Mocks
@@ -309,6 +326,17 @@ module RSpec
 
         context 'for an unloaded unnested constant' do
           it_behaves_like "unloaded constant stubbing", "X"
+        end
+
+        context 'for an dynamically defined nested constant' do
+          before do
+            stub_const "TestConstMissingClass::Missing::X", :foo
+          end
+
+          it "uses dynamically defined class" do
+            TestConstMissingClass::Missing::X.should == :foo
+            TestConstMissingClass::Missing.new.foo.should == :bar
+          end
         end
 
         context 'for an unloaded nested constant' do


### PR DESCRIPTION
Added `const_get` before calling `const_defined` because `Module#const_missing` may
define target constant.

Representive case is a Ruby on Rails (`ActiveSupport`),
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/dependencies.rb#L176

In test in a Rails app, you'll get an error if you used `stub_const` for
controllers, models, helpers, etc before it get loaded by
`ActiveSupport::Dependencies::ModuleConstMissing#const_missing`.
1. `stub_const "FooController::X", :foo`
2. `rspec-mocks` defines `FooController` as empty module
3. call `FooController`
4. Normally, const_missing has called and Rails loads the controller,
   but `rspec-mocks` defined `FooController` in `stub_const`,
   so controller won't be loaded.
5. You'll get an error.
