### PR TITLE
Expect to raise exception in assertion within should_receive

### DIFF
--- a/spec/rspec/mocks/bug_report_10263_spec.rb
+++ b/spec/rspec/mocks/bug_report_10263_spec.rb
@@ -7,10 +7,9 @@ describe "Double" do
     test_double.should_receive(:msg) do |arg|
       expect(arg).to be_true #this call exposes the problem
     end
-    begin
+    expect {
       test_double.msg(false)
-    rescue Exception
-    end
+    }.to raise_exception
   end
 
   specify "then the next example should behave as expected instead of saying" do


### PR DESCRIPTION
I'm seeing behavior where the exception isn't thrown in my rails app, but it is thrown in this test -- but as the test was written it doesn't confirm the exception/assertion is raised; this fixed that.
