### PR TITLE
Add a spec which demonstrates how args work with stub chain

### DIFF
--- a/spec/rspec/mocks/stub_chain_spec.rb
+++ b/spec/rspec/mocks/stub_chain_spec.rb
@@ -32,17 +32,13 @@ module RSpec
         it "accepts any number of arguments to the stubbed messages" do
           object.stub_chain(:msg1, :msg2).and_return(:return_value)
 
-          expect {
-            object.msg1("nonsense", :value).msg2("another", :nonsense, 3.0, "value")
-          }.not_to raise_error
+          expect(object.msg1("nonsense", :value).msg2("another", :nonsense, 3.0, "value")).to eq(:return_value)
         end
 
         it "accepts any number of arguments to the stubbed messages with a return value from a hash" do
           object.stub_chain(:msg1, :msg2 => :return_value)
 
-          expect {
-            object.msg1("nonsense", :value).msg2("another", :nonsense, 3.0, "value")
-          }.not_to raise_error
+          expect(object.msg1("nonsense", :value).msg2("another", :nonsense, 3.0, "value")).to eq(:return_value)
         end
 
         context "using and_return" do


### PR DESCRIPTION
I couldn't find any specs on arguments for the stubs on stub_chain. There were some questions about it in IRC so I've added this spec which gives us a check for the behaviour in 2.14.0 before expect syntax for this was added. I've got a parallel branch with some specs for 3.0.0 which is coming next.
