### PR TITLE
Switch to be_truthy and be_falsey

### DIFF
--- a/features/mutating_constants/stub_undefined_constant.feature
+++ b/features/mutating_constants/stub_undefined_constant.feature
@@ -33,15 +33,15 @@ Feature: Stub Undefined Constant
       module MyGem
         describe SomeClass do
           it "can stub an arbitrarily deep constant that is undefined" do
-            defined?(SomeClass::A).should be_false
+            defined?(SomeClass::A).should be_falsey
             stub_const("MyGem::SomeClass::A::B::C", 3)
             SomeClass::A::B::C.should eq(3)
             SomeClass::A.should be_a(Module)
           end
 
           it 'undefines the intermediary constants that were dynamically created' do
-            defined?(SomeClass).should be_true
-            defined?(SomeClass::A).should be_false
+            defined?(SomeClass).should be_truthy
+            defined?(SomeClass::A).should be_falsey
           end
         end
       end

--- a/spec/rspec/mocks/and_yield_spec.rb
+++ b/spec/rspec/mocks/and_yield_spec.rb
@@ -25,7 +25,7 @@ describe RSpec::Mocks::Mock do
         obj.stub(:method_that_accepts_a_block).and_yield do |eval_context|
           evaluated = true
         end
-        expect(evaluated).to be_true
+        expect(evaluated).to be_truthy
       end
 
       it "passes an eval context object to the supplied block" do

--- a/spec/rspec/mocks/any_instance/message_chains_spec.rb
+++ b/spec/rspec/mocks/any_instance/message_chains_spec.rb
@@ -7,13 +7,13 @@ describe RSpec::Mocks::AnyInstance::MessageChains do
 
   it "knows if a method does not have an expectation set on it" do
     chains.add(:method_name, stub_chain)
-    expect(chains.has_expectation?(:method_name)).to be_false
+    expect(chains.has_expectation?(:method_name)).to be_falsey
   end
 
   it "knows if a method has an expectation set on it" do
     chains.add(:method_name, stub_chain)
     chains.add(:method_name, expectation_chain)
-    expect(chains.has_expectation?(:method_name)).to be_true
+    expect(chains.has_expectation?(:method_name)).to be_truthy
   end
 
   it "can remove all stub chains" do

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -696,13 +696,13 @@ module RSpec
             context "public methods" do
               before(:each) do
                 klass.any_instance.stub(:existing_method).and_return(1)
-                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_true
+                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_truthy
               end
 
               it "restores the class to its original state after each example when no instance is created" do
                 space.verify_all
 
-                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_false
+                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_falsey
                 expect(klass.new.existing_method).to eq(existing_method_return_value)
               end
 
@@ -711,7 +711,7 @@ module RSpec
 
                 space.verify_all
 
-                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_false
+                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_falsey
                 expect(klass.new.existing_method).to eq(existing_method_return_value)
               end
 
@@ -721,7 +721,7 @@ module RSpec
 
                 space.verify_all
 
-                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_false
+                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_falsey
                 expect(klass.new.existing_method).to eq(existing_method_return_value)
               end
             end
@@ -733,11 +733,11 @@ module RSpec
               end
 
               it "cleans up the backed up method" do
-                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_false
+                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_falsey
               end
 
               it "restores a stubbed private method after the spec is run" do
-                expect(klass.private_method_defined?(:private_method)).to be_true
+                expect(klass.private_method_defined?(:private_method)).to be_truthy
               end
 
               it "ensures that the restored method behaves as it originally did" do
@@ -755,11 +755,11 @@ module RSpec
               end
 
               it "cleans up the backed up method" do
-                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_false
+                expect(klass.method_defined?(:__existing_method_without_any_instance__)).to be_falsey
               end
 
               it "restores a stubbed private method after the spec is run" do
-                expect(klass.private_method_defined?(:private_method)).to be_true
+                expect(klass.private_method_defined?(:private_method)).to be_truthy
               end
 
               it "ensures that the restored method behaves as it originally did" do

--- a/spec/rspec/mocks/argument_expectation_spec.rb
+++ b/spec/rspec/mocks/argument_expectation_spec.rb
@@ -9,23 +9,23 @@ module RSpec
       it "considers an object that responds to #matches? and #failure_message_for_should to be a matcher" do
         obj.stub(:matches?)
         obj.stub(:failure_message_for_should)
