### PR TITLE
Allow receive_message_chain to be constained by arguments

### DIFF
--- a/lib/rspec/mocks/matchers/receive_message_chain.rb
+++ b/lib/rspec/mocks/matchers/receive_message_chain.rb
@@ -11,7 +11,7 @@ module RSpec
           @recorded_customizations  = []
         end
 
-        [:and_return, :and_throw, :and_raise, :and_yield, :and_call_original].each do |msg|
+        [:with, :and_return, :and_throw, :and_raise, :and_yield, :and_call_original].each do |msg|
           define_method(msg) do |*args, &block|
             @recorded_customizations << ExpectationCustomization.new(msg, args, block)
             self

--- a/spec/rspec/mocks/matchers/receive_message_chain_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_message_chain_spec.rb
@@ -57,6 +57,13 @@ module RSpec::Mocks::Matchers
         expect(object.to_a.length).to eq(3)
       end
 
+      it "can constrain the return value by the argument to the last call" do
+        allow(object).to receive_message_chain(:one, :plus).with(1) { 2 }
+        allow(object).to receive_message_chain(:one, :plus).with(2) { 3 }
+        expect(object.one.plus(1)).to eq(2)
+        expect(object.one.plus(2)).to eq(3)
+      end
+
       it "works with and_call_original", :pending => "See https://github.com/rspec/rspec-mocks/pull/467#issuecomment-28631621" do
         list = [1, 2, 3]
         expect(list).to receive_message_chain(:to_a, :length).and_call_original


### PR DESCRIPTION
With the old should syntax you could constrain `stub` and `stub_chain` calls by their arguments using with, e.g.

``` Ruby
describe do
  let(:object) { double }

  specify do
    object.stub(:call).with(1) { 2 }
    object.stub(:call).with(3) { 4 }
    expect(object.call 1).to eq 2
    expect(object.call 3).to eq 4
  end

  specify do
    object.stub_chain(:call, :call).with(1) { 2 }
    object.stub_chain(:call, :call).with(3) { 4 }
    expect(object.call.call 1).to eq 2
    expect(object.call.call 3).to eq 4
  end
end
```

But the equivalent in the expect syntax:

``` Ruby
  specify do
    allow(object).to receive(:call).with(1) { 2 }
    allow(object).to receive(:call).with(3) { 4 }
    expect(object.call 1).to eq 2
    expect(object.call 3).to eq 4
  end

  specify do
    allow(object).to receive_message_chain(:call, :call).with(1) { 2 }
    allow(object).to receive_message_chain(:call, :call).with(3) { 4 }
    expect(object.call.call 1).to eq 2
    expect(object.call.call 3).to eq 4
  end
end
```

Fails on the later `receive_messaage_chain` because we don't define `with`. 

This makes that change, and supports constraining arguments on message chains. Given the simplicity of the "fix" I'm inclined to support this, WDYT @myronmarston 

Fixes #696.
