### PR TITLE
Fixup some warnings

### DIFF
--- a/spec/rspec/mocks/combining_implementation_instructions_spec.rb
+++ b/spec/rspec/mocks/combining_implementation_instructions_spec.rb
@@ -171,7 +171,7 @@ module RSpec
       end
 
       it 'warns when the inner implementation block is overriden' do
-        expect(RSpec).to receive(:warning).with /overriding a previous implementation/
+        expect(RSpec).to receive(:warning).with(/overriding a previous implementation/)
         double.stub(:foo).with(:arg) { :with_block }.at_least(:once) { :at_least_block }
       end
 

--- a/spec/rspec/mocks/matchers/receive_messages_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_messages_spec.rb
@@ -85,7 +85,7 @@ module RSpec
 
       it 'fails with the correct location' do
         expect(obj).to receive_messages(:a => 1, :b => 2); line = __LINE__
-        expect(expectation_error.backtrace[0]).to match /#{__FILE__}:#{line}/
+        expect(expectation_error.backtrace[0]).to match(/#{__FILE__}:#{line}/)
       end
 
       it_behaves_like "complains when given blocks"

--- a/spec/rspec/mocks/space_spec.rb
+++ b/spec/rspec/mocks/space_spec.rb
@@ -20,7 +20,8 @@ module RSpec::Mocks
         parent      = parent_class.new
         child       = child_class.new
 
-        grandparent_proxy = space.proxy_for(grandparent)
+        space.proxy_for(grandparent)
+
         parent_proxy      = space.proxy_for(parent)
         child_proxy       = space.proxy_for(child)
 


### PR DESCRIPTION
Mostly started this to fixup some stray warnings, but started converting some
syntax across, realised that we have a lot of `should` syntax here and that
currently causes a deprecation notice(s). Should we do anything about that?

Also there are some more warnings caused by overriding let definitions, via
`shared_examples` which is definitely supported behaviour, should we deal with
that warning?

Thoughts?
