### PR TITLE
Fix method redefinition warnings.

### DIFF
--- a/lib/rspec/mocks/instance_method_stasher.rb
+++ b/lib/rspec/mocks/instance_method_stasher.rb
@@ -75,6 +75,9 @@ module RSpec
       def restore
         return unless @method_is_stashed
 
+        if @klass.__send__(:method_defined?, @method)
+          @klass.__send__(:undef_method, @method)
+        end
         @klass.__send__(:alias_method, @method, stashed_method_name)
         @klass.__send__(:remove_method, stashed_method_name)
         @method_is_stashed = false

--- a/lib/rspec/mocks/syntax.rb
+++ b/lib/rspec/mocks/syntax.rb
@@ -60,9 +60,11 @@ module RSpec
             ::RSpec::Mocks.proxy_for(self).received_message?(message, *args, &block)
           end
 
-          Class.class_eval do
-            def any_instance
-              ::RSpec::Mocks.any_instance_recorder_for(self)
+          unless Class.respond_to? :any_instance
+            Class.class_eval do
+              def any_instance
+                ::RSpec::Mocks.any_instance_recorder_for(self)
+              end
             end
           end
         end


### PR DESCRIPTION
Fixes a few method redefinition warnings seen when running rspec-mocks's specs.
