### PR TITLE
Allow objects to be marshaled outside per-test lifecycle.

### DIFF
--- a/lib/rspec/mocks/error_space.rb
+++ b/lib/rspec/mocks/error_space.rb
@@ -20,6 +20,10 @@ module RSpec
       def verify_all
       end
 
+      def registered?(object)
+        false
+      end
+
       private
 
       def raise_lifecycle_message

--- a/spec/rspec/mocks/extensions/marshal_spec.rb
+++ b/spec/rspec/mocks/extensions/marshal_spec.rb
@@ -50,5 +50,22 @@ describe Marshal, 'extensions' do
         expect(Marshal.load(serialized)).to be_nil
       end
     end
+
+    context 'outside the per-test lifecycle' do
+      def outside_per_test_lifecycle
+        RSpec::Mocks.teardown
+        yield
+      ensure
+        RSpec::Mocks.setup
+      end
+
+      it 'does not duplicate the object before serialization' do
+        obj = UndupableObject.new
+        outside_per_test_lifecycle do
+          serialized = Marshal.dump(obj)
+          expect(Marshal.load(serialized)).to be_an(UndupableObject)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This was reported by @noelrappin:

https://twitter.com/noelrap/status/418853517323796480

/cc @samphippen 
