### PR TITLE
Ruby 2.1 compatibility

### DIFF
--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -81,23 +81,32 @@ module RSpec
         any_instance_class_recorder_observing_method?(superklass)
       end
 
-      # @private
-      def original_method_from_ancestry
-        original_method_from_ancestor(object_singleton_class.ancestors)
-      rescue NameError
-        raise unless @object.respond_to?(:superclass)
+      our_singleton_class = class << self; self; end
+      if our_singleton_class.ancestors.include? our_singleton_class
+        # In Ruby 2.1, ancestors include the correct ancestors, including the singleton classes
+        def original_method_from_ancestry
+          # Lookup in the ancestry, skipping over the singleton class itself
+          original_method_from_ancestor(object_singleton_class.ancestors.drop(1))
+        end
+      else
+        # @private
+        def original_method_from_ancestry
+          original_method_from_ancestor(object_singleton_class.ancestors)
+        rescue NameError
+          raise unless @object.respond_to?(:superclass)
 
-        # Example: a singleton method defined on @object's superclass.
-        #
-        # Note: we have to give precedence to instance methods
-        # defined on @object's class, because in a case like:
-        #
-        # `klass.should_receive(:new).and_call_original`
-        #
-        # ...we want `Class#new` bound to `klass` (which will return
-        # an instance of `klass`), not `klass.superclass.new` (which
-        # would return an instance of `klass.superclass`).
-        original_method_from_superclass
+          # Example: a singleton method defined on @object's superclass.
+          #
+          # Note: we have to give precedence to instance methods
+          # defined on @object's class, because in a case like:
+          #
+          # `klass.should_receive(:new).and_call_original`
+          #
+          # ...we want `Class#new` bound to `klass` (which will return
+          # an instance of `klass`), not `klass.superclass.new` (which
+          # would return an instance of `klass.superclass`).
+          original_method_from_superclass
+        end
       end
 
       def original_method_from_ancestor(ancestors)


### PR DESCRIPTION
Ruby 2.1 will return a more consistent ancestor list from singleton classes. This pull request addresses this change. Note that this makes processing easier in 2.1.

Note: I saw some checks on RUBY_VERSION in the code, but I opted to check for the behavior instead.
