### PR TITLE
and_return broken on implicit (self) receiver stubs

### DIFF
--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -48,6 +48,19 @@ module RSpec
           add_stub(orig_caller, message.to_sym, opts, &block)
       end
 
+      # @api private
+      # semi private message to remove duplicated info to renable
+      # implict stub!
+      def allow_messages(subject, message_or_hash, opts={}, &block)
+        if ::Hash === message_or_hash
+          message_or_hash.each do |message,value|
+            allow_message(subject,message,opts).and_return(value)
+          end
+        else
+          allow_message(subject,message_or_hash,opts,&block)
+        end
+      end
+
       # Sets a message expectation on `subject`.
       # @param subject the subject on which the message will be expected
       # @param message a symbol, representing the message that will be

--- a/lib/rspec/mocks/syntax.rb
+++ b/lib/rspec/mocks/syntax.rb
@@ -22,12 +22,8 @@ module RSpec
           end
 
           def stub(message_or_hash, opts={}, &block)
-            if ::Hash === message_or_hash
-              message_or_hash.each {|message, value| stub(message).and_return value }
-            else
-              opts[:expected_from] = caller(1)[0]
-              ::RSpec::Mocks.allow_message(self, message_or_hash, opts, &block)
-            end
+            opts[:expected_from] = caller(1)[0]
+            ::RSpec::Mocks.allow_messages(self, message_or_hash, opts, &block)
           end
 
           def unstub(message)
@@ -36,7 +32,8 @@ module RSpec
 
           def stub!(message_or_hash, opts={}, &block)
             ::RSpec.deprecate "stub!", :replacement => "stub"
-            stub(message_or_hash, opts={}, &block)
+            opts[:expected_from] = caller(1)[0]
+            ::RSpec::Mocks.allow_messages(self, message_or_hash, opts, &block)
           end
 
           def unstub!(message)


### PR DESCRIPTION
RSpec 2.13 supported implicit receivers inside describes. For example, instead of doing `obj.stub!(...)`, you could do `self.stub!(...)` (or just `stub!(...)`), where self is the context of the `it` block. This was not a common usage, but it is extremely useful for testing modules with private features. You could `include Foo` into your context and use it from the spec. This no longer works in 2.14. 

Minimal reproduction:

``` ruby
require 'rspec'

describe 'implicit mocks' do
  it 'accepts and_return on an implicit mock' do
    stub!(:foo).and_return('bar')
    expect(foo).to eq('bar')
  end
end
```

Output:

```
~/spec$ rspec foo_spec.rb 
F

Failures:

  1) implicit mocks accepts and_return on an implicit mock
     Failure/Error: stub!(:foo).and_return('bar')
       Stub :foo received unexpected message :and_return with ("bar")
     # ./foo_spec.rb:5:in `block (2 levels) in <top (required)>'
```

A more complete usage scenario might be:

``` ruby
require 'rspec'

module Foo
  private # these methods are not callable from outside
  def foo; bar end
  def bar; 0 end
end

describe Foo do
  include Foo

  describe '#foo' do
    it 'returns the result of #bar' do
      stub!(:bar).and_return(42)
      expect(foo).to eq(42)
    end
  end
end
```

If this will not be supported in 3.x, are there any suggestions on how to not rely on implicit receivers for these tests?
