### PR TITLE
Fix `config.transfer_nested_constants = true`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Bug Fixes:
 
 * Fix module prepend detection to work properly on ruby 2.0 for a case
   where a module is extended onto itself. (Myron Marston)
+* Fix `transfer_nested_constants` option so that transferred constants
+  get properly reset at the end of the example. (Myron Marston)
 * Fix `config.transfer_nested_constants = true` so that you don't
   erroneously get errors when stubbing a constant that is not a module
   or a class. (Myron Marston)

--- a/lib/rspec/mocks/mutate_const.rb
+++ b/lib/rspec/mocks/mutate_const.rb
@@ -258,12 +258,12 @@ module RSpec
           @context = recursive_const_get(@context_parts.join('::'))
           @original_value = get_const_defined_on(@context, @const_name)
 
-          constants_to_transfer = verify_constants_to_transfer!
+          @constants_to_transfer = verify_constants_to_transfer!
 
           @context.__send__(:remove_const, @const_name)
           @context.const_set(@const_name, @mutated_value)
 
-          transfer_nested_constants(constants_to_transfer)
+          transfer_nested_constants
         end
 
         def to_constant
@@ -275,12 +275,16 @@ module RSpec
         end
 
         def reset
+          Array(@constants_to_transfer).each do |const|
+            @mutated_value.__send__(:remove_const, const)
+          end
+
           @context.__send__(:remove_const, @const_name)
           @context.const_set(@const_name, @original_value)
         end
 
-        def transfer_nested_constants(constants)
-          constants.each do |const|
+        def transfer_nested_constants
+          @constants_to_transfer.each do |const|
             @mutated_value.const_set(const, get_const_defined_on(original_value, const))
           end
         end

--- a/spec/rspec/mocks/mutate_const_spec.rb
+++ b/spec/rspec/mocks/mutate_const_spec.rb
@@ -241,6 +241,15 @@ module RSpec
             expect(stub::Nested).to be(tc_nested)
           end
 
+          it 'removes the transferred constants on reset' do
+            stub = Module.new
+            stub_const("TestClass", stub, :transfer_nested_constants => true)
+
+            expect {
+              reset_all
+            }.to change { stub.constants }.to([])
+          end
+
           it 'does not transfer nested constants that are inherited from a superclass' do
             stub = Module.new
             stub_const("TestSubClass", stub, :transfer_nested_constants => true)


### PR DESCRIPTION
We shouldn’t give users an error when they stub
a constant that is not a class or module.

Fixes #677.
