### PR TITLE
Use matcher description when raising an expectation error for an unfulfilled expectation.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@ Bug Fixes:
   taking the args into account when checking the order. (Myron Marston)
 * Fix bug in `have_received(...).ordered` where it was wrongly
   considering stubs when checking the order. (Myron Marston)
+* Message expectation matchers now show descriptions from argument
+  matchers when their expectations aren't met. (Jon Rowe)
 
 Enhancements:
 

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -96,32 +96,42 @@ module RSpec
       # @private
       def received_part_of_expectation_error(actual_received_count, *args)
         "received: #{count_message(actual_received_count)}" +
-          method_call_args_description(args)
+          actual_method_call_args_description(actual_received_count, args)
       end
 
       # @private
       def expected_part_of_expectation_error(expected_received_count, expectation_count_type, argument_list_matcher)
         "expected: #{count_message(expected_received_count, expectation_count_type)}" +
-          method_call_args_description(argument_list_matcher.expected_args, true)
+          expected_method_call_args_description(argument_list_matcher.expected_args)
       end
 
       # @private
-      def method_call_args_description(args, format = false)
+      def actual_method_call_args_description(count, args)
+        method_call_args_description(args) ||
+          if count > 0 && args.length > 0
+            " with arguments: #{args.inspect.gsub(/\A\[(.+)\]\z/, '(\1)')}"
+          else
+            ""
+          end
+      end
+
+      # @private
+      def expected_method_call_args_description(args)
+        method_call_args_description(args) ||
+          if args.length > 0
+            " with arguments: #{format_args(*args)}"
+          else
+            ""
+          end
+      end
+
+      # @private
+      def method_call_args_description(args)
         case args.first
           when ArgumentMatchers::AnyArgsMatcher
             return " with any arguments"
           when ArgumentMatchers::NoArgsMatcher
             return " with no arguments"
-        end
-
-        if args.length > 0
-          if format
-            " with arguments: #{format_args *args}"
-          else
-            " with arguments: #{args.inspect.gsub(/\A\[(.+)\]\z/, '(\1)')}"
-          end
-        else
-          ""
         end
       end
 

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -51,7 +51,7 @@ module RSpec
           expect {
             receiver.foo(1.1)
           }.to raise_error(/expected.*\(an instance of Fixnum\)/)
-          reset_all
+          receiver.foo(1)
         end
 
         it 'allows a `do...end` block implementation to be provided' do
@@ -289,6 +289,13 @@ module RSpec
         it_behaves_like "an expect syntax expectation", :allow_other_matchers do
           let(:receiver) { double }
           let(:wrapped)  { expect(receiver) }
+
+          it 'sets up a message expectation that formats argument matchers correctly' do
+            wrapped.to receive(:foo).with an_instance_of Fixnum
+            expect { verify_all }.to(
+              raise_error(/expected: 1 time with arguments: \(an instance of Fixnum\)\n\s+received: 0 times$/)
+            )
+          end
         end
         it_behaves_like "resets partial mocks cleanly" do
           let(:target) { expect(object) }
@@ -300,6 +307,11 @@ module RSpec
           let(:klass)    { Class.new }
           let(:wrapped)  { expect_any_instance_of(klass) }
           let(:receiver) { klass.new }
+
+          it 'sets up a message expectation that formats argument matchers correctly' do
+            wrapped.to receive(:foo).with an_instance_of Fixnum
+            expect { verify_all }.to raise_error(/should have received the following message\(s\) but didn't/)
+          end
         end
         it_behaves_like "resets partial mocks of any instance cleanly" do
           let(:target) { expect_any_instance_of(klass) }


### PR DESCRIPTION
Use `format_args` for expected in `raise_expectation_error`, it was the one place where we weren't formatting args for expected so you didn't get nice messages. Note the spec is a bit weird because if you meet the expectation you get the correct error message without the patch (as it raises a different error).

Fixes #676
