### PR TITLE
Remove mock and stub in favour of double

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ Breaking Changes for 3.0.0:
   Phippen)
 * Remove 1.8.6 workarounds (Jon Rowe)
 * Remove `stub!` and `unstub!`. (Sam Phippen)
+* Remove `mock(name, methods)` and `stub(name, methods)`,
+  leaving `double(name, methods)` for creating test doubles.  (Sam Phippen)
 
 Enhancements:
 

--- a/features/outside_rspec/configuration.feature
+++ b/features/outside_rspec/configuration.feature
@@ -34,8 +34,6 @@ Feature: configure any test framework to use rspec-mocks
       example.init
 
       puts example.respond_to?(:double)
-      puts example.respond_to?(:mock)
-      puts example.respond_to?(:stub)
       """
 
     When I run `ruby foo.rb`

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -25,22 +25,8 @@ module RSpec
       #   card.suit  #=> "Spades"
       #   card.rank  #=> "A"
       #
-      # @see #mock
-      # @see #stub
       def double(*args)
         declare_double('Double', *args)
-      end
-
-      # Deprecated: Use [double](#double-instance_method).
-      def mock(*args)
-        RSpec.deprecate "mock", :replacement => "double"
-        declare_double('Mock', *args)
-      end
-
-      # Deprecated: Use [double](#double-instance_method).
-      def stub(*args)
-        RSpec.deprecate "stub", :replacement => "double"
-        declare_double('Stub', *args)
       end
 
       # Disables warning messages about expectations being set on nil.

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -9,16 +9,4 @@ describe "double" do
     double = double('name')
     expect {double.foo}.to raise_error(/Double "name" received/)
   end
-
-  describe "deprecated aliases" do
-    it "warns if #stub is used" do
-      expect(RSpec).to receive(:deprecate).with("stub", :replacement => "double")
-      stub("TestDouble")
-    end
-
-    it "warns if #mock is used" do
-      expect(RSpec).to receive(:deprecate).with("mock", :replacement => "double")
-      mock("TestDouble")
-    end
-  end
 end


### PR DESCRIPTION
This removes mock and stub as ways of creating doubles, it _does not_ remove stub on other objects. These were deprecated, this removes them for RSpec 3.
