### PR TITLE
Any instance prepend spike

### DIFF
--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -163,7 +163,7 @@ module RSpec
         end
 
         def restore_method!(method_name)
-          if public_protected_or_private_method_defined?(build_alias_method_name(method_name))
+          if method_defined_on_klass?(build_alias_method_name(method_name))
             restore_original_method!(method_name)
           else
             remove_dummy_method!(method_name)
@@ -173,7 +173,7 @@ module RSpec
         def restore_original_method!(method_name)
           if @klass.instance_method(method_name).owner == @klass
             alias_method_name = build_alias_method_name(method_name)
-            @klass.class_exec do
+            definition_target.class_exec do
               remove_method method_name
               alias_method  method_name, alias_method_name
               remove_method alias_method_name
@@ -182,24 +182,29 @@ module RSpec
         end
 
         def remove_dummy_method!(method_name)
-          @klass.class_exec do
-            remove_method method_name
+          definition_target.class_exec do
+            remove_method method_name if method_defined?(method_name)
           end
         end
 
         def backup_method!(method_name)
           alias_method_name = build_alias_method_name(method_name)
-          @klass.class_exec do
+          definition_target.class_exec do
             alias_method alias_method_name, method_name
           end if public_protected_or_private_method_defined?(method_name)
         end
 
         def public_protected_or_private_method_defined?(method_name)
+          MethodReference.method_defined_at_any_visibility?(definition_target, method_name)
+        end
+
+        def method_defined_on_klass?(method_name)
           MethodReference.method_defined_at_any_visibility?(@klass, method_name)
         end
 
         def observe!(method_name)
           if RSpec::Mocks.configuration.verify_partial_doubles?
+            # TODO: test/fix this with prepended module.
             unless public_protected_or_private_method_defined?(method_name)
               raise MockExpectationError,
                 "#{@klass} does not implement ##{method_name}"
@@ -210,7 +215,7 @@ module RSpec
           @observed_methods << method_name
           backup_method!(method_name)
           recorder = self
-          @klass.__send__(:define_method, method_name) do |*args, &blk|
+          definition_target.__send__(:define_method, method_name) do |*args, &blk|
             recorder.playback!(self, method_name)
             self.__send__(method_name, *args, &blk)
           end
@@ -219,13 +224,35 @@ module RSpec
         def mark_invoked!(method_name)
           backup_method!(method_name)
           recorder = self
-          @klass.__send__(:define_method, method_name) do |*args, &blk|
+          definition_target.__send__(:define_method, method_name) do |*args, &blk|
             invoked_instance = recorder.instance_that_received(method_name)
             inspect = "#<#{self.class}:#{object_id} #{instance_variables.map { |name| "#{name}=#{instance_variable_get name}" }.join(', ')}>"
             raise RSpec::Mocks::MockExpectationError, "The message '#{method_name}' was received by #{inspect} but has already been received by #{invoked_instance}"
           end
         end
 
+        if Support::RubyFeatures.module_prepends_supported?
+          RSpecPrependedModule = Class.new(Module)
+
+          def definition_target
+            @definition_target ||= if klass_has_prepended_module?
+              RSpecPrependedModule.new.tap do |mod|
+                @klass.prepend mod
+              end
+            else
+              @klass
+            end
+          end
+
+          def klass_has_prepended_module?
+            true # hardcoded for now to force all `any_instance` uses to run with the prepended module code path to see what breaks
+            # @klass.ancestors.take_while { |mod| !(Class === mod) }.any?
+          end
+        else
+          def definition_target
+            @klass
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This is the start of my attempt at a fix for #661 and #582.

I've worked on this for a few days....and getting this to work is _very_ complicated.  I got the initial spec to pass but then I wanted to confirm that the use of a prepended module works for all the other `any_instance` behaviors and so I temporarily hardcoded `klass_has_prepended_module?` to return true...and lots of stuff failed.  Getting this to work is not going to be easy.

So, I'm thinking that for now maybe we provide an explicit "stubbing any instance when the class has a prepended module that defines the same method is not supported" error message.  While that wouldn't solve @pex's failure as reported in #661, it would provide an explicit error rather than a confusing `SystemStackError`, and given that `any_instance` is a feature we recommend not using, I don't want to spend tons of effort complicating it to make it support module prepends.

Thoughts?

/cc @xaviershay @JonRowe @samphippen @cupakromer @soulcutter 
