### PR TITLE
Allow chaining receive modifications off do..end blocks

### DIFF
--- a/lib/rspec/mocks/matchers/receive.rb
+++ b/lib/rspec/mocks/matchers/receive.rb
@@ -76,6 +76,7 @@ module RSpec
           @recorded_customizations.each do |customization|
             customization.playback_onto(expectation)
           end
+          expectation
         end
 
         class Customization

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -32,6 +32,14 @@ module RSpec
           expect(receiver.foo).to eq(4)
         end
 
+        it 'allows chaining off a `do...end` block implementation to be provided' do
+          wrapped.to receive(:foo) do
+            4
+          end.and_return(6)
+
+          expect(receiver.foo).to eq(6)
+        end
+
         it 'allows a `{ ... }` block implementation to be provided' do
           wrapped.to receive(:foo) { 5 }
           expect(receiver.foo).to eq(5)


### PR DESCRIPTION
Further to #382 this fixes a block precedence option when chaining matchers
off do ... end blocks.
