### PR TITLE
output deprecation warning on #any_number_of_times

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -334,6 +334,9 @@ module RSpec
 
       # Allows an expected message to be received any number of times.
       def any_number_of_times(&block)
+        RSpec::Mocks.warn_deprecation <<-MSG
+DEPRECATION: `#any_number_of_times` is deprecated, use `#stub` instead. Called from #{caller(0)[1]}
+MSG
         @implementation = block if block
         @expected_received_count = :any
         self

--- a/spec/rspec/mocks/any_number_of_times_spec.rb
+++ b/spec/rspec/mocks/any_number_of_times_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 describe "AnyNumberOfTimes" do
   before(:each) do
     @mock = RSpec::Mocks::Mock.new("test mock")
+    RSpec::Mocks.stub(:warn_deprecation)
+  end
+
+  it "outputs a deprecation warning" do
+    RSpec::Mocks.should_receive(:warn_deprecation).with(/DEPRECATION: `#any_number_of_times` is deprecated/)
+    @mock.should_receive(:random_call).any_number_of_times
   end
 
   it "passes if any number of times method is called many times" do


### PR DESCRIPTION
closes https://github.com/rspec/rspec-mocks/issues/131
should be merged/not merged together with https://github.com/rspec/rspec-mocks/pull/231
