### PR TITLE
Fix edge case that triggered “can't add a new key into hash during iteration"

### DIFF
--- a/lib/rspec/mocks/space.rb
+++ b/lib/rspec/mocks/space.rb
@@ -65,7 +65,7 @@ module RSpec
       end
 
       def verify_all
-        proxies.each_value { |proxy| proxy.verify }
+        proxies.values.each { |proxy| proxy.verify }
         any_instance_recorders.each_value { |recorder| recorder.verify }
       end
 

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -35,6 +35,15 @@ module RSpec
         expect { reset dbl }.not_to raise_error
       end
 
+      it "generates the correct error when an unfulfilled expectation uses an unused double as a `with` argument" do
+        expect {
+          a = double('a')
+          b = double('b')
+          expect(a).to receive(:append).with(b)
+          verify_all
+        }.to raise_error(RSpec::Mocks::MockExpectationError)
+      end
+
       it 'allows string representation of methods in constructor' do
         dbl = double('foo' => 1)
         expect(dbl.foo).to eq(1)


### PR DESCRIPTION
This was triggered when a double was used as a `with` arg
but was otherwise unused — in this case, there was no mock
proxy for it, but while verifying one would get created
(due to internal implementation details). Doing so in a
`each_value` loop caused the error.

Fixes #710.

/cc @samphippen 
