### PR TITLE
Display warning for ruby 2.0.0p195 about the TypeError bug

### DIFF
--- a/lib/rspec/mocks/instance_method_stasher.rb
+++ b/lib/rspec/mocks/instance_method_stasher.rb
@@ -73,8 +73,8 @@ module RSpec
         end
       end
 
-      if RUBY_DESCRIPTION.include?('2.0.0p247')
-        # ruby 2.0.0-p247 has a bug that we can't work around :(.
+      if RUBY_DESCRIPTION.include?('2.0.0p247') || RUBY_DESCRIPTION.include?('2.0.0p195')
+        # ruby 2.0.0-p247 and 2.0.0-p195 both have a bug that we can't work around :(.
         # https://bugs.ruby-lang.org/issues/8686
         def handle_restoration_failures
           yield


### PR DESCRIPTION
The TypeError bug shows up in the `p195` version of ruby too making it very hard to debug cause there's no warning about it. The specs are failing randomly (depending on the randomly generated seed) with the following message:

```
TypeError: compared with non class/module
```
