### PR TITLE
Provide a failure message when trying to observe an unimplemented method...

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,8 @@ Bug Fixes:
   accessed in `inspect` by providing our own inspect output. (Jon Rowe)
 * Fix bug in `any_instance` logic that did not allow you to mock or stub
   private methods if `verify_partial_doubles` was configured. (Oren Dobzinski)
+* Include useful error message when trying to observe an unimplemented method
+  on an any instance. (Xavier Shay)
 
 ### 3.0.0.beta2 / 2014-02-17
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.0.0.beta1...v3.0.0.beta2)

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -209,7 +209,10 @@ module RSpec
 
         def observe!(method_name)
           if RSpec::Mocks.configuration.verify_partial_doubles?
-            raise MockExpectationError unless public_protected_or_private_method_defined?(method_name)
+            unless public_protected_or_private_method_defined?(method_name)
+              raise MockExpectationError,
+                "#{@klass} does not implement ##{method_name}"
+            end
           end
 
           stop_observing!(method_name) if already_observing?(method_name)

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -309,14 +309,18 @@ module RSpec
       end
 
       it 'does not allow a non-existing method to be called on any_instance' do
-        prevents { expect_any_instance_of(klass).to receive(:unimplemented) }
+        prevents(/does not implement/) {
+          expect_any_instance_of(klass).to receive(:unimplemented)
+        }
       end
 
       it 'does not allow missing methods to be called on any_instance' do
         # This is potentially surprising behaviour, but there is no way for us
         # to know that this method is valid since we only have class and not an
         # instance.
-        prevents { expect_any_instance_of(klass).to receive(:dynamic_method) }
+        prevents(/does not implement/) {
+          expect_any_instance_of(klass).to receive(:dynamic_method)
+        }
       end
 
       it 'verifies arity range when receiving a message' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,9 +42,9 @@ module VerifyAndResetHelpers
 end
 
 module VerificationHelpers
-  def prevents(&block)
+  def prevents(msg = //, &block)
     expect(&block).to \
-      raise_error(RSpec::Mocks::MockExpectationError)
+      raise_error(RSpec::Mocks::MockExpectationError, msg)
   end
 end
 


### PR DESCRIPTION
... on any instance.

Fixes #639 

I opted for consistency with the rest of the class, rather than your suggestion of using the error generator. I don't believe we have access to the latter here at the moment.

@myronmarston 
