### PR TITLE
When generating a failure message for expected args, don't use description if nil or empty

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -171,7 +171,13 @@ module RSpec
       end
 
       def arg_list(*args)
-        args.collect {|arg| arg.respond_to?(:description) ? arg.description : arg.inspect}.join(", ")
+        args.collect {|arg| arg_has_valid_description(arg) ? arg.description : arg.inspect }.join(", ")
+      end
+
+      def arg_has_valid_description(arg)
+        return false unless arg.respond_to?(:description)
+
+        !arg.description.nil? && !arg.description.empty?
       end
 
       def format_received_args(*args)

--- a/spec/rspec/mocks/failing_argument_matchers_spec.rb
+++ b/spec/rspec/mocks/failing_argument_matchers_spec.rb
@@ -119,6 +119,39 @@ module RSpec
           @double.msg arg
         end.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"double\" received :msg with unexpected arguments\n  expected: (3)\n       got: (my_thing)")
       end
+
+      it "fails with sensible message when arg#description is nil" do
+        arg = Class.new do
+          def description
+          end
+
+          def inspect
+            "my_thing"
+          end
+        end.new
+
+        expect do
+          @double.should_receive(:msg).with(arg)
+          @double.msg 3
+        end.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"double\" received :msg with unexpected arguments\n  expected: (my_thing)\n       got: (3)")
+      end
+
+      it "fails with sensible message when arg#description is blank" do
+        arg = Class.new do
+          def description
+            ""
+          end
+
+          def inspect
+            "my_thing"
+          end
+        end.new
+
+        expect do
+          @double.should_receive(:msg).with(arg)
+          @double.msg 3
+        end.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"double\" received :msg with unexpected arguments\n  expected: (my_thing)\n       got: (3)")
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, when setting a expectation with an argument with a blank description, the failure message lists no argument. This can be confusing, and should default to calling arg.inspect if the description is blank.
