### PR TITLE
Get `and_call_original` to work properly on class hierarchies.

### DIFF
--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -25,7 +25,7 @@ module RSpec
         # method handles for missing methods even if `respond_to?` is correct.
         @original_method ||=
           @method_stasher.original_method ||
-          @proxy.method_handle_for(method_name) ||
+          @proxy.original_method_handle_for(method_name) ||
           Proc.new do |*args, &block|
             @object.__send__(:method_missing, @method_name, *args, &block)
           end

--- a/lib/rspec/mocks/space.rb
+++ b/lib/rspec/mocks/space.rb
@@ -122,6 +122,12 @@ module RSpec
         proxies[id] = case object
           when NilClass   then ProxyForNil.new(@expectation_ordering)
           when TestDouble then object.__build_mock_proxy(@expectation_ordering)
+          when Class
+            if RSpec::Mocks.configuration.verify_partial_doubles?
+              VerifyingPartialClassDoubleProxy.new(self, object, @expectation_ordering)
+            else
+              PartialClassDoubleProxy.new(self, object, @expectation_ordering)
+            end
           else
             if RSpec::Mocks.configuration.verify_partial_doubles?
               VerifyingPartialDoubleProxy.new(object, @expectation_ordering)

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -103,6 +103,11 @@ module RSpec
     end
 
     # @private
+    class VerifyingPartialClassDoubleProxy < VerifyingPartialDoubleProxy
+      include PartialClassDoubleProxyMethods
+    end
+
+    # @private
     class VerifyingMethodDouble < MethodDouble
       def initialize(object, method_name, proxy, method_reference)
         super(object, method_name, proxy)


### PR DESCRIPTION
For #613.

/cc @xaviershay @samphippen @JonRowe @cupakromer 
