### PR TITLE
Remove `stub!` and `unstub!`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Breaking Changes for 3.0.0:
 * Raise an explicit error if `should_not_receive(...).and_return` is used. (Sam
   Phippen)
 * Remove 1.8.6 workarounds (Jon Rowe)
+* Remove `stub!` and `unstub!`. (Sam Phippen)
 
 Enhancements:
 

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -89,16 +89,6 @@ module RSpec
         end
 
         # @private
-        def stub!(*)
-          raise "stub! is not supported on any_instance. Use stub instead."
-        end
-
-        # @private
-        def unstub!(*)
-          raise "unstub! is not supported on any_instance. Use unstub instead."
-        end
-
-        # @private
         def stop_all_observation!
           @observed_methods.each {|method_name| restore_method!(method_name)}
         end

--- a/lib/rspec/mocks/syntax.rb
+++ b/lib/rspec/mocks/syntax.rb
@@ -34,16 +34,6 @@ module RSpec
             ::RSpec::Mocks.space.proxy_for(self).remove_stub(message)
           end
 
-          def stub!(message_or_hash, opts={}, &block)
-            ::RSpec.deprecate "stub!", :replacement => "stub"
-            stub(message_or_hash, opts={}, &block)
-          end
-
-          def unstub!(message)
-            ::RSpec.deprecate "unstub!", :replacement => "unstub"
-            unstub(message)
-          end
-
           def stub_chain(*chain, &blk)
             ::RSpec::Mocks::StubChain.stub_chain_on(self, *chain, &blk)
           end
@@ -81,8 +71,6 @@ module RSpec
           undef should_not_receive
           undef stub
           undef unstub
-          undef stub!
-          undef unstub!
           undef stub_chain
           undef as_null_object
           undef null_object?

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -265,22 +265,6 @@ module RSpec
         end
       end
 
-      context "with #stub!" do
-        it "raises with a message instructing the user to use stub instead" do
-          expect do
-            klass.any_instance.stub!(:foo)
-          end.to raise_error(/Use stub instead/)
-        end
-      end
-
-      context "with #unstub!" do
-        it "raises with a message instructing the user to use unstub instead" do
-          expect do
-            klass.any_instance.unstub!(:foo)
-          end.to raise_error(/Use unstub instead/)
-        end
-      end
-
       context "unstub implementation" do
         it "replaces the stubbed method with the original method" do
           klass.any_instance.stub(:existing_method)

--- a/spec/rspec/mocks/methods_spec.rb
+++ b/spec/rspec/mocks/methods_spec.rb
@@ -18,7 +18,7 @@ module RSpec
         expect(added_methods).to match_array([
           :as_null_object, :null_object?,
           :received_message?, :should_not_receive, :should_receive,
-          :stub, :stub!, :stub_chain, :unstub, :unstub!
+          :stub, :stub_chain, :unstub
         ])
       end
     end

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -37,32 +37,6 @@ module RSpec
         end
       end
 
-      describe "using stub!" do
-        it "warns of deprecation but still returns the declared value when message is received" do
-          expect(RSpec).to receive(:deprecate).with("stub!", :replacement => "stub")
-          @instance.stub!(:msg).and_return(:return_value)
-          expect(@instance.msg).to equal(:return_value)
-          verify @instance
-        end
-      end
-
-      describe 'using unstub' do
-        it 'removes the message stub' do
-          @instance.stub(:msg)
-          @instance.unstub(:msg)
-          expect { @instance.msg }.to raise_error NoMethodError
-        end
-      end
-
-      describe 'using unstub!' do
-        it 'removes the message stub but warns about deprecation' do
-          @instance.stub(:msg)
-          RSpec.should_receive(:deprecate).with("unstub!", :replacement => "unstub")
-          @instance.unstub!(:msg)
-          expect { @instance.msg }.to raise_error NoMethodError
-        end
-      end
-
       it "instructs an instance to respond_to the message" do
         @instance.stub(:msg)
         expect(@instance).to respond_to(:msg)


### PR DESCRIPTION
These were deprecated and delegate straight to stub and unstub, so I removed them with a view to removing deprecations for RSpec 3.
