### PR TITLE
Fully embrace _exec over _eval.

### DIFF
--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -8,7 +8,7 @@ module RSpec
       attr_accessor :space
 
       def setup(host)
-        (class << host; self; end).class_eval do
+        (class << host; self; end).class_exec do
           include RSpec::Mocks::ExampleMethods
         end
         self.space ||= RSpec::Mocks::Space.new

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -137,7 +137,7 @@ module RSpec
 
         def restore_original_method!(method_name)
           alias_method_name = build_alias_method_name(method_name)
-          @klass.class_eval do
+          @klass.class_exec do
             remove_method method_name
             alias_method  method_name, alias_method_name
             remove_method alias_method_name
@@ -145,14 +145,14 @@ module RSpec
         end
 
         def remove_dummy_method!(method_name)
-          @klass.class_eval do
+          @klass.class_exec do
             remove_method method_name
           end
         end
 
         def backup_method!(method_name)
           alias_method_name = build_alias_method_name(method_name)
-          @klass.class_eval do
+          @klass.class_exec do
             alias_method alias_method_name, method_name
           end if public_protected_or_private_method_defined?(method_name)
         end

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -118,7 +118,7 @@ module RSpec
       end
 
       def self.included(klass)
-        klass.class_eval do
+        klass.class_exec do
           # This gets mixed in so that if `RSpec::Matchers` is included in
           # `klass` later, it's definition of `expect` will take precedence.
           include ExpectHost unless method_defined?(:expect)

--- a/lib/rspec/mocks/space.rb
+++ b/lib/rspec/mocks/space.rb
@@ -73,7 +73,7 @@ module RSpec
           return id if object.equal?(::ObjectSpace._id2ref(id))
           # this suggests that object.__id__ is proxying through to some wrapped object
 
-          object.instance_eval do
+          object.instance_exec do
             @__id_for_rspec_mocks_space ||= ::SecureRandom.uuid
           end
         end

--- a/lib/rspec/mocks/syntax.rb
+++ b/lib/rspec/mocks/syntax.rb
@@ -10,7 +10,7 @@ module RSpec
       def self.enable_should(syntax_host = default_should_syntax_host)
         return if should_enabled?(syntax_host)
 
-        syntax_host.class_eval do
+        syntax_host.class_exec do
           def should_receive(message, opts={}, &block)
             opts[:expected_from] ||= caller(1)[0]
             ::RSpec::Mocks.expect_message(self, message.to_sym, opts, &block)
@@ -52,7 +52,7 @@ module RSpec
           end
 
           unless Class.respond_to? :any_instance
-            Class.class_eval do
+            Class.class_exec do
               def any_instance
                 ::RSpec::Mocks.any_instance_recorder_for(self)
               end
@@ -66,7 +66,7 @@ module RSpec
       def self.disable_should(syntax_host = default_should_syntax_host)
         return unless should_enabled?(syntax_host)
 
-        syntax_host.class_eval do
+        syntax_host.class_exec do
           undef should_receive
           undef should_not_receive
           undef stub
@@ -77,7 +77,7 @@ module RSpec
           undef received_message?
         end
 
-        Class.class_eval do
+        Class.class_exec do
           undef any_instance
         end
       end
@@ -87,7 +87,7 @@ module RSpec
       def self.enable_expect(syntax_host = ::RSpec::Mocks::ExampleMethods)
         return if expect_enabled?(syntax_host)
 
-        syntax_host.class_eval do
+        syntax_host.class_exec do
           def receive(method_name, &block)
             Matchers::Receive.new(method_name, block)
           end
@@ -105,7 +105,7 @@ module RSpec
           end
         end
 
-        RSpec::Mocks::ExampleMethods::ExpectHost.class_eval do
+        RSpec::Mocks::ExampleMethods::ExpectHost.class_exec do
           def expect(target)
             ExpectationTarget.new(target)
           end
@@ -117,14 +117,14 @@ module RSpec
       def self.disable_expect(syntax_host = ::RSpec::Mocks::ExampleMethods)
         return unless expect_enabled?(syntax_host)
 
-        syntax_host.class_eval do
+        syntax_host.class_exec do
           undef receive
           undef allow
           undef expect_any_instance_of
           undef allow_any_instance_of
         end
 
