### PR TITLE
Correct stub undefined parent modules all the way down when stubbing a nested constant.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,6 +43,8 @@ Bug Fixes:
 * Fix regression in `stub_chain`/`receive_message_chain` that caused
   it to raise an `ArgumentError` when passing args to the stubbed
   methods. (Sam Phippen)
+* Correct stub of undefined parent modules all the way down when stubbing a
+  nested constant. (Xavier Shay)
 
 Enhancements:
 

--- a/spec/rspec/mocks/mutate_const_spec.rb
+++ b/spec/rspec/mocks/mutate_const_spec.rb
@@ -451,6 +451,18 @@ module RSpec
           it("returns nil for the original value")      { expect(const.original_value).to be_nil }
         end
 
+        context 'for a previously undefined parent of a stubbed constant' do
+          before { stub_const("TestClass::UndefinedModule::Undefined", :other) }
+          let(:const) { Constant.original("TestClass::UndefinedModule") }
+
+          it("exposes its name")                        { expect(const.name).to eq("TestClass::UndefinedModule") }
+          it("indicates it was not previously defined") { expect(const).not_to be_previously_defined }
+          it("indicates it has been mutated")           { expect(const).to be_mutated }
+          it("indicates it has been stubbed")           { expect(const).to be_stubbed }
+          it("indicates it has not been hidden")        { expect(const).not_to be_hidden }
+          it("returns nil for the original value")      { expect(const.original_value).to be_nil }
+        end
+
         context 'for a previously undefined unstubbed constant' do
           let(:const) { Constant.original("TestClass::Undefined") }
 

--- a/spec/rspec/mocks/verifying_double_spec.rb
+++ b/spec/rspec/mocks/verifying_double_spec.rb
@@ -84,6 +84,13 @@ module RSpec
             expect(o.undefined_instance_method(:arg)).to eq(true)
           end
 
+          it 'handles classes that are materialized after mocking' do
+            stub_const "A::B", Object.new
+            o = instance_double "A", :undefined_instance_method => true
+
+            expect(o.undefined_instance_method).to eq(true)
+          end
+
           context 'for null objects' do
             let(:o) { instance_double('NonLoadedClass').as_null_object }
 


### PR DESCRIPTION
This is necessary for verifying doubles to work correctly, since they
need to distinguish between real and stubbed constants.

This fell out quite nicely. I'm not confident I've either named the `Constant` spec correctly nor covered the correct cases (though it certainly fails before this change), so please review that in particular.

Fixes #529.

R @myronmarston @JonRowe 
