### PR TITLE
Reorganize marshal code.

### DIFF
--- a/lib/rspec/mocks/extensions/marshal.rb
+++ b/lib/rspec/mocks/extensions/marshal.rb
@@ -1,9 +1,11 @@
 module Marshal
   class << self
     def dump_with_mocks(*args)
+      return dump_without_mocks(*args) unless ::RSpec::Mocks.space
+
       object = args.shift
 
-      if ( ::RSpec::Mocks.space && !::RSpec::Mocks.space.registered?(object) ) || NilClass === object
+      if !::RSpec::Mocks.space.registered?(object) || NilClass === object
         return dump_without_mocks(*args.unshift(object))
       end
 


### PR DESCRIPTION
- This appears to fix rspec/rspec-core#950.
- It's better, anyway, since it bypasses the unnecessary
  shifting/unshifting for this case.

I'd love if we had a failing spec for this but I don't really understand marshal and DRB to understand how the old logic was causing this bug.  This change seems logically identical but it fixes the problem :/
