### PR TITLE
Remove a to_not raise_error(NameError) in mock_spec.

### DIFF
--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -494,7 +494,6 @@ module RSpec
         @double.foobar
         verify @double
 
-        expect { @double.foobar }.to_not raise_error(NameError)
         expect { @double.foobar }.to raise_error(RSpec::Mocks::MockExpectationError)
       end
 


### PR DESCRIPTION
to_not raise_error with a specific class is now deprecated. I'm removing this because of the warning. Not 100% about this one: @myronmarston it appears that this one is originally yours. Is removing this the right thing to do?
