### PR TITLE
Fix errors caused by `double.as_null_object.freeze` on 2.99

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ Bug Fixes:
 * Fix bug that caused errors at the end of each example
   when a `double.as_null_object` had been frozen. (Yuji Nakayama, #698)
 
+Deprecations
+
+* Deprecate freezing a test double. (Yuji Nakayama, #698)
+
 ### 2.99.0 / 2014-06-01
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v2.99.0.rc1...v2.99.0)
 

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -64,6 +64,11 @@ module RSpec
         __mock_proxy.null_object? ? true : super
       end
 
+      def freeze
+        RSpec.deprecate 'Freezing a test double'
+        super
+      end
+
       # @private
       def __build_mock_proxy
         proxy = TestDoubleProxy.new(self, @name, @options || {})

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -66,6 +66,17 @@ describe "double" do
     end
   end
 
+  context 'when frozen' do
+    it 'warns of deprecation' do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
+      double.freeze
+    end
+
+    it 'is really frozen' do
+      expect(double.freeze).to be_frozen
+    end
+  end
+
   context 'when it has turned into a null object and been frozen' do
     before do
       double.as_null_object.freeze


### PR DESCRIPTION
This fixes #698.
