### PR TITLE
Correct the entry of should syntax deprecation in changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -50,7 +50,7 @@ Enhancements:
 Deprecations:
 
 * Using the old `:should` syntax without explicitly configuring it
-  is disabled. It will continue to work but will emit a deprecation
+  is deprecated. It will continue to work but will emit a deprecation
   warning in RSpec 3 if you do not explicitly enable it. (Sam Phippen)
 
 Bug Fixes:


### PR DESCRIPTION
On RSpec 3, the `should` syntax is not _disabled_, it's _deprecated_.

The same entry in `rspec-expectations` is all right.
https://github.com/rspec/rspec-expectations/blob/311b60baad804fc19c12b07903138c04cc60d570/Changelog.md
