### PR TITLE
Blocks provided to `with` are used as implementation.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ Breaking Changes for 3.0.0:
 * Make `at_least(0)` raise an error. (Sam Phippen)
 * Remove support for `require 'spec/mocks'` which had been kept
   in place for backwards compatibility with rspec 1 (Myron Marston).
+* Blocks provided to `with` are always used as implementation (Xavier Shay).
 
 Enhancements:
 

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -353,8 +353,13 @@ module RSpec
       #   cart.add(Book.new(:isbn => 1934356379))
       #   # => passes
       def with(*args, &block)
-        self.inner_implementation_action = block if block_given? unless args.empty?
-        @argument_list_matcher = ArgumentListMatcher.new(*args, &block)
+        if args.empty?
+          raise ArgumentError,
+            "`with` must have at least one argument. Use `no_args` matcher to set the expectation of receiving no arguments."
+        end
+
+        self.inner_implementation_action = block
+        @argument_list_matcher = ArgumentListMatcher.new(*args)
         self
       end
 

--- a/lib/rspec/mocks/verifying_message_expecation.rb
+++ b/lib/rspec/mocks/verifying_message_expecation.rb
@@ -26,14 +26,13 @@ module RSpec
       # @override
       def with(*args, &block)
         unless ArgumentMatchers::AnyArgsMatcher === args.first
-          expected_arity = if block
-            block.arity
-          elsif ArgumentMatchers::NoArgsMatcher === args.first
+          expected_arity = if ArgumentMatchers::NoArgsMatcher === args.first
             0
           elsif args.length > 0
             args.length
           else
-            raise ArgumentError, "No arguments nor block given."
+            # No arguments given, this will raise.
+            super
           end
 
           ensure_arity!(expected_arity)

--- a/spec/rspec/mocks/block_return_value_spec.rb
+++ b/spec/rspec/mocks/block_return_value_spec.rb
@@ -31,6 +31,12 @@ describe "a double declaration with a block handed to:" do
       obj.stub(:foo).with('baz') { 'bar' }
       expect(obj.foo('baz')).to eq('bar')
     end
+
+    it "returns the value of executing the block with given argument" do
+      obj = Object.new
+      obj.stub(:foo).with('baz') {|x| 'bar' + x }
+      expect(obj.foo('baz')).to eq('barbaz')
+    end
   end
 
   %w[once twice ordered and_return].each do |method|

--- a/spec/rspec/mocks/failing_argument_matchers_spec.rb
+++ b/spec/rspec/mocks/failing_argument_matchers_spec.rb
@@ -97,11 +97,10 @@ module RSpec
          end.to raise_error(/array_including\(1,2,3\)/)
       end
 
-      it "fails with block matchers" do
+      it "fails with zero arguments" do
         expect do
           @double.should_receive(:msg).with {|arg| expect(arg).to eq :received }
-          @double.msg :no_msg_for_you
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected: :received.*\s*.*got: :no_msg_for_you/)
+        end.to raise_error(ArgumentError, /must have at least one argument/)
       end
 
       it "fails with sensible message when args respond to #description" do

--- a/spec/rspec/mocks/passing_argument_matchers_spec.rb
+++ b/spec/rspec/mocks/passing_argument_matchers_spec.rb
@@ -89,26 +89,6 @@ module RSpec
         end
       end
 
-      context "handling block matchers" do
-        it "matches arguments against RSpec expectations" do
-          @double.should_receive(:random_call).with {|arg1, arg2, arr, *rest|
-            expect(arg1).to eq 5
-            expect(arg2.length).to be >= 3
-            expect(arg2.length).to be <= 10
-            expect(arr.map {|i| i * 2}).to eq [2,4,6]
-            expect(rest).to eq [:fee, "fi", 4]
-          }
-          @double.random_call 5, "hello", [1,2,3], :fee, "fi", 4
-        end
-
-        it "does not eval the block as the return value" do
-          eval_count = 0
-          @double.should_receive(:msg).with {|a| eval_count += 1}
-          @double.msg(:ignore)
-          expect(eval_count).to eq(1)
-        end
-      end
-
       context "handling non-matcher arguments" do
         it "matches non special symbol (can be removed when deprecated symbols are removed)" do
           @double.should_receive(:random_call).with(:some_symbol)

--- a/spec/rspec/mocks/verifying_message_expecation_spec.rb
+++ b/spec/rspec/mocks/verifying_message_expecation_spec.rb
@@ -55,21 +55,11 @@ module RSpec
           end
         end
 
-        describe 'when called with a block' do
-          it 'matches arity against the arity of the block' do
-            subject.method_finder = Proc.new { lambda {|_| } }
-            expect(error_generator).to receive(:raise_arity_error).
-              with(instance_of(ArityCalculator), 2)
-
-            subject.with {|x, y| }
-          end
-        end
-
         describe 'when called with no arguments and no block' do
           it 'raises' do
             expect {
               subject.with
-            }.to raise_error(ArgumentError, "No arguments nor block given.")
+            }.to raise_error(ArgumentError)
           end
         end
       end


### PR DESCRIPTION
It is confusing to have different behaviour depending on whether the
block has arguments or not, and there are better ways to do this.

This behaviour matches that of other message expectations.

Fixes #377.
