### PR TITLE
Document stub behavior on `clone` and `dup`.

### DIFF
--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -100,6 +100,21 @@ module RSpec
           klass.bar(2)
         }.to raise_error(RSpec::Mocks::MockExpectationError, /MyClass/)
       end
+
+      it "shares message expectations with clone" do
+        expect(object).to receive(:foobar)
+        twin = object.clone
+        twin.foobar
+        expect{ verify twin }.not_to raise_error
+        expect{ verify object }.not_to raise_error
+      end
+
+      it "clears message expectations when `dup`ed" do
+        expect(object).to receive(:foobar)
+        duplicate = object.dup
+        expect{ duplicate.foobar }.to raise_error(NoMethodError, /foobar/)
+        expect{ verify object }.to raise_error(RSpec::Mocks::MockExpectationError, /foobar/)
+      end
     end
 
     describe "Using a partial mock on a proxy object", :if => defined?(::BasicObject) do

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -74,6 +74,16 @@ module RSpec
         expect(@instance.msg2).to eq(2)
       end
 
+      it "is retained when stubbed object is `clone`d" do
+        allow(@stub).to receive(:foobar).and_return(1)
+        expect(@stub.clone.foobar).to eq(1)
+      end
+
+      it "is cleared when stubbed object when `dup`ed" do
+        allow(@stub).to receive(:foobar).and_return(1)
+        expect{ @stub.dup.foobar }.to raise_error NoMethodError, /foobar/
+      end
+
       context "stubbing with prepend", :if => Support::RubyFeatures.module_prepends_supported? do
         module ToBePrepended
           def value


### PR DESCRIPTION
For more details on the inner workings on `clone` vs `dup` see:

  http://stackoverflow.com/a/10183477/29262

`dup` does not copy object state. Stubs are viewed as part of object
state, so they are not transfered. However, `clone` should copy an
object's state; thus the stubs should also be copied.
