### PR TITLE
`and_yield` not using default block argument when no argument given.

### DIFF
--- a/spec/rspec/mocks/and_yield_spec.rb
+++ b/spec/rspec/mocks/and_yield_spec.rb
@@ -99,6 +99,33 @@ describe RSpec::Mocks::Double do
           verify yielded_arg
         end
 
+        context "that are optional" do
+          it "yields the default argument when the argument is not given" do
+            default_arg = Object.new
+            obj = Object.new
+
+            allow(obj).to receive(:a_message).and_yield
+            expect(default_arg).to receive(:bar)
+
+            obj.a_message do |receiver=default_arg|
+              receiver.bar
+            end
+          end
+
+          it "yields given argument when the argument is given" do
+            default_arg = Object.new
+            given_arg = Object.new
+            obj = Object.new
+
+            allow(obj).to receive(:a_message).and_yield(given_arg)
+            expect(given_arg).to receive(:bar)
+
+            obj.a_message do |receiver=default_arg|
+              receiver.bar
+            end
+          end
+        end
+
         it "fails when expectations set on the eval context and yielded arguments are not met" do
           configured_eval_context = nil
           yielded_arg = Object.new


### PR DESCRIPTION
Using ruby 2.1.2

``` ruby
default_arg = Object.new
obj = Object.new

allow(obj).to receive(:a_message).and_yield
expect(default_arg).to receive(:bar)

obj.a_message do |receiver=default_arg|
  receiver.bar
end
```

The above code fails with:

```
 Failure/Error: obj.a_message do |receiver=default_arg|
        #<Object:0x007fe3ac1ce408> yielded || to block with arity of 1
```

The block has a arity of 0 or 1 not 1. So I would expect that when no argument
is given to `and_yield` it would use the default block argument.

I have a supplied a test that exposes this but I'm not sure how to fix this.
