### PR TITLE
Deal with 1.8.7 any_instance block deprecation warnings.

### DIFF
--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -214,6 +214,8 @@ module RSpec
         end
 
         context "with a block" do
+          before { allow_unavoidable_1_8_deprecation }
+
           it "stubs a method" do
             klass.any_instance.stub(:foo) { 1 }
             expect(klass.new.foo).to eq(1)

--- a/spec/rspec/mocks/before_all_spec.rb
+++ b/spec/rspec/mocks/before_all_spec.rb
@@ -39,7 +39,7 @@ describe "using rspec-mocks constructs in before(:all)" do
   describe "an any_instance stub" do
     before(:all) do
       deprecations.clear
-      Object.any_instance.stub(:foo) { 13 }
+      Object.any_instance.stub(:foo => 13)
     end
 
     it 'works in examples and prints a deprecation' do

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -178,6 +178,8 @@ module RSpec
       end
 
       describe "allow_any_instance_of(...).to receive" do
+        before { allow_unavoidable_1_8_deprecation }
+
         include_examples "an expect syntax allowance" do
           let(:klass)    { Class.new }
           let(:wrapped)  { allow_any_instance_of(klass) }
@@ -199,6 +201,8 @@ module RSpec
       end
 
       describe "expect_any_instance_of(...).to receive" do
+        before { allow_unavoidable_1_8_deprecation }
+
         include_examples "an expect syntax expectation", :does_not_report_line_num do
           let(:klass)    { Class.new }
           let(:wrapped)  { expect_any_instance_of(klass) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,8 +20,6 @@ module VerifyAndResetHelpers
   end
 end
 
-# TODO: This is duplicated in rspec-core, should be extracted into
-# rspec-support when that project gets started.
 module HelperMethods
   def expect_deprecation_with_call_site(file, line)
     expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
@@ -31,6 +29,10 @@ module HelperMethods
 
   def allow_deprecation
     allow(RSpec.configuration.reporter).to receive(:deprecation)
+  end
+
+  def allow_unavoidable_1_8_deprecation
+    allow_deprecation if RUBY_VERSION.to_f < 1.9
   end
 end
 


### PR DESCRIPTION
The metadata provided by 1.8's `Proc` objects do not
provide sufficient information to only issue this
deprecation warning when it's truly necessary.
See cd3208a79fed0f0ea9bf22f34ef8b6ebd04fec2b for
the background about why.

The best we can do is work around these warnings.
