### PR TITLE
Remove throw arguments ambiguity

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -142,7 +142,7 @@ module RSpec
       #   car.stub(:go).and_throw(:out_of_gas)
       #   car.stub(:go).and_throw(:out_of_gas, :level => 0.1)
       def and_throw(*args)
-        @implementation = Proc.new { throw *args }
+        @implementation = Proc.new { throw(*args) }
       end
 
       # Tells the object to yield one or more args to a block when the message


### PR DESCRIPTION
When running the specs for another project with the `-w` flag, I was receiving the following warning:

`rspec/mocks/message_expectation.rb:145: warning: '*' interpreted as argument prefix`

This patch adds parentheses to remove the ambiguity of `*` and the associated warning.
