### PR TITLE
Make RSpec::Mocks::Space more thread-safe.

### DIFF
--- a/benchmarks/thread_safety.rb
+++ b/benchmarks/thread_safety.rb
@@ -1,0 +1,24 @@
+$LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
+
+require 'benchmark'
+require 'rspec/mocks'
+
+Benchmark.bm do |bm|
+  bm.report("fetching a proxy") do
+    RSpec::Mocks.with_temporary_scope do
+      o = Object.new
+      100000.times {
+        RSpec::Mocks.space.proxy_for(o)
+      }
+    end
+  end
+end
+
+# Without synchronize (not thread-safe):
+#
+#       user     system      total        real
+# fetching a proxy  0.120000   0.000000   0.120000 (  0.141333)
+#
+# With synchronize (thread-safe):
+#       user     system      total        real
+# fetching a proxy  0.180000   0.000000   0.180000 (  0.189553)


### PR DESCRIPTION
It used to be possible for different threads to receive different proxy
objects, potentially a source of bugs such as #380.

This is non-trivial to write a spec for, but you can trivially
demonstrate the problem by adding a `sleep` into the fetch blocks, and
then running:

```
o = Object.new
t = Thread.new do
  RSpec::Mocks.space.proxy_for(o)
end
b = RSpec::Mocks.space.proxy_for(o)
a = t.value

expect(a).to eq(b)
```

@myronmarston @knewter @alindeman 
