### PR TITLE
Generate a useful description for have_received

### DIFF
--- a/features/spies/spy_pure_mock_method.feature
+++ b/features/spies/spy_pure_mock_method.feature
@@ -61,3 +61,16 @@ Feature: Spy on a stubbed method on a pure mock
     When I run `rspec failed_message_expectations_spec.rb`
     Then the output should contain "expected: (:expected, :arguments)"
     And the output should contain "got: (:unexpected)"
+
+  Scenario: generate a spy message
+    Given a file named "spy_message_spec.rb" with:
+      """ruby
+      describe "have_received" do
+      subject(:invitation) { double('invitation', :deliver => true) }
+        before { invitation.deliver }
+
+        it { should have_received(:deliver) }
+      end
+      """
+    When I run `rspec --format documentation spy_message_spec.rb`
+    Then the output should contain "should have received deliver"

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -74,6 +74,11 @@ module RSpec
       end
 
       # @private
+      def describe_expectation(message, expected_received_count, actual_received_count, *args)
+        "have received #{message}#{format_args(*args)} #{count_message(expected_received_count)}"
+      end
+
+      # @private
       def raise_out_of_order_error(message)
         __raise "#{intro} received :#{message} out of order"
       end

--- a/lib/rspec/mocks/have_received.rb
+++ b/lib/rspec/mocks/have_received.rb
@@ -13,14 +13,14 @@ module RSpec
       def matches?(subject)
         @subject = subject
         @expectation = expect
-        @expectation.expected_messages_received?
+        expected_messages_received?
       end
 
       def does_not_match?(subject)
         @subject = subject
         ensure_count_unconstrained
         @expectation = expect.never
-        @expectation.expected_messages_received?
+        expected_messages_received?
       end
 
       def failure_message
@@ -29,6 +29,10 @@ module RSpec
 
       def negative_failure_message
         generate_failure_message
+      end
+
+      def description
+        expect.description
       end
 
       CONSTRAINTS.each do |expectation|
@@ -41,9 +45,9 @@ module RSpec
       private
 
       def expect
-        build_expectation do |expectation|
-          apply_constraints_to expectation
-        end
+        expectation = mock_proxy.build_expectation(@method_name)
+        apply_constraints_to expectation
+        expectation
       end
 
       def apply_constraints_to(expectation)
@@ -72,8 +76,9 @@ module RSpec
         error.message
       end
 
-      def build_expectation(&block)
-        mock_proxy.build_expectation(@method_name, &block)
+      def expected_messages_received?
+        mock_proxy.replay_received_message_on @expectation
+        @expectation.expected_messages_received?
       end
 
       def mock_proxy

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -257,6 +257,11 @@ module RSpec
         return nil
       end
 
+      # @private
+      def description
+        @error_generator.describe_expectation(@message, @expected_received_count, @actual_received_count, *expected_args)
+      end
+
       def raise_out_of_order_error
         @error_generator.raise_out_of_order_error @message
       end

--- a/spec/rspec/mocks/have_received_spec.rb
+++ b/spec/rspec/mocks/have_received_spec.rb
@@ -75,6 +75,11 @@ module RSpec
           end
         end
 
+        it 'generates a useful description' do
+          matcher = have_received(:expected_method).with(:expected_args).once
+          expect(matcher.description).to eq 'have received expected_method(:expected_args) 1 time'
+        end
+
         context "counts" do
           let(:dbl) { double(:expected_method => nil) }
 


### PR DESCRIPTION
- Makes `it { should have_received(:message) }` produce useful output

Resolves #254.

A few implementation notes:
- I added the actual description to ErrorGenerator, as it has a lot of useful, reusable behavior related to messages. However, it's not a message, so maybe it should go somewhere else, or that class should be renamed to "MessageGenerator"?
- I separated `Proxy#build_expectation` into two phases so that exceptions won't be raised when calling `matches?` or `description`.  Otherwise, you don't get a description if you mess up the stub.
