### PR TITLE
Use the matching parent stub rather than just picking the first one.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,12 @@ Bug fixes
   `obj.stub(:foo).and_return(1, 2)`) was later mocked with a
   single return value (e.g. `obj.should_receive(:foo).once.and_return(1)`).
   (Myron Marston)
+* Fix bug related to a mock expectation for a method that already had
+  multiple stubs with different `with` constraints. Previously, the
+  first stub was used, even though it may not have matched the passed
+  args. The fix defers this decision until the message is received so
+  that the proper stub response can be chosen based on the passed
+  arguments (Myron Marston).
 
 ### 2.12.2 / 2013-01-27
 [full changelog](http://github.com/rspec/rspec-mocks/compare/v2.12.1...v.2.12.2)

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -214,12 +214,8 @@ module RSpec
       # @private
       def add_expectation(error_generator, expectation_ordering, expected_from, opts, &implementation)
         configure_method
-        expectation = if existing_stub = stubs.first
-                        existing_stub.build_child(expected_from, 1, opts, &implementation)
-                      else
-                        MessageExpectation.new(error_generator, expectation_ordering,
-                                               expected_from, self, 1, opts, &implementation)
-                      end
+        expectation = MessageExpectation.new(error_generator, expectation_ordering,
+                                             expected_from, self, 1, opts, stubs, &implementation)
         expectations << expectation
         expectation
       end

--- a/spec/rspec/mocks/and_yield_spec.rb
+++ b/spec/rspec/mocks/and_yield_spec.rb
@@ -5,6 +5,19 @@ describe RSpec::Mocks::Mock do
   let(:obj) { double }
 
   describe "#and_yield" do
+    context 'when the method double has been constrained by `with`' do
+      it 'uses the default stub if the provided args do not match' do
+        obj.stub(:foo) { 15 }
+        obj.stub(:foo).with(:yield).and_yield
+
+        # should_receive is required to trigger the bug:
+        # https://github.com/rspec/rspec-mocks/issues/127
+        obj.should_receive(:foo)
+
+        expect(obj.foo(:dont_yield)).to eq(15)
+      end
+    end
+
     context "with eval context as block argument" do
 
       it "evaluates the supplied block as it is read" do

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -260,6 +260,19 @@ module RSpec
       it "supports options" do
         @stub.stub(:foo, :expected_from => "bar")
       end
+
+      it 'uses the correct stubbed response when responding to a mock expectation' do
+        @stub.stub(:bar) { 15 }
+        @stub.stub(:bar).with(:eighteen) { 18 }
+        @stub.stub(:bar).with(:thirteen) { 13 }
+
+        @stub.should_receive(:bar).exactly(4).times
+
+        expect(@stub.bar(:blah)).to eq(15)
+        expect(@stub.bar(:thirteen)).to eq(13)
+        expect(@stub.bar(:eighteen)).to eq(18)
+        expect(@stub.bar).to eq(15)
+      end
     end
 
   end


### PR DESCRIPTION
Previously, when a mock expectation was added, it was derived as a
child stub from the first existing stub. However, if there were multiple
existing stubs constrained with different `with` criteria, this could
cause it to pick the wrong one because it arbitrarily chose the first
one.

Our fix is to defer the choosing of the parent stub until the message
expectation is invoked, at which point we can properly match the
parent stub based on the arguments.

As part of this, I've refactored MessageExpectation, extracting a new
MessageImplementation class to hold the logic for an implementation
based on `and_return` and `and_yield` declarations.

Fixes #127.

@dchelimsky / @alindeman -- can one or both of you review this?  This is a large enough change that it has the potential to introduce regressions (although, all specs pass, of course).  If either of you can think of a simpler/better fix, please let me know!
