### PR TITLE
disallow unstub! on any_instance

### DIFF
--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -92,6 +92,11 @@ module RSpec
         end
 
         # @private
+        def unstub!(*)
+          raise "unstub! is not supported on any_instance. Use unstub instead."
+        end
+
+        # @private
         def stop_all_observation!
           @observed_methods.each {|method_name| restore_method!(method_name)}
         end

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -245,6 +245,14 @@ module RSpec
         end
       end
 
+      context "with #unstub!" do
+        it "raises with a message instructing the user to use unstub instead" do
+          expect do
+            klass.any_instance.unstub!(:foo)
+          end.to raise_error(/Use unstub instead/)
+        end
+      end
+
       context "unstub implementation" do
         it "replaces the stubbed method with the original method" do
           klass.any_instance.stub(:existing_method)


### PR DESCRIPTION
Calling **unstub!** on any_instance threw me for a bit of a loop today.

Scenario (Cucumber before do):

```
Before do
  User.any_instance.stub(:after_database_authentication)
end
```

This works:

```
And /^And I do stuff$/ do
  User.any_instance.unstub(:after_database_authentication)
end
```

This breaks:

```
And /^And I do stuff$/ do
  User.any_instance.unstub!(:after_database_authentication)
end
```

In pry:

Good:

```
User.any_instance.unstub(:after_database_authentication)
=> :after_database_authentication
```

Bad:

```
User.any_instance.unstub!(:after_database_authentication)
RSpec::Mocks::MockExpectationError: The method `after_database_authentication` was not stubbed or was already unstubbed
from /Users/ryan/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/rspec-mocks-2.9.0/lib/rspec/mocks/method_double.rb:181:in `raise_method_not_stubbed_error'
```

This should prevent any future headaches. I'm unsure of any scenarios where you would use the current implementation of any_instance.unstub! (let me know if you do!).
