### PR TITLE
Feature for specific argument constraints (ex/ double.stub(:foo).with_fourth_argument(...))

### DIFF
--- a/spec/rspec/mocks/stubbed_message_expectations_spec.rb
+++ b/spec/rspec/mocks/stubbed_message_expectations_spec.rb
@@ -54,5 +54,48 @@ describe "expection set on previously stubbed method" do
         expect(e.message).to include('expected: ("a", ["b"])', 'got: (["a"], "b")')
       }
     end
+
+    describe "when using a short-hand specific argument constraint method" do
+      context "for a stubbed method" do
+        it 'assumes "anything" for all arguments other than the specified argument' do
+          [:first, :second, :third, :fourth, :fifth, :sixth, :seventh, :eigth, :ninth] \
+            .each_with_index do |interval, index|
+
+            with_x_argument = "with_#{interval}_argument"
+
+            dbl = double
+            params = [anything] * 10
+            dbl.stub(:test).with(*params)
+
+            dbl.should_receive(:test).send(with_x_argument, 1)
+
+            expect { verify dbl }.to raise_error
+              /\((#<.+AnyArgMatcher.+>, ){#{index}}1(, #<.+AnyArgMatcher.+>){#{9-index}}\)/
+          end
+        end
+      end
+
+      context "for a concrete method" do
+        class FakeConcreteObject
+          def concrete_method(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
+          end
+        end
+
+        it 'assumes "anything" for all arguments other than the specified argument' do
+          [:first, :second, :third, :fourth, :fifth, :sixth, :seventh, :eigth, :ninth] \
+            .each_with_index do |interval, index|
+
+            with_x_argument = "with_#{interval}_argument"
+
+            obj = FakeConcreteObject.new
+
+            obj.should_receive(:concrete_method).send(with_x_argument, 1)
+
+            expect { verify obj }.to raise_error
+              /\((#<.+AnyArgMatcher.+>, ){#{index}}1(, #<.+AnyArgMatcher.+>){#{9-index}}\)/
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I wanted to propose a new feature for rspec that allows an argument constraint style for a specific argument.

So, instead of:

``` ruby
it "verifies one part" do
  ...
  x.should_receive(:foo).with(value, anything, anything, anything, anything)
  ...
end

it "verifies the other part" do
  ...
  x.should_receive(:foo).with(anything, value, anything, anything, anything)
  ...
end

it "verifies yet some other part" do
  ...
  x.should_receive(:foo).with(anything, anything, value, anything, anything)
  ...
end
```

I'd like it to be:

``` ruby
it "verifies one part" do
  ...
  x.should_receive(:foo).with_first_argument(value)
  ...
end

it "verifies the other part" do
  ...
  x.should_receive(:foo).with_second_argument(value)
  ...
end

it "verifies yet some other part" do
  ...
  x.should_receive(:foo).with_third_argument(value)
  ...
end
```

Some of the benefits
- It's easier to read
- Tests won't need to be updated if you add additional parameters to a method. With the current style of using _anything_, if I were to add a parameter to a method, I would then have to update all my with(...) constraints to include another _anything_ argument. This feature eliminates the need to rework the existing tests.

This pull request includes a working implementation that's tested, but I don't think it's all the way there. Before putting more time into the implementation, I first wanted to get some feedback from the rspec team to see if you would accept a feature like this. If the team does like it, I would love to get it to the point that meets the rspec team's standards, and also would love to hear suggestions regarding any implementation ideas.

Thanks!
Mike
