### PR TITLE
Deprecate #stub! and #unstub!

### DIFF
--- a/lib/rspec/mocks/methods.rb
+++ b/lib/rspec/mocks/methods.rb
@@ -52,7 +52,10 @@ module RSpec
         stub(message_or_hash, opts={}, &block)
       end
 
-      alias_method :unstub!, :unstub
+      def unstub!(message)
+        RSpec::Mocks.warn_deprecation "\nDEPRECATION: use #unstub instead of #unstub!.  #{caller(0)[1]}\n"
+        unstub(message)
+      end
 
       # @overload stub_chain(method1, method2)
       # @overload stub_chain("method1.method2")

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -46,6 +46,22 @@ module RSpec
         end
       end
 
+      describe 'using unstub' do
+        it 'removes the message stub' do
+          @instance.stub(:msg)
+          @instance.unstub(:msg)
+          expect { @instance.msg }.to raise_error NoMethodError
+        end
+      end
+
+      describe 'using unstub!' do
+        it 'removes the message stub but warns about deprecation' do
+          @instance.stub(:msg)
+          RSpec::Mocks.should_receive(:warn_deprecation).with(/DEPRECATION: use #unstub instead of #unstub!/)
+          @instance.unstub!(:msg)
+          expect { @instance.msg }.to raise_error NoMethodError
+        end
+      end
 
       it "instructs an instance to respond_to the message" do
         @instance.stub(:msg)


### PR DESCRIPTION
Further to discussion #122 this deprecates `stub!` and `unstub!`.
I added an additional test case for `unstub`, seeing as it wasn't tested on the top level...
