### PR TITLE
Add regression spec for #549.

### DIFF
--- a/spec/rspec/mocks/block_return_value_spec.rb
+++ b/spec/rspec/mocks/block_return_value_spec.rb
@@ -23,6 +23,17 @@ describe "a double declaration with a block handed to:" do
       obj.stub(:foo) { 'bar' }
       expect(obj.foo).to eq('bar')
     end
+
+    # The "receives a block" part is important: 1.8.7 has a bug that reports the
+    # wrong arity when a block receives a block.
+    it 'forwards all given args to the block, even when it receives a block' do
+      obj = Object.new
+      yielded_args = []
+      eval("obj.stub(:foo) { |*args, &bl| yielded_args << args }")
+      obj.foo(1, 2, 3)
+
+      expect(yielded_args).to eq([[1, 2, 3]])
+    end
   end
 
   describe "with" do


### PR DESCRIPTION
This is already fixed in 3.0 but it's good to add
a spec to prevent future regressions.