-        expect(argument_expectation.send(:is_matcher?, obj)).to be_true
+        expect(argument_expectation.send(:is_matcher?, obj)).to be_truthy
       end
 
       it "considers an object that responds to #matches? and #failure_message to be a matcher for backward compatibility" do
         obj.stub(:matches?)
         obj.stub(:failure_message)
-        expect(argument_expectation.send(:is_matcher?, obj)).to be_true
+        expect(argument_expectation.send(:is_matcher?, obj)).to be_truthy
       end
 
       it "does NOT consider an object that only responds to #matches? to be a matcher" do
         obj.stub(:matches?)
-        expect(argument_expectation.send(:is_matcher?, obj)).to be_false
+        expect(argument_expectation.send(:is_matcher?, obj)).to be_falsey
       end
 
       it "does not consider a null object to be a matcher" do
         obj.as_null_object
-        expect(argument_expectation.send(:is_matcher?, obj)).to be_false
+        expect(argument_expectation.send(:is_matcher?, obj)).to be_falsey
       end
     end
   end

--- a/spec/rspec/mocks/bug_report_10263_spec.rb
+++ b/spec/rspec/mocks/bug_report_10263_spec.rb
@@ -5,7 +5,7 @@ describe "Double" do
 
   specify "when one example has an expectation inside the block passed to should_receive" do
     test_double.should_receive(:msg) do |arg|
-      expect(arg).to be_true #this call exposes the problem
+      expect(arg).to be_truthy #this call exposes the problem
     end
     begin
       test_double.msg(false)

--- a/spec/rspec/mocks/bug_report_8165_spec.rb
+++ b/spec/rspec/mocks/bug_report_8165_spec.rb
@@ -16,7 +16,7 @@ describe "An object where respond_to? is true and does not have method" do
     obj = Object.new
     obj.should_receive(:respond_to?).with(:foobar).and_return(true)
     obj.should_receive(:foobar).and_return(:baz)
-    expect(obj.respond_to?(:foobar)).to be_true
+    expect(obj.respond_to?(:foobar)).to be_truthy
     expect(obj.foobar).to eq :baz
   end
 
@@ -24,7 +24,7 @@ describe "An object where respond_to? is true and does not have method" do
     obj = double("obj")
     obj.should_receive(:respond_to?).with(:foobar).and_return(true)
     obj.should_receive(:foobar).and_return(:baz)
-    expect(obj.respond_to?(:foobar)).to be_true
+    expect(obj.respond_to?(:foobar)).to be_truthy
     expect(obj.foobar).to eq :baz
   end
 

--- a/spec/rspec/mocks/combining_implementation_instructions_spec.rb
+++ b/spec/rspec/mocks/combining_implementation_instructions_spec.rb
@@ -21,7 +21,7 @@ module RSpec
             expect(dbl.foo(:arg, &b)).to eq(3)
           }.to yield_with_args(5)
 
-          expect(@block_called).to be_true
+          expect(@block_called).to be_truthy
         end
 
         it 'works when passing a block to `stub`' do
@@ -111,7 +111,7 @@ module RSpec
           expect { dbl.foo(&b) }.to raise_error("boom")
         }.to yield_with_args(5)
 
-        expect(block_called).to be_true
+        expect(block_called).to be_truthy
       end
 
       it 'can combine and_yield and and_throw' do
@@ -132,7 +132,7 @@ module RSpec
           expect { dbl.foo(&b) }.to throw_symbol(:bar)
         }.to yield_with_args(5)
 
-        expect(block_called).to be_true
+        expect(block_called).to be_truthy
       end
 
       it 'returns `nil` from all terminal actions to discourage further configuration' do

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -282,7 +282,7 @@ module RSpec
       context "when rspec-expectations is included in the test framework first" do
         before do
           # the examples here assume `expect` is define in RSpec::Matchers...
-          expect(RSpec::Matchers.method_defined?(:expect)).to be_true
+          expect(RSpec::Matchers.method_defined?(:expect)).to be_truthy
         end
 
         let(:framework) do
@@ -304,7 +304,7 @@ module RSpec
       context "when rspec-expectations is included in the test framework last" do
         before do
           # the examples here assume `expect` is define in RSpec::Matchers...
