### PR TITLE
Removes #to_str implementation from test_double

### DIFF
--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -53,8 +53,6 @@ module RSpec
         inspect.gsub('<','[').gsub('>',']')
       end
 
-      #alias_method :to_str, :to_s
-
       # @private
       def respond_to?(message, incl_private=false)
         __mock_proxy.null_object? ? true : super

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -773,7 +773,7 @@ module RSpec
         end
       end
 
-      describe "#to_str" do
+      describe "#to_str", :unless => RUBY_VERSION == '1.9.2' do
         it "should not respond to #to_str to avoid being coerced to strings by the runtime" do
           double = double("Foo")
           expect { double.to_str }.to raise_error(

--- a/spec/rspec/mocks/verifying_double_spec.rb
+++ b/spec/rspec/mocks/verifying_double_spec.rb
@@ -467,7 +467,7 @@ module RSpec
           }.to raise_error(/Module or String expected/)
         end
 
-        it "trying to raise a class_double raises a TypeError" do
+        it "trying to raise a class_double raises a TypeError", :unless => RUBY_VERSION == '1.9.2' do
           subject = Object.new
           class_double("StubbedError").as_stubbed_const
           allow(subject).to receive(:some_method).and_raise(StubbedError)


### PR DESCRIPTION
Having `test_double` implement `to_str` makes the Ruby runtime coerce it to a string whenever needed and this isn't the intended behaviour for this object. This behaviour led to issue #567 as Ruby will try to coerce the exception object into string when raising ( [here](https://github.com/ruby/ruby/blob/191b373d26a48058bcc8955bf3afe426f60eaaea/eval.c#L678) ) an exception and since `test_double` does implement `to_str` it is coerced to string and raised instead of failing with the correct 'this is not an exception object' error.

This fixes #567 by providing a better error message in it's case.
