### PR TITLE
Squat on less of the user's method namespace.

### DIFF
--- a/lib/rspec/mocks/argument_matchers.rb
+++ b/lib/rspec/mocks/argument_matchers.rb
@@ -203,7 +203,7 @@ module RSpec
       #   object.should_receive(:message).with(hash_including(:key))
       #   object.should_receive(:message).with(hash_including(:key, :key2 => val2))
       def hash_including(*args)
-        HashIncludingMatcher.new(anythingize_lonely_keys(*args))
+        HashIncludingMatcher.new(ArgumentMatchers.anythingize_lonely_keys(*args))
       end
 
       # Matches an array that includes the specified items at least once.
@@ -226,7 +226,7 @@ module RSpec
       #   object.should_receive(:message).with(hash_excluding(:key))
       #   object.should_receive(:message).with(hash_excluding(:key, :key2 => :val2))
       def hash_excluding(*args)
-        HashExcludingMatcher.new(anythingize_lonely_keys(*args))
+        HashExcludingMatcher.new(ArgumentMatchers.anythingize_lonely_keys(*args))
       end
 
       alias_method :hash_not_including, :hash_excluding
@@ -252,11 +252,10 @@ module RSpec
 
       alias_method :a_kind_of, :kind_of
 
-      private
-
-      def anythingize_lonely_keys(*args)
+      # @api private
+      def self.anythingize_lonely_keys(*args)
         hash = args.last.class == Hash ? args.delete_at(-1) : {}
-        args.each { | arg | hash[arg] = anything }
+        args.each { | arg | hash[arg] = AnyArgMatcher.new(nil) }
         hash
       end
     end

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -28,7 +28,7 @@ module RSpec
       #   card.rank  #=> "A"
       #
       def double(*args)
-        declare_double(Mock, *args)
+        ExampleMethods.declare_double(Mock, *args)
       end
 
       # @overload instance_double(doubled_class)
@@ -43,7 +43,7 @@ module RSpec
       # [double](double).
       def instance_double(doubled_class, *args)
         ref = ObjectReference.for(doubled_class)
-        declare_verifying_double(InstanceVerifyingDouble, ref, *args)
+        ExampleMethods.declare_verifying_double(InstanceVerifyingDouble, ref, *args)
       end
 
       # @overload class_double(doubled_class)
@@ -58,7 +58,7 @@ module RSpec
       # [double](double).
       def class_double(doubled_class, *args)
         ref = ObjectReference.for(doubled_class)
-        declare_verifying_double(ClassVerifyingDouble, ref, *args)
+        ExampleMethods.declare_verifying_double(ClassVerifyingDouble, ref, *args)
       end
 
       # @overload object_double(object_or_name)
@@ -73,7 +73,7 @@ module RSpec
       # for verification. In all other ways it behaves like a [double](double).
       def object_double(object_or_name, *args)
         ref = ObjectReference.for(object_or_name, :allow_direct_object_refs)
-        declare_verifying_double(ObjectVerifyingDouble, ref, *args)
+        ExampleMethods.declare_verifying_double(ObjectVerifyingDouble, ref, *args)
       end
 
       # Disables warning messages about expectations being set on nil.
@@ -164,6 +164,7 @@ module RSpec
         Matchers::HaveReceived.new(method_name, &block)
       end
 
+      # @api private
       def self.included(klass)
         klass.class_exec do
           # This gets mixed in so that if `RSpec::Matchers` is included in
@@ -172,9 +173,8 @@ module RSpec
         end
       end
 
-    private
-
-      def declare_verifying_double(type, ref, *args)
+      # @api private
+      def self.declare_verifying_double(type, ref, *args)
         if RSpec::Mocks.configuration.verify_doubled_constant_names? &&
           !ref.defined?
 
@@ -187,7 +187,8 @@ module RSpec
         declare_double(type, ref, *args)
       end
 
-      def declare_double(type, *args)
+      # @api private
+      def self.declare_double(type, *args)
         args << {} unless Hash === args.last
         type.new(*args)
       end

--- a/spec/rspec/mocks/example_methods_spec.rb
+++ b/spec/rspec/mocks/example_methods_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+module RSpec
+  module Mocks
+    describe ExampleMethods do
+      it 'does not define private helper methods since it gets included into a ' +
+         'namespace where users define methods and could inadvertently overwrite ' +
+         'them' do
+        expect(ExampleMethods.private_instance_methods).to eq([])
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
RSpec::Mocks::ExampleMethods is mixed into a context
where users freely define their own methods.  As such,
it's best to not define private helper methods as the
user may inadvertently overwrite them. These methods
were all stateless, anyway, so they work equally well
as class methods and this creates less surface area
for override problems.
