### PR TITLE
Better error message when calling private method on a verifying double.

### DIFF
--- a/lib/rspec/mocks/verifying_double.rb
+++ b/lib/rspec/mocks/verifying_double.rb
@@ -65,7 +65,10 @@ module RSpec
       def initialize(doubled_module, *args)
         @doubled_module = doubled_module
 
-        __initialize_as_test_double(doubled_module, *args)
+        __initialize_as_test_double(
+          "#{doubled_module.description} (instance)",
+          *args
+        )
       end
 
       def __build_mock_proxy(order_group)
@@ -86,7 +89,7 @@ module RSpec
       def initialize(doubled_module, *args)
         @doubled_module = doubled_module
 
-        __initialize_as_test_double(doubled_module, *args)
+        __initialize_as_test_double(doubled_module.description, *args)
       end
 
       def __build_mock_proxy(order_group)

--- a/spec/rspec/mocks/verifying_double_spec.rb
+++ b/spec/rspec/mocks/verifying_double_spec.rb
@@ -131,6 +131,14 @@ module RSpec
             expect(o.send(:msg)).to eq("received")
           end
 
+          it 'gives a descriptive error message for NoMethodError' do
+            o = instance_double("LoadedClass")
+            expect {
+              o.defined_private_method
+            }.to raise_error(NoMethodError,
+                               /Double "LoadedClass \(instance\)"/)
+          end
+
           describe "method visibility" do
             shared_examples_for "preserves method visibility" do |visibility|
               method_name = :"defined_#{visibility}_method"
@@ -301,6 +309,13 @@ module RSpec
             prevents { expect(o).to receive(:defined_instance_method) }
             prevents { o.should_receive(:undefined_instance_method) }
             prevents { o.should_receive(:defined_instance_method) }
+          end
+
+          it 'gives a descriptive error message for NoMethodError' do
+            o = class_double("LoadedClass")
+            expect {
+              o.defined_private_class_method
+            }.to raise_error(NoMethodError, /Double "LoadedClass"/)
           end
 
           describe "method visibility" do


### PR DESCRIPTION
Fixes #531.

I didn't include a test for object doubles, since it doesn't cover any extra code paths and the behaviour isn't that important. That isn't a strongly held opinion though.

R @myronmarston 
