### PR TITLE
Initial implementation of warning in before(:all) blocks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ Breaking Changes for 3.0.0:
 * Change how to integrate rspec-mocks in other test frameworks. You now
   need to include `RSpec::Mocks::ExampleMethods` in your test context.
   (Myron Marston)
+* Prevent RSpec mocks' doubles and partial doubles from being used outside of
+  the per-test lifecycle (e.g. from a `before(:all)` hook). (Sam Phippen)
 
 Bug Fixes:
 

--- a/features/test_frameworks/test_unit.feature
+++ b/features/test_frameworks/test_unit.feature
@@ -15,6 +15,10 @@ Feature: Test::Unit integration
       class RSpecMocksTest < Test::Unit::TestCase
         include RSpec::Mocks::ExampleMethods
 
+        def setup
+          RSpec::Mocks.setup
+        end
+
         def teardown
           RSpec::Mocks.verify
         ensure

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -1,6 +1,7 @@
 require 'rspec/mocks/framework'
 require 'rspec/mocks/version'
 require 'rspec/support'
+require "rspec/mocks/error_space"
 
 module RSpec
   # Contains top-level utility methods. While this contains a few
@@ -8,18 +9,21 @@ module RSpec
   # a test or example. They exist primarily for integration with
   # test frameworks (such as rspec-core).
   module Mocks
+    ERROR_SPACE = RSpec::Mocks::ErrorSpace.new
+    MOCK_SPACE = RSpec::Mocks::Space.new
+
     class << self
       # Stores rspec-mocks' global state.
       # @api private
       attr_accessor :space
     end
 
-    self.space = RSpec::Mocks::Space.new
+    self.space = ERROR_SPACE
 
     # Performs per-test/example setup. This should be called before
     # an test or example begins.
-    def self.setup(host)
-      # Nothing to do for now
+    def self.setup(host=nil)
+      self.space = MOCK_SPACE
     end
 
     # Verifies any message expectations that were set during the
@@ -33,6 +37,7 @@ module RSpec
     # each example, even if an error was raised during the example.
     def self.teardown
       space.reset_all
+      self.space = ERROR_SPACE
     end
 
     # Adds an allowance (stub) on `subject`

--- a/lib/rspec/mocks/error_space.rb
+++ b/lib/rspec/mocks/error_space.rb
@@ -1,0 +1,31 @@
+module RSpec
+  module Mocks
+    # @private
+    # Raised when doubles or partial doubles are used outside of the per-test lifecycle.
+    OutsideOfExampleError = Class.new(StandardError)
+
+    # @private
+    class ErrorSpace
+      def proxy_for(*args)
+        raise_lifecycle_message
+      end
+
+      def any_instance_recorder_for(*args)
+        raise_lifecycle_message
+      end
+
+      def reset_all
+      end
+
+      def verify_all
+      end
+
+      private
+
+      def raise_lifecycle_message
+        raise OutsideOfExampleError, "The use of doubles or partial doubles from rspec-mocks outside of the per-test lifecycle is not supported."
+      end
+    end
+
+  end
+end

--- a/lib/rspec/mocks/matchers/have_received.rb
+++ b/lib/rspec/mocks/matchers/have_received.rb
@@ -54,9 +54,11 @@ module RSpec
       private
 
         def expect
-          expectation = mock_proxy.build_expectation(@method_name)
-          apply_constraints_to expectation
-          expectation
+          @expectation ||= begin
+            expectation = mock_proxy.build_expectation(@method_name)
+            apply_constraints_to expectation
+            expectation
+          end
         end
 
         def apply_constraints_to(expectation)

--- a/lib/rspec/mocks/standalone.rb
+++ b/lib/rspec/mocks/standalone.rb
@@ -1,2 +1,3 @@
 require 'rspec/mocks'
 include RSpec::Mocks::ExampleMethods
+RSpec::Mocks.setup

--- a/spec/rspec/mocks/null_object_mock_spec.rb
+++ b/spec/rspec/mocks/null_object_mock_spec.rb
@@ -89,15 +89,11 @@ module RSpec
         expect(("%i" % @double)).to eq("0")
       end
 
-      it "does not allow null-ness to persist between examples" do
+      it "does not allow null objects to be used outside of examples" do
         RSpec::Mocks.teardown
 
-        expect(@double).not_to be_null_object
-        expect { @double.some.long.message.chain }.to raise_error(RSpec::Mocks::MockExpectationError)
-
-        @double.as_null_object
-        expect(@double).to be_null_object
-        expect { @double.some.long.message.chain }.not_to raise_error
+        expect { @double.some.long.message.chain }.to raise_error(RSpec::Mocks::OutsideOfExampleError)
+        expect { @double.as_null_object }.to raise_error(RSpec::Mocks::OutsideOfExampleError)
       end
     end
 

