### PR TITLE
Message expect/allow API independent of configurable syntax.

### DIFF
--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -35,6 +35,11 @@ module RSpec
           add_stub(caller(1)[0], message.to_sym, &block)
       end
 
+      def expect_message(subject, message, &block)
+        ::RSpec::Mocks.proxy_for(subject).
+          add_message_expectation(caller(1)[0], message.to_sym, &block)
+      end
+
       # @api private
       KERNEL_METHOD_METHOD = ::Kernel.instance_method(:method)
 

--- a/spec/rspec/mocks/syntax_agnostic_message_matchers_spec.rb
+++ b/spec/rspec/mocks/syntax_agnostic_message_matchers_spec.rb
@@ -34,7 +34,36 @@ module RSpec
     end
 
     describe ".expect_message" do
-      pending
+      let(:subject) { Object.new }
+
+      it "sets up basic message expectation, verifies as uncalled" do
+        expect {
+          ::RSpec::Mocks.expect_message(subject, :basic)
+        }.to change {
+          subject.respond_to?(:basic)
+        }.to(true)
+
+        expect { verify subject }.to raise_error(RSpec::Mocks::MockExpectationError)
+      end
+
+      it "sets up basic message expectation, verifies as called" do
+        ::RSpec::Mocks.expect_message(subject, :basic)
+        subject.basic
+        verify subject
+      end
+
+      it "sets up message expectation with params and return value" do
+        ::RSpec::Mocks.expect_message(subject, :msg).with(:in).and_return(:out)
+        expect(subject.msg(:in)).to eq(:out)
+        verify subject
+      end
+
+      it "accepts a block implementation for the expected message" do
+        ::RSpec::Mocks.expect_message(subject, :msg) { :value }
+        expect(subject.msg).to eq(:value)
+        verify subject
+      end
+
     end
 
   end


### PR DESCRIPTION
An API independent of configurable syntax for setting message expectations/allowances is necessary, as highlighted by rspec/rspec-rails#764 and rspec/rspec-mocks#306.

Proposed interface by @myronmarston in rspec/rspec-rails#764:

``` ruby
RSpec::Mocks.expect_message(object, :message).with("foo").and_return(5)
RSpec::Mocks.allow_message(object, :message).with("foo").and_return(5)
```

I'll upgrade this to a pull request once I've written code at Rails Camp this weekend.