-          expect(RSpec::Matchers.method_defined?(:expect)).to be_true
+          expect(RSpec::Matchers.method_defined?(:expect)).to be_truthy
         end
 
         let(:framework) do

--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -205,7 +205,7 @@ module RSpec
 
       it "fails if expectation block fails" do
         @double.should_receive(:something) do |bool|
-          expect(bool).to be_true
+          expect(bool).to be_truthy
         end
 
         expect {

--- a/spec/rspec/mocks/mutate_const_spec.rb
+++ b/spec/rspec/mocks/mutate_const_spec.rb
@@ -78,18 +78,18 @@ module RSpec
 
       shared_examples_for "loaded constant hiding" do |const_name|
         before do
-          expect(recursive_const_defined?(const_name)).to be_true
+          expect(recursive_const_defined?(const_name)).to be_truthy
         end
 
         it 'allows it to be hidden' do
           hide_const(const_name)
-          expect(recursive_const_defined?(const_name)).to be_false
+          expect(recursive_const_defined?(const_name)).to be_falsey
         end
 
         it 'resets the constant when rspec clear its mocks' do
           hide_const(const_name)
           reset_rspec_mocks
-          expect(recursive_const_defined?(const_name)).to be_true
+          expect(recursive_const_defined?(const_name)).to be_truthy
         end
 
         it 'returns nil' do
@@ -101,7 +101,7 @@ module RSpec
         include_context "constant example methods", const_name
 
         before do
-          expect(recursive_const_defined?(const_name)).to be_false
+          expect(recursive_const_defined?(const_name)).to be_falsey
         end
 
         it 'allows it to be stubbed' do
@@ -112,7 +112,7 @@ module RSpec
         it 'removes the constant when rspec clears its mocks' do
           stub_const(const_name, 7)
           reset_rspec_mocks
-          expect(recursive_const_defined?(const_name)).to be_false
+          expect(recursive_const_defined?(const_name)).to be_falsey
         end
 
         it 'returns the stubbed value' do
@@ -130,18 +130,18 @@ module RSpec
         include_context "constant example methods", const_name
 
         before do
-          expect(recursive_const_defined?(const_name)).to be_false
+          expect(recursive_const_defined?(const_name)).to be_falsey
         end
 
         it 'allows it to be hidden, though the operation has no effect' do
           hide_const(const_name)
-          expect(recursive_const_defined?(const_name)).to be_false
+          expect(recursive_const_defined?(const_name)).to be_falsey
         end
 
         it 'remains undefined after rspec clears its mocks' do
           hide_const(const_name)
           reset_rspec_mocks
-          expect(recursive_const_defined?(const_name)).to be_false
+          expect(recursive_const_defined?(const_name)).to be_falsey
         end
 
         it 'returns nil' do
@@ -206,7 +206,7 @@ module RSpec
           orig_value = TOP_LEVEL_VALUE_CONST
 
           hide_const("TOP_LEVEL_VALUE_CONST")
-          expect(recursive_const_defined?("TOP_LEVEL_VALUE_CONST")).to be_false
+          expect(recursive_const_defined?("TOP_LEVEL_VALUE_CONST")).to be_falsey
 
           stub_const("TOP_LEVEL_VALUE_CONST", 12345)
           expect(TOP_LEVEL_VALUE_CONST).to eq 12345
@@ -247,8 +247,8 @@ module RSpec
             stub = Module.new
             stub_const("TestSubClass", stub, :transfer_nested_constants => true)
             expect(stub::P).to eq(:p)
-            expect(defined?(stub::M)).to be_false
-            expect(defined?(stub::N)).to be_false
+            expect(defined?(stub::M)).to be_falsey
+            expect(defined?(stub::N)).to be_falsey
           end
 
           it 'raises an error when asked to transfer a nested inherited constant' do
@@ -266,7 +266,7 @@ module RSpec
             stub_const("TestClass", stub, :transfer_nested_constants => [:M, :N])
             expect(stub::M).to eq(:m)
             expect(stub::N).to eq(:n)
-            expect(defined?(stub::Nested)).to be_false
+            expect(defined?(stub::Nested)).to be_falsey
           end
 
           it 'raises an error if asked to transfer nested constants but given an object that does not support them' do
@@ -302,7 +302,7 @@ module RSpec
 
           it 'raises an error if asked to transfer a nested constant that is not defined' do
             original_tc = TestClass
-            expect(defined?(TestClass::V)).to be_false
+            expect(defined?(TestClass::V)).to be_falsey
             stub = Module.new
 
             expect {
@@ -345,10 +345,10 @@ module RSpec
           it_behaves_like "unloaded constant stubbing", "X::Y"
 
           it 'removes the root constant when rspec clears its mocks' do
-            expect(defined?(X)).to be_false
+            expect(defined?(X)).to be_falsey
             stub_const("X::Y", 7)
             reset_rspec_mocks
-            expect(defined?(X)).to be_false
+            expect(defined?(X)).to be_falsey
           end
         end
 
@@ -356,10 +356,10 @@ module RSpec
           it_behaves_like "unloaded constant stubbing", "X::Y::Z"
 
           it 'removes the root constant when rspec clears its mocks' do
-            expect(defined?(X)).to be_false
+            expect(defined?(X)).to be_falsey
             stub_const("X::Y::Z", 7)
             reset_rspec_mocks
-            expect(defined?(X)).to be_false
+            expect(defined?(X)).to be_falsey
           end
         end
 
@@ -367,12 +367,12 @@ module RSpec
           it_behaves_like "unloaded constant stubbing", "TestClass::X"
 
           it 'removes the unloaded constant but leaves the loaded constant when rspec resets its mocks' do
-            expect(defined?(TestClass)).to be_true
-            expect(defined?(TestClass::X)).to be_false
+            expect(defined?(TestClass)).to be_truthy
+            expect(defined?(TestClass::X)).to be_falsey
             stub_const("TestClass::X", 7)
             reset_rspec_mocks
-            expect(defined?(TestClass)).to be_true
-            expect(defined?(TestClass::X)).to be_false
+            expect(defined?(TestClass)).to be_truthy
+            expect(defined?(TestClass::X)).to be_falsey
           end
 
           it 'raises a helpful error if it cannot be stubbed due to an intermediary constant that is not a module' do
@@ -385,12 +385,12 @@ module RSpec
           it_behaves_like "unloaded constant stubbing", "TestClass::Nested::NestedEvenMore::X::Y::Z"
 
           it 'removes the first unloaded constant but leaves the loaded nested constant when rspec resets its mocks' do
-            expect(defined?(TestClass::Nested::NestedEvenMore)).to be_true
-            expect(defined?(TestClass::Nested::NestedEvenMore::X)).to be_false
+            expect(defined?(TestClass::Nested::NestedEvenMore)).to be_truthy
+            expect(defined?(TestClass::Nested::NestedEvenMore::X)).to be_falsey
             stub_const("TestClass::Nested::NestedEvenMore::X::Y::Z", 7)
             reset_rspec_mocks
-            expect(defined?(TestClass::Nested::NestedEvenMore)).to be_true
-            expect(defined?(TestClass::Nested::NestedEvenMore::X)).to be_false
+            expect(defined?(TestClass::Nested::NestedEvenMore)).to be_truthy
+            expect(defined?(TestClass::Nested::NestedEvenMore::X)).to be_falsey
           end
         end
       end

--- a/spec/rspec/mocks/record_messages_spec.rb
+++ b/spec/rspec/mocks/record_messages_spec.rb
@@ -7,19 +7,19 @@ module RSpec
         @mock = double("mock").as_null_object
       end
       it "answers false for received_message? when no messages received" do
-        expect(@mock.received_message?(:message)).to be_false
+        expect(@mock.received_message?(:message)).to be_falsey
       end
       it "answers true for received_message? when message received" do
         @mock.message
-        expect(@mock.received_message?(:message)).to be_true
+        expect(@mock.received_message?(:message)).to be_truthy
       end
       it "answers true for received_message? when message received with correct args" do
         @mock.message 1,2,3
-        expect(@mock.received_message?(:message, 1,2,3)).to be_true
+        expect(@mock.received_message?(:message, 1,2,3)).to be_truthy
       end
       it "answers false for received_message? when message received with incorrect args" do
         @mock.message 1,2,3
-        expect(@mock.received_message?(:message, 1,2)).to be_false
+        expect(@mock.received_message?(:message, 1,2)).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Since we're changing to be_truthy and be_falsey, we must update our own usage of these matchers.

This is also going to have to be pulled across to `2-99-maintenance` before we release it, to avoid internal deprecation warnings.
