### PR TITLE
Including one more spec for verifying proxy to make sure allow/receive expectations work

### DIFF
--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -315,6 +315,11 @@ module RSpec
         expect { object.implemented }.to raise_error(sample_error)
       end
 
+      it 'allows stubbing and calls the stubbed implementation' do
+        allow(object).to receive(:implemented) { :value }
+        expect(object.implemented).to eq(:value)
+      end
+
     end
   end
 end


### PR DESCRIPTION
This is a complement to #623, this validates that:

``` ruby
allow(object).to receive(:implemented) { :value }
```

Correctly evaluates the block given as the implementation.

As for the other two methods, `add_simple_stub` doesn't take a block (it prints a warning if you give it a block as it is used only at the `receive_messages` call) and `add_message_expectation` is exercised by the original fix for #623.

@myronmarston @JonRowe 