--- a/spec/rspec/mocks/stubbing_in_before_all_spec.rb
+++ b/spec/rspec/mocks/stubbing_in_before_all_spec.rb
@@ -1,0 +1,103 @@
+require "spec_helper"
+require "delegate"
+
+describe "Stubbing/mocking methods in before(:all) blocks" do
+  old_rspec = nil
+
+  shared_examples_for "A stub/mock in a before(:all) block" do |message_expectation_block|
+    the_error = nil
+    before(:all) do
+      begin
+        use_rspec_mocks
+      rescue
+        the_error = $!
+      end
+    end
+
+    it "raises an error with a useful message" do
+      expect(the_error).to be_a_kind_of(RSpec::Mocks::OutsideOfExampleError)
+
+      expect(the_error.message).to match(/The use of doubles or partial doubles from rspec-mocks outside of the per-test lifecycle is not supported./)
+    end
+  end
+
+  describe "#stub" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        Object.stub(:foo)
+      end
+    end
+  end
+
+  describe "#unstub" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        Object.unstub(:foo)
+      end
+    end
+  end
+
+  describe "#should_receive" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        Object.should_receive(:foo)
+      end
+    end
+  end
+
+  describe "#should_not_receive" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        Object.should_not_receive(:foo)
+      end
+    end
+  end
+
+  describe "#any_instance" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        Object.any_instance.should_receive(:foo)
+      end
+    end
+  end
+
+  describe "#stub_chain" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        Object.stub_chain(:foo)
+      end
+    end
+  end
+
+  describe "#expect(...).to receive" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        expect(Object).to receive(:foo)
+      end
+    end
+  end
+
+  describe "#allow(...).to receive" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        allow(Object).to receive(:foo)
+      end
+    end
+  end
+
+  describe "#expect_any_instance_of(...).to receive" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        expect_any_instance_of(Object).to receive(:foo)
+      end
+    end
+  end
+
+  describe "#allow_any_instance_of(...).to receive" do
+    it_behaves_like "A stub/mock in a before(:all) block" do
+      def use_rspec_mocks
+        allow_any_instance_of(Object).to receive(:foo)
+      end
+    end
+  end
+end

--- a/spec/rspec/mocks_spec.rb
+++ b/spec/rspec/mocks_spec.rb
@@ -12,13 +12,13 @@ describe RSpec::Mocks do
   end
 
   describe "::teardown" do
-    it "delegates to the space" do
+    it "prevents further expectations from being set" do
       foo = double
       foo.should_receive(:bar)
       RSpec::Mocks::teardown
       expect do
         foo.bar
-      end.to raise_error(/received unexpected message/)
+      end.to raise_error(RSpec::Mocks::OutsideOfExampleError)
     end
   end
 


### PR DESCRIPTION
So this works, but I'm not sure I like the implementation.

The nice thing is that it doesn't talk to RSpec core at all and achieves the desired behaviour (I believe). On the minus side it requires tracking more state and because we can't do message expectations in before blocks I've had to stub Kernel.warn manually, also I'm not sure if the RSpec::Mocks class itself is the right place to track this state.

I'd love some design feedback here, it's a little rough and ready, but it definitely solves the problem.

An example of what it looks like when running outside of RSpec's own test suite:

```
(warn-stubbing-before-all)$ ber --color hi_spec.rb 
/Users/sam/dev/rspec/rspec-dev/repos/rspec-support/lib/rspec/support/warnings.rb:28: warning: method redefined; discarding old warning
/Users/sam/dev/rspec/rspec-dev/repos/rspec-core/lib/rspec/core/warnings.rb:25: warning: previous definition of warning was here
/Users/sam/dev/rspec/rspec-dev/repos/rspec-support/lib/rspec/support/warnings.rb:35: warning: method redefined; discarding old warn_with
/Users/sam/dev/rspec/rspec-dev/repos/rspec-core/lib/rspec/core/warnings.rb:32: warning: previous definition of warn_with was here
/Users/sam/dev/rspec/rspec-dev/repos/rspec-mocks/lib/rspec/mocks.rb:19: warning: instance variable @usable not initialized
WARNING: calling stub on objects in `before(:all)` blocks is unsupported. Consider using `let` or `before(:each)` instead. Called from /Users/sam/dev/rspec/rspec-dev/repos/rspec-mocks/hi_spec.rb:5:in `block (2 levels) in <top (required)>'.
F

Failures:

  1) qwoifej return nil
     Failure/Error: Foo.find.should eq(nil)
     NoMethodError:
       undefined method `find' for Foo:Class
     # ./hi_spec.rb:9:in `block (2 levels) in <top (required)>'

Finished in 0.00059 seconds
1 example, 1 failure

Failed examples:

rspec ./hi_spec.rb:8 # qwoifej return nil
```
