### PR TITLE
Use Kernel#inspect instead of #to_s

### DIFF
--- a/spec/rspec/mocks/partial_mock_spec.rb
+++ b/spec/rspec/mocks/partial_mock_spec.rb
@@ -94,7 +94,7 @@ module RSpec
 
       it "includes the class name in the error when mocking a class method that is called an extra time with the wrong args" do
         klass = Class.new do
-          def self.to_s
+          def self.inspect
             "MyClass"
           end
         end


### PR DESCRIPTION
Kernel#inspect does not call #to_s anymore, on Ruby2.0.0

```
klass = Class.new do
  def self.to_s
    "MyClass"
  end
end

Ruby1.9.3
=> MyClass

Ruby2.0.0
=> #<Class:0x007ffe0c4c2ab8>
```
