### PR TITLE
Work around JRuby returning empty parameters on repeated calls.

### DIFF
--- a/lib/rspec/mocks/method_reference.rb
+++ b/lib/rspec/mocks/method_reference.rb
@@ -59,8 +59,20 @@ module RSpec
       # definition of "implemented". However, it's the best we can do.
       alias method_defined? method_implemented?
 
-      def find_method(m)
-        m.instance_method(@method_name)
+      # works around the fact that repeated calls for method parameters will
+      # falsely return empty arrays on JRuby in certain circumstances, this
+      # is necessary here because we can't dup/clone UnboundMethods.
+      #
+      # This is necessary due to a bug in JRuby prior to 1.7.5 fixed in:
+      # https://github.com/jruby/jruby/commit/99a0613fe29935150d76a9a1ee4cf2b4f63f4a27
+      if RUBY_PLATFORM == 'java' && JRUBY_VERSION.split('.')[-1].to_i < 5
+        def find_method(m)
+          m.dup.instance_method(@method_name)
+        end
+      else
+        def find_method(m)
+          m.instance_method(@method_name)
+        end
       end
     end
 


### PR DESCRIPTION
This fixes a JRuby bug where by repeated calls to parameters on unbound 
instance methods falsely return []

e.g. on JRuby 1.7.4

``` Ruby
 String.instance_method(:replace).parameters
 # => [[:req]]
 String.instance_method(:replace).parameters
 # => []
```

And with this "fix"

``` Ruby
 String.dup.instance_method(:replace).parameters
 # => [[:req]]
 String.dup.instance_method(:replace).parameters
 # => [[:req]]
```
