### PR TITLE
Add link to Test Double bliki

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ you are interested in learning more, here is some recommended reading:
 * Mock Objects: http://www.mockobjects.com/
 * Endo-Testing: http://stalatest.googlecode.com/svn/trunk/Literatur/mockobjects.pdf
 * Mock Roles, Not Objects: http://jmock.org/oopsla2004.pdf
+* Test Double: http://www.martinfowler.com/bliki/TestDouble.html
 * Test Double Patterns: http://xunitpatterns.com/Test%20Double%20Patterns.html
 * Mocks aren't stubs: http://www.martinfowler.com/articles/mocksArentStubs.html
 


### PR DESCRIPTION
I noticed you are already linking to the xUnitPatterns definitions and Martin Fowler's bliki Mocks Aren't Stubs.

I thought it would be good to link to Martin Fowler's Test Double bliki.  I feel it is a clear, compact summary of the information in the other two links.
