### PR TITLE
Fix `any_instance.unstub` of subclasses which have been `any_instance.stub`ed.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,8 @@ Bug Fixes:
 * Fix `expect` syntax so that it does not wrongly emit a "You're
   overriding a previous implementation for this stub" warning when
   you are not actually doing that. (Myron Marston)
+* Fix `any_instance.unstub` when used on sub classes for whom the super
+  class has had `any_instance.stub` invoked on. (Jon Rowe)
 
 Enhancements:
 

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -125,10 +125,36 @@ module RSpec
         end
 
         def already_observing?(method_name)
-          @observed_methods.include?(method_name)
+          @observed_methods.include?(method_name) || super_class_observing?(method_name)
         end
 
-        private
+      protected
+
+        def stop_observing!(method_name)
+          restore_method!(method_name)
+          @observed_methods.delete(method_name)
+          super_class_observers_for(method_name).each do |ancestor|
+            ::RSpec::Mocks.any_instance_recorder_for(ancestor).stop_observing!(method_name)
+          end
+        end
+
+      private
+
+        def ancestor_is_an_observer?(method_name)
+          lambda do |ancestor|
+            unless ancestor == @klass
+              ::RSpec::Mocks.any_instance_recorder_for(ancestor).already_observing?(method_name)
+            end
+          end
+        end
+
+        def super_class_observers_for(method_name)
+          @klass.ancestors.select(&ancestor_is_an_observer?(method_name))
+        end
+
+        def super_class_observing?(method_name)
+          @klass.ancestors.any?(&ancestor_is_an_observer?(method_name))
+        end
 
         def normalize_chain(*args)
           args.shift.to_s.split('.').map {|s| s.to_sym}.reverse.each {|a| args.unshift a}
@@ -150,11 +176,13 @@ module RSpec
         end
 
         def restore_original_method!(method_name)
-          alias_method_name = build_alias_method_name(method_name)
-          @klass.class_exec do
-            remove_method method_name
-            alias_method  method_name, alias_method_name
-            remove_method alias_method_name
+          if @klass.instance_method(method_name).owner == @klass
+            alias_method_name = build_alias_method_name(method_name)
+            @klass.class_exec do
+              remove_method method_name
+              alias_method  method_name, alias_method_name
+              remove_method alias_method_name
+            end
           end
         end
 
@@ -173,11 +201,6 @@ module RSpec
 
         def public_protected_or_private_method_defined?(method_name)
           MethodReference.method_defined_at_any_visibility?(@klass, method_name)
-        end
-
-        def stop_observing!(method_name)
-          restore_method!(method_name)
-          @observed_methods.delete(method_name)
         end
 
         def observe!(method_name)

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -97,6 +97,9 @@ module RSpec
         end
 
         context "behaves as 'every instance'" do
+          let(:super_class) { Class.new { def foo; 'bar'; end } }
+          let(:sub_class)   { Class.new(super_class) }
+
           it "stubs every instance in the spec" do
             klass.any_instance.stub(:foo).and_return(result = Object.new)
             expect(klass.new.foo).to eq(result)
@@ -114,6 +117,19 @@ module RSpec
 
             foo = 'foo'.freeze
             expect(foo.dup.concat 'bar').to eq 'foobar'
+          end
+
+          it 'handles stubbing on super and subclasses' do
+            super_class.any_instance.stub(:foo)
+            sub_class.any_instance.stub(:foo).and_return('baz')
+            expect(sub_class.new.foo).to eq('baz')
+          end
+
+          it 'handles method restoration on subclasses' do
+            super_class.any_instance.stub(:foo)
+            sub_class.any_instance.stub(:foo)
+            sub_class.any_instance.unstub(:foo)
+            expect(sub_class.new.foo).to eq("bar")
           end
         end
 


### PR DESCRIPTION
Fixup unstubing of sub classes when super classes are stubbed via any_instance, fixes #474.

...
