### PR TITLE
Threadsafety followup

### DIFF
--- a/lib/rspec/mocks/space.rb
+++ b/lib/rspec/mocks/space.rb
@@ -108,11 +108,12 @@ module RSpec
       # using threads then a Mutex will be available to us. If not, we don't
       # need to synchronize anyway.
       def new_mutex
-        (defined?(::Mutex) ? ::Mutex : FakeMutex).new
+        defined?(::Mutex) ? ::Mutex.new : FakeMutex
       end
 
-      class FakeMutex
-        def synchronize
+      # @private
+      module FakeMutex
+        def self.synchronize
           yield
         end
       end


### PR DESCRIPTION
Follow up to #634.  I noticed the warnings when running rspec-core's specs.  They weren't being surfaced here because of rspec/rspec-core#1444.  The doc coverage check is apparently not running against rspec-mocks (see rspec/rspec-dev#63) so I fixed that, too.

/cc @xaviershay 
