### PR TITLE
Fix regression in `expect_any_instance_of`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ Bug Fixes:
 
 * Fix `receive_message_chain(...)` so that it supports `with` just like
   `stub_chain` did. (Jon Rowe, #697)
+* Fix regression in `expect_any_instance_of` so that it expects the
+  message on _any_ instance rather than on _every_ instance.
+  (Myron Marston, #699)
 
 ### 3.0.0 / 2014-06-01
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.0.0.rc1...v3.0.0)

--- a/lib/rspec/mocks/any_instance/proxy.rb
+++ b/lib/rspec/mocks/any_instance/proxy.rb
@@ -60,7 +60,11 @@ module RSpec
 
         def should_receive(method_name, &block)
           perform_proxying(__method__, [method_name], block) do |proxy|
-            proxy.add_message_expectation(method_name, &block)
+            # Yeah, this is a bit odd...but if we used `add_message_expectation`
+            # then it would act like `expect_every_instance_of(klass).to receive`.
+            # The any_instance recorder takes care of validating that an instance
+            # received the message.
+            proxy.add_stub(method_name, &block)
           end
         end
 

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -459,6 +459,14 @@ module RSpec
           expect(instance.foo(2)).to eq(2)
         end
 
+        it "does not set the expectation on every instance" do
+          # Setup an unrelated object of the same class that won't receive the expected message.
+          allow('non-related object').to receive(:non_related_method)
+
+          expect_any_instance_of(Object).to receive(:foo)
+          'something'.foo
+        end
+
         it "does not modify the return value of stubs set on an instance" do
           expect_any_instance_of(Object).to receive(:foo).twice
           object = Object.new


### PR DESCRIPTION
As of e00d6d7cf0f044bc9bd55d1defbbb433a88d67a4 it was (wrongly) acting like `expect_every_instance_of`.

Fixes #699.
