### PR TITLE
Fix behaviour for simple stubs when stubbing core methods.

### DIFF
--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -183,8 +183,10 @@ module RSpec
         return unless @method_is_proxied
 
         object_singleton_class.__send__(:remove_method, @method_name)
-        @method_stasher.restore
-        restore_original_visibility
+        if @method_stasher.method_is_stashed?
+          @method_stasher.restore
+          restore_original_visibility
+        end
 
         @method_is_proxied = false
       end
@@ -248,7 +250,8 @@ module RSpec
       # cannot match on arguments. It is used as an optimization over
       # `add_stub` where it is known in advance that this is all that will be
       # required of a stub, such as when passing attributes to the `double`
-      # example method.
+      # example method. They do not stash or restore existing method
+      # definitions.
       #
       # @private
       def add_simple_stub(method_name, response)

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -9,4 +9,11 @@ describe "double" do
     double = double('name')
     expect {double.foo}.to raise_error(/Double "name" received/)
   end
+
+  it 'restores standard object methods on reset' do
+    dbl = double(:tainted? => true)
+    expect(dbl.tainted?).to eq(true)
+    reset dbl
+    expect(dbl.tainted?).to eq(false)
+  end
 end


### PR DESCRIPTION
Fixes #403.

Please verify that my assumption about proxied methods is correct (per the comment in the diff.)

@soulcutter @alindeman @myronmarston
