### PR TITLE
Address ruby warning.

### DIFF
--- a/spec/rspec/mocks/and_yield_spec.rb
+++ b/spec/rspec/mocks/and_yield_spec.rb
@@ -112,6 +112,8 @@ describe RSpec::Mocks::Double do
 
           it "yields given argument when the argument is given" do
             default_arg = Object.new
+            allow(default_arg).to receive(:bar)
+
             given_arg = Object.new
             obj = Object.new
 


### PR DESCRIPTION
rspec-mocks/spec/rspec/mocks/and_yield_spec.rb:114: warning: assigned but unused variable - default_arg
