### PR TITLE
Fix regression in 2.14.

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -607,10 +607,27 @@ MSG
         end.last
       end
 
-      def arg_slice_for(args, arity)
-        if arity >= 0
-          args.slice(0, arity)
-        else
+      if RUBY_VERSION.to_f > 1.8
+        def arg_slice_for(args, arity)
+          if arity >= 0
+            args.slice(0, arity)
+          else
+            args
+          end
+        end
+      else
+        # 1.8.7's `arity` lies somtimes:
+        # Given:
+        #   def print_arity(&b) puts b.arity; end
+        #
+        # This prints 1:
+        #   print_arity { |a, b, c, &bl| }
+        #
+        # But this prints 3:
+        #   print_arity { |a, b, c| }
+        #
+        # Given that it lies, we can't trust it and we don't slice the args.
+        def arg_slice_for(args, arity)
           args
         end
       end

--- a/spec/rspec/mocks/block_return_value_spec.rb
+++ b/spec/rspec/mocks/block_return_value_spec.rb
@@ -1,6 +1,17 @@
 require "spec_helper"
 
 describe "a double declaration with a block handed to:" do
+  # The "receives a block" part is important: 1.8.7 has a bug that reports the
+  # wrong arity when a block receives a block.
+  it 'forwards all given args to the block, even when it receives a block', :unless => RUBY_VERSION.to_s == '1.8.6' do
+    obj = Object.new
+    yielded_args = []
+    eval("obj.stub(:foo) { |*args, &bl| yielded_args << args }")
+    obj.foo(1, 2, 3)
+
+    expect(yielded_args).to eq([[1, 2, 3]])
+  end
+
   describe "should_receive" do
     it "returns the value of executing the block" do
       obj = Object.new


### PR DESCRIPTION
`block.arity` on 1.8.7 can be a lie, apparently :(.

This fixes #549 for 2.99.
