### PR TITLE
Make have_received complain if passed a block

### DIFF
--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -114,7 +114,7 @@ module RSpec
       #   # You can also use most message expectations:
       #   expect(invitation).to have_received(:accept).with(mailer).once
       def have_received(method_name)
-        raise "have_received matcher does not take a block argument. Called from #{caller[0]}" if block_given?
+        warn "have_received ignores its block argument. Called from #{caller[0]}" if block_given?
         Matchers::HaveReceived.new(method_name)
       end
 

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -60,11 +60,13 @@ module RSpec
           }.to raise_error(/0 times/)
         end
 
-        it "raises an exception when a block is used to match the arguments" do
+        it "warns when a block is used to match the arguments" do
           dbl = double_with_met_expectation(:expected_method)
-          expect {
-            expect(dbl).to have_received(:expected_method) { }
-          }.to raise_error(/have_received matcher does not take a block argument/)
+          self.stub(:warn => nil)
+          expect(dbl).to have_received(:expected_method) { }; line = __LINE__
+          file = __FILE__
+          message = /have_received ignores its block argument. Called from #{file}:#{line}/
+          expect(self).to have_received(:warn).with(message)
         end
 
         context "with" do


### PR DESCRIPTION
I rather stupidly assumed I could use a block passed to have_received to make
assertions about the arguments passed in a method call, in the same way that is
possible with the 'receive' matcher. Ordinarily I wouldn't think such a mistake
would warrant being guarded against in the test library itself, however, in this
case the test silently passes, rather than erroring out. This patch makes
have_received raise an exception if passed a block argument to make it clear
that matching against arguments to the method call in this way is not possible.
