### PR TITLE
Fix link to dynamic-classes feature

### DIFF
--- a/features/verifying_doubles/instance_doubles.feature
+++ b/features/verifying_doubles/instance_doubles.feature
@@ -7,7 +7,7 @@ Feature: Using an instance double
   arguments is correct.
 
   For methods handled by `method_missing`, see [dynamic
-  objects](./dynamic-objects).
+  classes](./dynamic-classes).
 
   Background:
     Given a file named "app/models/user.rb" with:


### PR DESCRIPTION
Currently the link on https://relishapp.com/rspec/rspec-mocks/v/3-0/docs/verifying-doubles/using-an-instance-double to dynamic objects 404s