-        RSpec::Mocks::ExampleMethods::ExpectHost.class_eval do
+        RSpec::Mocks::ExampleMethods::ExpectHost.class_exec do
           undef expect
         end
       end

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -149,7 +149,7 @@ describe "and_call_original" do
 
     context 'on an object that defines method_missing' do
       before do
-        klass.class_eval do
+        klass.class_exec do
           private
 
           def method_missing(name, *args)

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -209,7 +209,7 @@ module RSpec
         it 'can use the `expect` syntax' do
           dbl = double
 
-          framework.new.instance_eval do
+          framework.new.instance_exec do
             expect(dbl).to receive(:foo).and_return(3)
           end
 
@@ -219,7 +219,7 @@ module RSpec
         it 'expects the method to be called when `expect` is used' do
           dbl = double
 
-          framework.new.instance_eval do
+          framework.new.instance_exec do
             expect(dbl).to receive(:foo)
           end
 
@@ -229,7 +229,7 @@ module RSpec
         it 'supports `expect(...).not_to receive`' do
           dbl = double
 
-          framework.new.instance_eval do
+          framework.new.instance_exec do
             expect(dbl).not_to receive(:foo)
           end
 
@@ -239,7 +239,7 @@ module RSpec
         it 'supports `expect(...).to_not receive`' do
           dbl = double
 
-          framework.new.instance_eval do
+          framework.new.instance_exec do
             expect(dbl).to_not receive(:foo)
           end
 
@@ -262,7 +262,7 @@ module RSpec
 
         it 'cannot use `expect` with another matcher' do
           expect {
-            framework.new.instance_eval do
+            framework.new.instance_exec do
               expect(3).to eq(3)
             end
           }.to raise_error(/only the `receive` matcher is supported with `expect\(...\).to`/)
@@ -295,7 +295,7 @@ module RSpec
         include_examples "using rspec-mocks in another test framework"
 
         it 'can use `expect` with any matcher' do
-          framework.new.instance_eval do
+          framework.new.instance_exec do
             expect(3).to eq(3)
           end
         end
@@ -317,7 +317,7 @@ module RSpec
         include_examples "using rspec-mocks in another test framework"
 
         it 'can use `expect` with any matcher' do
-          framework.new.instance_eval do
+          framework.new.instance_exec do
             expect(3).to eq(3)
           end
         end

--- a/spec/rspec/mocks/partial_mock_spec.rb
+++ b/spec/rspec/mocks/partial_mock_spec.rb
@@ -20,7 +20,7 @@ module RSpec
       end
 
       it "does not conflict with @options in the object" do
-        object.instance_eval { @options = Object.new }
+        object.instance_exec { @options = Object.new }
         object.should_receive(:blah)
         object.blah
       end

--- a/spec/rspec/mocks/serialization_spec.rb
+++ b/spec/rspec/mocks/serialization_spec.rb
@@ -8,7 +8,7 @@ module RSpec
 
       def self.with_yaml_loaded(&block)
         context 'with YAML loaded' do
-          module_eval(&block)
+          module_exec(&block)
         end
       end
 
@@ -17,16 +17,16 @@ module RSpec
           before do
             # We can't really unload yaml, but we can fake it here...
             hide_const("YAML")
-            Struct.class_eval do
+            Struct.class_exec do
               alias __old_to_yaml to_yaml
               undef to_yaml
             end
           end
 
-          module_eval(&block)
+          module_exec(&block)
 
           after do
-            Struct.class_eval do
+            Struct.class_exec do
               alias to_yaml __old_to_yaml
               undef __old_to_yaml
             end

--- a/spec/rspec/mocks/test_double_spec.rb
+++ b/spec/rspec/mocks/test_double_spec.rb
@@ -4,14 +4,14 @@ module RSpec
   module Mocks
     describe TestDouble do
       before(:all) do
-        Module.class_eval do
+        Module.class_exec do
           private
           def use; end
         end
       end
 
       after(:all) do
-        Module.class_eval do
+        Module.class_exec do
           undef use
         end
       end


### PR DESCRIPTION
Follow up on #340. Fully embrace `_exec` versions over the `_eval`.
