### PR TITLE
Fixing issue with Ruby 1.8.7 not setting the &block parameter when calling super

### DIFF
--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -113,8 +113,8 @@ module RSpec
         VerifyingMessageExpectation
       end
 
-      def add_expectation(*arg)
-        super.tap { |x| x.method_reference = @method_reference }
+      def add_expectation(*args, &block)
+        super(*args, &block).tap { |x| x.method_reference = @method_reference }
       end
 
       def proxy_method_invoked(obj, *args, &block)

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -308,6 +308,13 @@ module RSpec
           a_string_including("Wrong number of arguments. Expected 0, got 1.")
         )
       end
+
+      it 'allows the mock to raise an error with yield' do
+        sample_error = Class.new(StandardError)
+        expect(object).to receive(:implemented) { raise sample_error }
+        expect { object.implemented }.to raise_error(sample_error)
+      end
+
     end
   end
 end


### PR DESCRIPTION
Sending both *args and &block directly make the code do what it was expected
to do, this fixes #623.
