### PR TITLE
Change an error back to a deprecation warning.

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -72,19 +72,19 @@ module RSpec
       #   counter.count # => 1
       def and_return(*values, &implementation)
         if negative?
-          raise "`and_return` is not supported with negative message expectations"
-        else
-          @expected_received_count = [@expected_received_count, values.size].max unless ignoring_args? || (@expected_received_count == 0 and @at_least)
-
-          if implementation
-            # TODO: deprecate `and_return { value }`
-            self.inner_implementation_action = implementation
-          else
-            self.terminal_implementation_action = AndReturnImplementation.new(values)
-          end
-
-          nil
+          RSpec.deprecate "`and_return` on a negative message expectation"
         end
+
+        @expected_received_count = [@expected_received_count, values.size].max unless ignoring_args? || (@expected_received_count == 0 and @at_least)
+
+        if implementation
+          # TODO: deprecate `and_return { value }`
+          self.inner_implementation_action = implementation
+        else
+          self.terminal_implementation_action = AndReturnImplementation.new(values)
+        end
+
+        nil
       end
 
       # Tells the object to delegate to the original unmodified method

--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -48,18 +48,28 @@ module RSpec
         }.to raise_error(/trying to negate it again/)
       end
 
-      it "warns when `and_return` is called on a negative expectation" do
-        expect {
-          @double.should_not_receive(:do_something).and_return(1)
-        }.to raise_error(/not supported/)
+      def expect_and_return_warning
+        expect(RSpec).to receive(:deprecate).with(/`and_return` on a negative message expectation/)
+      end
 
-        expect {
-          expect(@double).not_to receive(:do_something).and_return(1)
-        }.to raise_error(/not supported/)
+      it "warns when `should_not_receive().and_return` is used" do
+        expect_and_return_warning
+        @double.should_not_receive(:foo).and_return(1)
+      end
 
-        expect {
-          expect(@double).to receive(:do_something).never.and_return(1)
-        }.to raise_error(/not supported/)
+      it "warns when `should_receive().never.and_return` is used" do
+        expect_and_return_warning
+        @double.should_receive(:foo).never.and_return(1)
+      end
+
+      it "warns when `expect().not_to receive().and_return` is used" do
+        expect_and_return_warning
+        expect(@double).not_to receive(:foo).and_return(1)
+      end
+
+      it "warns when `expect().to receive().never.and_return` is used" do
+        expect_and_return_warning
+        expect(@double).to receive(:foo).never.and_return(1)
       end
 
       it "passes when receiving message specified as not to be received with different args" do


### PR DESCRIPTION
When we merged from a master-focused PR we accidentally change this for 2.14.
