### PR TITLE
Deprecate using a with block with arguments.

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -344,7 +344,15 @@ module RSpec
       #   cart.add(Book.new(:isbn => 1934356379))
       #   # => passes
       def with(*args, &block)
-        self.inner_implementation_action = block if block_given? unless args.empty?
+        if block_given?
+          if args.empty?
+            RSpec.deprecate "Using the return value of a `with` block to validate passed arguments rather than as an implementation",
+              :replacement => "the `satisfy` matcher, a custom matcher or validate the arguments in an implementation block"
+          else
+            self.inner_implementation_action = block
+          end
+        end
+
         @argument_list_matcher = ArgumentListMatcher.new(*args, &block)
         self
       end

--- a/spec/rspec/mocks/block_return_value_spec.rb
+++ b/spec/rspec/mocks/block_return_value_spec.rb
@@ -65,6 +65,22 @@ describe "a double declaration with a block handed to:" do
       obj.stub(:foo).with(1, 2, &lambda { 'bar' })
       expect(obj.foo(1, 2)).to eq('bar')
     end
+
+    it 'warns of deprecation when provided block but no arguments' do
+      expect(RSpec).to receive(:deprecate) do |message, opts|
+        expect(message).to match(/Using the return value of a `with` block/)
+      end
+      obj = Object.new
+      obj.stub(:foo).with {|x| 'baz' }.and_return('bar')
+      expect(obj.foo(1)).to eq('bar')
+    end
+
+    it 'includes callsite in deprecation of provided block but no arguments' do
+      obj = Object.new
+      expect_deprecation_with_call_site __FILE__, __LINE__ + 1
+      obj.stub(:foo).with {|x| 'baz' }.and_return('bar')
+      expect(obj.foo(1)).to eq('bar')
+    end
   end
 
   %w[once twice ordered and_return].each do |method|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,16 @@ module VerifyAndResetHelpers
   end
 end
 
+# TODO: This is duplicated in rspec-core, should be extracted into
+# rspec-support when that project gets started.
+module HelperMethods
+  def expect_deprecation_with_call_site(file, line)
+    expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
+      expect(options[:call_site]).to include([file, line].join(':'))
+    end
+  end
+end
+
 RSpec.configure do |config|
   config.mock_with :rspec
   config.color_enabled = true
@@ -44,6 +54,7 @@ RSpec.configure do |config|
   end
 
   config.include VerifyAndResetHelpers
+  config.include HelperMethods
 end
 
 shared_context "with syntax" do |syntax|


### PR DESCRIPTION
It is confusing to have different behaviour depending on whether the
block has arguments or not, and there are better ways to do this.

References #377.
