### PR TITLE
Stop inherited method's unrecoverble stub

### DIFF
--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -184,6 +184,7 @@ module RSpec
           if RSpec::Mocks.configuration.verify_partial_doubles?
             raise MockExpectationError unless @klass.method_defined?(method_name)
           end
+          ensure_restorable!(method_name)
 
           stop_observing!(method_name) if already_observing?(method_name)
           @observed_methods << method_name
@@ -201,6 +202,16 @@ module RSpec
             klass = ::RSpec::Mocks.method_handle_for(self, method_name).owner
             invoked_instance = ::RSpec::Mocks.any_instance_recorder_for(klass).instance_that_received(method_name)
             raise RSpec::Mocks::MockExpectationError, "The message '#{method_name}' was received by #{self.inspect} but has already been received by #{invoked_instance}"
+          end
+        end
+
+        def ensure_restorable!(method_name)
+          return unless Method.public_instance_methods.include?(:source_location)
+          return unless public_protected_or_private_method_defined?(method_name)
+          return if @klass.public_instance_methods(false).include?(method_name)
+
+          if @klass.instance_method(method_name).source_location.first == __FILE__
+            raise RSpec::Mocks::UnrestorableStubError, "Original method is already stubbed"
           end
         end
       end

--- a/lib/rspec/mocks/errors.rb
+++ b/lib/rspec/mocks/errors.rb
@@ -7,6 +7,10 @@ module RSpec
     # @private
     class AmbiguousReturnError < StandardError
     end
+
+    # @private
+    class UnrestorableStubError < StandardError
+    end
   end
 end
 

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -1024,6 +1024,28 @@ module RSpec
           expect(instance.existing_method).to eq :existing_method_return_value
         end
       end
+
+      context "when stubbing inherited method on both super and sub classes" do
+        let(:super_class) { Class.new { def foo; end } }
+        let(:sub_class) { Class.new(super_class) }
+
+        before do
+          super_class.any_instance.stub(:foo)
+        end
+
+        it "raises on defining stub immediately" do
+          pending('Ruby 1.9+ required') if RUBY_VERSION < '1.9'
+
+          expect {
+            sub_class.any_instance.stub(:foo)
+            # raised UnrestorableStubError above.
+            # without this guard, SystemStackError raised at `sub_class.new.foo`
+
+            sub_class.any_instance.unstub(:foo)
+            sub_class.new.foo
+          }.to raise_error(RSpec::Mocks::UnrestorableStubError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Stubbing inherited method with `any_instance` sometimes cause
SystemStackError, below is reproduction example.

``` ruby
class SuperClass
  def foo; end
end

class SubClass < SuperClass
end

describe SubClass do
  it "workds fine at firstt" do
    SuperClass.any_instance.stub(:foo)
    SubClass.any_instance.stub(:foo)
  end

  it "cause SystemStackError after removing stub" do
    SubClass.new.foo # => SystemStackError raised
  end
end
```

`restore_original_method` for SubClass restores SuperClass's stubbed method, so that `SubClass#foo` is broken.

This commit prevent this problem by raising error immediately when SubClass's `any_instance` stub is defined.
