### PR TITLE
Simplify implementation of consecutive return values.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,14 @@
+### Dev
+[full changelog](http://github.com/rspec/rspec-mocks/compare/v2.12.2...master)
+
+Bug fixes
+
+* Fix bug that caused weird behavior when a method that had
+  previously been stubbed with multiple return values (e.g.
+  `obj.stub(:foo).and_return(1, 2)`) was later mocked with a
+  single return value (e.g. `obj.should_receive(:foo).once.and_return(1)`).
+  (Myron Marston)
+
 ### 2.12.2 / 2013-01-27
 [full changelog](http://github.com/rspec/rspec-mocks/compare/v2.12.1...v.2.12.2)
 

--- a/spec/rspec/mocks/multiple_return_value_spec.rb
+++ b/spec/rspec/mocks/multiple_return_value_spec.rb
@@ -2,6 +2,19 @@ require 'spec_helper'
 
 module RSpec
   module Mocks
+    describe "a double stubbed with multiple return values" do
+      let(:a_double) { double }
+
+      before do
+        a_double.stub(:foo).and_return(:val_1, nil)
+      end
+
+      it 'can still set a message expectation with a single return value' do
+        a_double.should_receive(:foo).once.and_return(:val_1)
+        expect(a_double.foo).to eq(:val_1)
+      end
+    end
+
     describe "a message expectation with multiple return values and no specified count" do
       before(:each) do
         @double = double


### PR DESCRIPTION
There's no need to track extra instance variable state (e.g. @consecutive); 
instead, the implementation lambda can just do the right thing.

This also fixes #217. Previously, message_expectation got confused when it
was in consecutive mode (due to being stubbed with multiple return values)
and then got mocked with a single return value. This simplified implementation
fixes this bug.

@alindeman -- can you code review this, please?
