### PR TITLE
Update Rubinius on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ rvm:
   - ree
   - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
-  - rbx-19mode
+  - rbx-2.2.1
+  - rbx
   - 2.0.0
   - 2.1.0-preview2
 matrix:
   allow_failures:
-    - rvm: rbx-18mode
-    - rvm: rbx-19mode
+    - rvm: rbx-2.2.1
+    - rvm: rbx
 


### PR DESCRIPTION
Travis actually dropped (due to rvm dropping) support for rbx-1.8 and rbx-1.9.
There is now the option to have 2.2.1 and head. We should do something about
this.
