### PR TITLE
Fix have_received behavior for argument matching

### DIFF
--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -145,7 +145,7 @@ module RSpec
       # @private
       def record_message_received(message, *args, &block)
         @order_group.invoked SpecificMessage.new(object, message)
-        @messages_received << [message, args, block]
+        @messages_received << [message, cloned_args(args), block]
       end
 
       # @private
@@ -243,6 +243,19 @@ module RSpec
 
       def find_almost_matching_stub(method_name, *args)
         method_double_for(method_name).stubs.find {|stub| stub.matches_name_but_not_args(method_name, *args)}
+      end
+
+      def cloned_args(args)
+        args.map do |arg|
+          # Many instances respond_to?(:clone) even when that method raises an error
+          # Fixnum raises "TypeError: can't clone Fixnum"
+          # Regexp raises "SecurityError: can't modify literal regexp"
+          begin
+            arg.clone
+          rescue Exception
+            arg
+          end
+        end
       end
     end
 

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -123,6 +123,26 @@ module RSpec
               expect(dbl).to have_received(:expected_method).with(:unexpected, :args)
             }.to raise_error(/with unexpected arguments/)
           end
+
+          context 'method called multipled times' do
+            it 'passes when arguments are different objects' do
+              dbl = double_with_unmet_expectation(:expected_method)
+              dbl.expected_method({ :a => 1 })
+              dbl.expected_method({ :a => 2 })
+              expect(dbl).to have_received(:expected_method).with({ :a => 1 })
+              expect(dbl).to have_received(:expected_method).with({ :a => 2 })
+            end
+
+            it 'passes when arguments are the same object that changed between calls' do
+              dbl = double_with_unmet_expectation(:expected_method)
+              arg = { :a => 1 }
+              dbl.expected_method(arg)
+              arg[:a] = 2
+              dbl.expected_method(arg)
+              expect(dbl).to have_received(:expected_method).with({ :a => 1 })
+              expect(dbl).to have_received(:expected_method).with({ :a => 2 })
+            end
+          end
         end
 
         it 'generates a useful description' do


### PR DESCRIPTION
Ran into this and couldn't figure out why the test was failing. 
Not too proud of the solution so open to other possibilities. 
Also open to debate the merit of this as it is may be more of a corner case.
