### PR TITLE
Remove redundant allow.

### DIFF
--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -313,8 +313,7 @@ module RSpec
         prevents { expect(object).to receive(:unimplemented) }
       end
 
-      it 'boes not allow a spy on unimplemented method' do
-        allow(object).to receive(:object_id)
+      it 'does not allow a spy on unimplemented method' do
         prevents(/does not implement/) {
           expect(object).to have_received(:unimplemented)
         }


### PR DESCRIPTION
I originally thought this was required to allow use of the
`have_received` matcher, but not sure what I was thinking.

@myronmarston @JonRowe 

merge on green
