### PR TITLE
Externalize `any_instance` methods and state like we did mock proxies.

### DIFF
--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -27,6 +27,10 @@ module RSpec
         space.proxy_for(object)
       end
 
+      def any_instance_recorder_for(klass)
+        space.any_instance_recorder_for(klass)
+      end
+
       def configuration
         @configuration ||= Configuration.new
       end

--- a/lib/rspec/mocks/any_instance.rb
+++ b/lib/rspec/mocks/any_instance.rb
@@ -26,35 +26,7 @@ module RSpec
       #
       # @return [Recorder]
       def any_instance
-        AnyInstance.tracked_classes << self
-        __recorder
-      end
-
-      # @private
-      def rspec_verify
-        __recorder.verify
-      ensure
-        __recorder.stop_all_observation!
-        @__recorder = nil
-      end
-
-      # @private
-      def __recorder
-        @__recorder ||= AnyInstance::Recorder.new(self)
-      end
-
-      def self.verify_all
-        tracked_classes.each do |klass|
-          klass.rspec_verify
-        end
-      end
-
-      def self.reset_all
-        tracked_classes.clear
-      end
-
-      def self.tracked_classes
-        @tracked_classes ||= []
+        ::RSpec::Mocks.any_instance_recorder_for(self)
       end
     end
   end

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -70,12 +70,12 @@ module RSpec
 
       def original_unrecorded_any_instance_method
         return nil unless any_instance_class_recorder_observing_method?(@object.class)
-        alias_name = @object.class.__recorder.build_alias_method_name(@method_name)
+        alias_name = ::RSpec::Mocks.any_instance_recorder_for(@object.class).build_alias_method_name(@method_name)
         @object.method(alias_name)
       end
 
       def any_instance_class_recorder_observing_method?(klass)
-        return true if klass.__recorder.already_observing?(@method_name)
+        return true if ::RSpec::Mocks.any_instance_recorder_for(klass).already_observing?(@method_name)
         superklass = klass.superclass
         return false if superklass.nil?
         any_instance_class_recorder_observing_method?(superklass)

--- a/lib/rspec/mocks/space.rb
+++ b/lib/rspec/mocks/space.rb
@@ -2,10 +2,11 @@ module RSpec
   module Mocks
     # @api private
     class Space
-      attr_reader :proxies
+      attr_reader :proxies, :any_instance_recorders
 
       def initialize
         @proxies = {}
+        @any_instance_recorders = {}
       end
 
       def verify_all
@@ -13,23 +14,36 @@ module RSpec
           object.verify
         end
 
-        AnyInstance.verify_all
+        any_instance_recorders.each_value do |recorder|
+          recorder.verify
+        end
       end
 
       def reset_all
         ConstantMutator.reset_all
-        AnyInstance.reset_all
 
         proxies.each_value do |object|
           object.reset
         end
 
         proxies.clear
+        any_instance_recorders.clear
         expectation_ordering.clear
       end
 
       def expectation_ordering
         @expectation_ordering ||= OrderGroup.new
+      end
+
+      def any_instance_recorder_for(klass)
+        id = klass.__id__
+        any_instance_recorders.fetch(id) do
+          any_instance_recorders[id] = AnyInstance::Recorder.new(klass)
+        end
+      end
+
+      def remove_any_instance_recorder_for(klass)
+        any_instance_recorders.delete(klass.__id__)
       end
 
       def proxy_for(object)

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -711,7 +711,7 @@ module RSpec
       end
 
       context "when resetting post-verification" do
-        let(:space) { RSpec::Mocks::Space.new }
+        let(:space) { RSpec::Mocks.space }
 
         context "existing method" do
           before(:each) do
@@ -843,8 +843,9 @@ module RSpec
         end
 
         it "adds an class to the current space when #any_instance is invoked" do
-          klass.any_instance
-          expect(AnyInstance.tracked_classes).to include(klass)
+          expect {
+            klass.any_instance
+          }.to change { space.any_instance_recorders.size }.by(1)
         end
 
         it "adds an instance to the current space when stubbed method is invoked" do

--- a/spec/rspec/mocks/methods_spec.rb
+++ b/spec/rspec/mocks/methods_spec.rb
@@ -3,21 +3,27 @@ require 'spec_helper'
 module RSpec
   module Mocks
     describe Methods, :if => (Method.method_defined?(:owner)) do
-      def methods_added_to_all_objects
-        some_object = Object.new
+      def added_methods(klass, owner)
+        some_object = klass.new
         (some_object.methods + some_object.private_methods).select do |method|
-          some_object.method(method).owner == RSpec::Mocks::Methods
+          some_object.method(method).owner == owner
         end.map(&:to_sym)
       end
 
       it 'limits the number of methods that get added to all objects' do
         # If really necessary, you can add to this list, but long term,
         # we are hoping to cut down on the number of methods added to all objects
-        expect(methods_added_to_all_objects).to match_array([
+        expect(added_methods(Object, RSpec::Mocks::Methods)).to match_array([
           :as_null_object, :null_object?,
           :received_message?, :should_not_receive, :should_receive,
           :stub, :stub!, :stub_chain, :unstub, :unstub!
         ])
+      end
+
+      it 'limits the number of methods that get added to all classes ' do
+        # If really necessary, you can add to this list, but long term,
+        # we are hoping to cut down on the number of methods added to all classes
+        expect(added_methods(Class, RSpec::Mocks::AnyInstance)).to match_array([:any_instance])
       end
     end
   end


### PR DESCRIPTION
This is similar to #250, but doing a similar refactoring for `any_instance`.
