### PR TITLE
Add failing spec demonstrating issue.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ Enhancements:
 * Add spying methods (`spy`, `ìnstance_spy`, `class_spy` and `object_spy`)
   which create doubles as null objects for use with spying in testing. (Sam
   Phippen, #671)
+* `have_received` matcher will raise "does not implement" errors correctly when
+  used with verifying doubles and partial doubles. (Xavier Shay, #722)
 
 ### 3.0.2 / 2014-06-19
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.0.1...v3.0.2)

--- a/lib/rspec/mocks/matchers/have_received.rb
+++ b/lib/rspec/mocks/matchers/have_received.rb
@@ -22,6 +22,8 @@ module RSpec
           @block ||= block
           @subject = subject
           @expectation = expect
+          mock_proxy.ensure_implemented(@method_name)
+
           expected_messages_received_in_order?
         end
 
@@ -29,6 +31,7 @@ module RSpec
           @subject = subject
           ensure_count_unconstrained
           @expectation = expect.never
+          mock_proxy.ensure_implemented(@method_name)
           expected_messages_received_in_order?
         end
 

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -9,6 +9,11 @@ module RSpec
       end
 
       # @private
+      def ensure_implemented(*args)
+        # noop for basic proxies, see VerifyingProxy for behaviour.
+      end
+
+      # @private
       def initialize(object, order_group, name=nil, options={})
         @object = object
         @order_group = order_group

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -313,6 +313,13 @@ module RSpec
         prevents { expect(object).to receive(:unimplemented) }
       end
 
+      it 'boes not allow a spy on unimplemented method' do
+        allow(object).to receive(:object_id)
+        prevents(/does not implement/) {
+          expect(object).to have_received(:unimplemented)
+        }
+      end
+
       it 'verifies arity range when matching arguments' do
         prevents { expect(object).to receive(:implemented).with('bogus') }
       end

--- a/spec/rspec/mocks/spy_spec.rb
+++ b/spec/rspec/mocks/spy_spec.rb
@@ -35,6 +35,18 @@ describe "the spy family of methods" do
     it "records called methods" do
       expect(subject.tap { |s| s.foo}).to have_received(:foo)
     end
+
+    it 'fails fast when `have_received` is passed an undefined method name' do
+      expect {
+        expect(subject).to have_received(:bar)
+      }.to fail_matching("does not implement")
+    end
+
+    it 'fails fast when negative `have_received` is passed an undefined method name' do
+      expect {
+        expect(subject).to_not have_received(:bar)
+      }.to fail_matching("does not implement")
+    end
   end
 
   describe "instance_spy" do


### PR DESCRIPTION
When you're using a verified spy, and you do `have_received(:undefined_method)`, it does not give you a "does not implement" error.  It gives you a "expected to receive and did not" error.  Note that the verified aspect of the spy still functions in that if you try to satisfy the expectation by calling `undefined_method` on the spy, at that point you get the "does not implement" error, but this was surprising behavior to me and is potentially confusing...consider the case where there's a long method name and you use the correct spelling when calling the method but are off by one character in the `have_received` expression -- in that case, it can be confusing that you're told that the message was not received rather than being told that the method isn't implemented (which more strongly suggests the typo issue).

@xaviershay, do you want to take a stab at implementing this?
