### PR TITLE
Wrap pending blocks in a temporary scope.

### DIFF
--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -86,3 +86,8 @@ module RSpec
   end
 end
 
+# This is required so that pending code blocks can be run to see if they pass
+# yet.
+RSpec.configuration.pending_executors << lambda {|block|
+  RSpec::Mocks.with_temporary_scope(&block)
+}


### PR DESCRIPTION
This causes mock expectations to be verified at the end of the pending
block. Most often this is the expected behaviour, since the pending
scope is expected to be failing for whatever is inside of it.

Is this the right place to put this configuration? It feels kind of dirty.

Trigger for this was https://github.com/rspec/rspec-core/pull/1267

Alternatively, we could just switch the two pending specs in here to use `:skip` instead. Unclear how many other people would be affected by this issue though.
