### PR TITLE
Remove `TestDouble.extend_onto`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 ### 3.0.0.rc1 Development
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.0.0.beta2...master)
 
+Breaking Changes for 3.0.0:
+
+* Remove `RSpec::Mocks::TestDouble.extend_onto`. (Myron Marston)
+
 Enhancements:
 
 * Instead of crashing when cleaning up stub methods on a frozen object, it now

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -4,23 +4,17 @@ module RSpec
     # includes this module, and it is provided for cases where you want a
     # pure test double without subclassing RSpec::Mocks::Double.
     module TestDouble
-      # Extends the TestDouble module onto the given object and
-      # initializes it as a test double.
-      #
-      # @example
-      #
-      #   module = Module.new
-      #   RSpec::Mocks::TestDouble.extend_onto(module, "MyMixin", :foo => "bar")
-      #   module.foo  #=> "bar"
-      def self.extend_onto(object, name=nil, stubs={})
-        object.extend self
-        object.send(:__initialize_as_test_double, name, stubs)
-      end
-
       # Creates a new test double with a `name` (that will be used in error
       # messages only)
       def initialize(name=nil, stubs={})
-        __initialize_as_test_double(name, stubs)
+        @__expired = false
+        if Hash === name && stubs.empty?
+          stubs = name
+          @name = nil
+        else
+          @name = name
+        end
+        assign_stubs(stubs)
       end
 
       # Tells the object to respond to all messages. If specific stub values
@@ -72,17 +66,6 @@ module RSpec
       end
 
     private
-
-      def __initialize_as_test_double(name=nil, stubs={})
-        @__expired = false
-        if Hash === name && stubs.empty?
-          stubs = name
-          @name = nil
-        else
-          @name = name
-        end
-        assign_stubs(stubs)
-      end
 
       def method_missing(message, *args, &block)
         proxy = __mock_proxy

--- a/lib/rspec/mocks/verifying_double.rb
+++ b/lib/rspec/mocks/verifying_double.rb
@@ -48,7 +48,7 @@ module RSpec
         __send__(name, *args, &block)
       end
 
-      def __initialize_as_test_double(*args)
+      def initialize(*args)
         super
         @__sending_message = nil
       end
@@ -65,7 +65,7 @@ module RSpec
       def initialize(doubled_module, *args)
         @doubled_module = doubled_module
 
-        __initialize_as_test_double(
+        super(
           "#{doubled_module.description} (instance)",
           *args
         )
@@ -88,8 +88,7 @@ module RSpec
 
       def initialize(doubled_module, *args)
         @doubled_module = doubled_module
-
-        __initialize_as_test_double(doubled_module.description, *args)
+        super(doubled_module.description, *args)
       end
 
       def __build_mock_proxy(order_group)

--- a/spec/rspec/mocks/test_double_spec.rb
+++ b/spec/rspec/mocks/test_double_spec.rb
@@ -3,34 +3,6 @@ require 'spec_helper'
 module RSpec
   module Mocks
     describe TestDouble do
-      before(:all) do
-        Module.class_exec do
-          private
-          def use; end
-        end
-      end
-
-      after(:all) do
-        Module.class_exec do
-          undef use
-        end
-      end
-
-      it 'can be extended onto a module to make it a pure test double that can mock private methods' do
-        double = Module.new
-        double.stub(:use)
-        expect { double.use }.to raise_error(/private method `use' called/)
-
-        double = Module.new { TestDouble.extend_onto(self) }
-        double.should_receive(:use).and_return(:ok)
-        expect(double.use).to be(:ok)
-      end
-
-      it 'sets the test double name when a name is passed' do
-        double = Module.new { TestDouble.extend_onto(self, "MyDouble") }
-        expect { double.foo }.to raise_error(/Double "MyDouble" received/)
-      end
-
       describe "#freeze" do
         subject { double }
 
@@ -58,13 +30,12 @@ module RSpec
       [[:should, :expect], [:expect], [:should]].each do |syntax|
         context "with syntax #{syntax.inspect}" do
           include_context "with syntax", syntax
-          it 'stubs the methods passed in the stubs hash' do
-            double = Module.new do
-              TestDouble.extend_onto(self, "MyDouble", :a => 5, :b => 10)
-            end
 
-            expect(double.a).to eq(5)
-            expect(double.b).to eq(10)
+          it 'stubs the methods passed in the stubs hash' do
+            dbl = double("MyDouble", :a => 5, :b => 10)
+
+            expect(dbl.a).to eq(5)
+            expect(dbl.b).to eq(10)
           end
         end
       end

--- a/spec/rspec/mocks/verifying_double_spec.rb
+++ b/spec/rspec/mocks/verifying_double_spec.rb
@@ -316,6 +316,31 @@ module RSpec
             allow(o).to receive(:undefined_instance_method).with(:arg).and_return(1)
             expect(o.undefined_instance_method(:arg)).to eq(1)
           end
+
+          context "when stubbing a private module method" do
+            before(:all) do
+              Module.class_exec do
+                private
+                def use; end
+              end
+            end
+
+            after(:all) do
+              Module.class_exec do
+                undef use
+              end
+            end
+
+            it 'can mock private module methods' do
+              double = Module.new
+              allow(double).to receive(:use)
+              expect { double.use }.to raise_error(/private method `use' called/)
+
+              double = class_double("NonloadedClass")
+              expect(double).to receive(:use).and_return(:ok)
+              expect(double.use).to be(:ok)
+            end
+          end
         end
 
         describe 'when doubled class is loaded' do


### PR DESCRIPTION
This was added in #117 to support using a module
as a pure test double by extending `TestDouble`
onto the module. Since then, I've realized we can
get the same behavior by subclassing module:

``` Ruby
class MyModuleTestDouble < Module
  include TestDouble
end
```

...and that's what we do for class verifying doubles now.

Given that, there's no need to keep this API around anymore.
