### PR TITLE
Fix prepended module detection.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### 3.0.0 Development
+[Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.0.0.rc1...master)
+
+Bug Fixes:
+
+* Fix module prepend detection to work properly on ruby 2.0 for a case
+  where a module is extended onto itself. (Myron Marston)
+
 ### 3.0.0.rc1 / 2014-05-18
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.0.0.beta2...v3.0.0.rc1)
 

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -206,7 +206,7 @@ module RSpec
           @prepended_modules_of_singleton_class ||= begin
             singleton_class = @object.singleton_class
             singleton_class.ancestors.take_while do |mod|
-              !(Class === mod)
+              !(Class === mod || @object.equal?(mod))
             end
           end
         end

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -126,6 +126,17 @@ module RSpec
           }.not_to change { object.singleton_class.ancestors }
         end
 
+        it 'does not unnecessarily prepend a module when stubbing a method on a module extended onto itself' do
+          mod = Module.new do
+            extend self
+            def foo; :bar; end
+          end
+
+          expect {
+            allow(mod).to receive(:foo)
+          }.not_to change { mod.singleton_class.ancestors }
+        end
+
         it 'reuses our prepend module so as not to keep mutating the ancestors' do
           object = Object.new
           def object.value; :original; end


### PR DESCRIPTION
On ruby 2.0, when a module was extended onto itself,
we wrongly considered it to be a prepended module.

Fixes #672.
