### PR TITLE
In ErrorGenerator#initialize protect against options being nil

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -5,7 +5,7 @@ module RSpec
       attr_writer :opts
 
       def initialize(target, name, options={})
-        @declared_as = options[:__declared_as] || 'Mock'
+        @declared_as = (options && options[:__declared_as]) || 'Mock'
         @target = target
         @name = name
       end


### PR DESCRIPTION
When using the debugger I was getting errors whenever I tried to do anything:

```
(rdb:1) p 'a'
INTERNAL ERROR!!! You have a nil object when you didn't expect it!
You might have expected an instance of Array.
The error occurred while evaluating nil.[]
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/error_generator.rb:8:in `initialize'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/proxy.rb:35:in `new'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/proxy.rb:35:in `initialize'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/methods.rb:129:in `new'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/methods.rb:129:in `__mock_proxy'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/test_double.rb:50:in `respond_to?'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/test_double.rb:85:in `extract_options'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/commands/eval.rb:6:in `eval'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/commands/eval.rb:6:in `run_with_binding'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/commands/eval.rb:46:in `execute'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/processor.rb:275:in `one_cmd'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/processor.rb:261:in `block (2 levels) in process_commands'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/processor.rb:260:in `each'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/processor.rb:260:in `block in process_commands'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/processor.rb:253:in `catch'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/processor.rb:253:in `process_commands'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug/processor.rb:173:in `at_line'
    (eval):5:in `block in at_line'
    <internal:prelude>:10:in `synchronize'
    (eval):3:in `at_line'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/debugger-1.1.4/lib/ruby-debug-base.rb:54:in `at_line'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/test_double.rb:81:in `extract_options'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/test_double.rb:62:in `__initialize_as_test_double'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/test_double.rb:25:in `initialize'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/example_methods.rb:115:in `new'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/example_methods.rb:115:in `declare_double'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-mocks-2.13.1/lib/rspec/mocks/example_methods.rb:36:in `mock'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-rails-2.13.0/lib/rspec/rails/mocks.rb:99:in `mock_model'
    /Users/jshraibman/work/balance/spec/models/periodic_mailer_spec.rb:63:in `block (3 levels) in <top (required)>'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:237:in `instance_eval'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:237:in `instance_eval'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:21:in `run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:66:in `block in run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:66:in `each'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:66:in `run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:418:in `run_hook'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:334:in `run_before_each_hooks'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:300:in `run_before_each'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:113:in `block in run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:254:in `with_around_each_hooks'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example.rb:111:in `run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:390:in `block in run_examples'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:386:in `map'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:386:in `run_examples'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:371:in `run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:372:in `block in run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:372:in `map'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:372:in `run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:28:in `map'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:28:in `block in run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/reporter.rb:34:in `report'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:25:in `run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:80:in `run'
    /Users/jshraibman/.rvm/gems/ruby-1.9.3-p392/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:17:in `block in autorun'
```

I'm not sure why it was happening but here is a fix.

All cucumber tests are green.
