### PR TITLE
RSpec::Mocks::NamedObjectReference doesn't have a name method, creating specific spec for this case so there are no false positives

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -18,6 +18,8 @@ module RSpec
     # @private
     NegationUnsupportedError = Class.new(StandardError)
 
+    VerifyingDoubleNotDefinedError = Class.new(StandardError)
+
     # @private
     class ErrorGenerator
       attr_writer :opts

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -178,8 +178,8 @@ module RSpec
         if RSpec::Mocks.configuration.verify_doubled_constant_names? &&
           !ref.defined?
 
-          raise NameError,
-            "#{ref.name} is not a defined constant. " +
+          raise VerifyingDoubleNotDefinedError,
+            "#{ref.description} is not a defined constant. " +
             "Perhaps you misspelt it? " +
             "Disable check with verify_doubled_constant_names configuration option."
         end

--- a/spec/rspec/mocks/verifying_double_spec.rb
+++ b/spec/rspec/mocks/verifying_double_spec.rb
@@ -535,13 +535,13 @@ module RSpec
         it 'prevents creation of instance doubles for unloaded constants' do
           expect {
             instance_double('LoadedClas')
-          }.to raise_error(NameError)
+          }.to raise_error(VerifyingDoubleNotDefinedError)
         end
 
         it 'prevents creation of class doubles for unloaded constants' do
           expect {
             class_double('LoadedClas')
-          }.to raise_error(NameError)
+          }.to raise_error(VerifyingDoubleNotDefinedError)
         end
       end
 


### PR DESCRIPTION
So, was hacking some specs and started to see the following error:

```
 Failure/Error: expect {
   expected RSpec::Mocks::VerifyingDoubleNotDefinedError, got #<NoMethodError: undefined method `name' for #<RSpec::Mocks::NamedObjectReference:0x000001026308a0>> with backtrace:
     # ./lib/rspec/mocks/example_methods.rb:182:in `declare_verifying_double'
     # ./lib/rspec/mocks/example_methods.rb:46:in `instance_double'
```

Digging a bit into the source, the issue is that if the constant name given isn't loaded yet, it would try to raise an exception but would fail to do so because the double given does not have a `name` method, but it does have a `description` one.

The issue was not found on `rspec-mocks` specs because the match was for `NameError` and `NoMethodError` inherits from it, making that specific match a not very useful one.

So, I created a new exception for this specific case, changed the call from `name` to `description` and updated the matches for both cases.
