### PR TITLE
Raise if should_not and_return is used.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ### Development
 
+Breaking Changes for 3.0.0:
+
+* Raise an explicit error if `should_not_receive(...).and_return` is used. (Sam
+  Phippen)
+
 Enhancements:
 
 * Document test spies in the readme. (Adarsh Pandit)

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -452,10 +452,8 @@ module RSpec
         super(error_generator, expectation_ordering, expected_from, method_double, 0, {}, &implementation)
       end
 
-      # no-op
-      # @deprecated and_return is not supported with negative message expectations.
       def and_return(*)
-        RSpec.deprecate "and_return with should_not_receive"
+        raise "and_return is not supported with negative message expectations"
       end
 
       # @private

--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -43,9 +43,7 @@ module RSpec
       end
 
       it "warns when should_not_receive is followed by and_return" do
-        expect(RSpec).to receive(:deprecate).with("and_return with should_not_receive")
-
-        @double.should_not_receive(:do_something).and_return(1)
+        expect { @double.should_not_receive(:do_something).and_return(1) }.to raise_error(/not supported/)
       end
 
       it "passes when receiving message specified as not to be received with different args" do


### PR DESCRIPTION
Fixes #134. This removes deprecated behaviour by raising, in prep for RSpec 3
