### PR TITLE
Add specs demonstrating problem with verified doubles and keyword args.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ Enhancements:
 * `have_received` matcher will raise "does not implement" errors correctly when
   used with verifying doubles and partial doubles. (Xavier Shay, #722)
 * Don't inadvertently define `BasicObject` in 1.8.7. (Chris Griego, #739)
+* Allow matchers to be used in place of keyword arguments in `with`
+  expectations. (Xavier Shay, #726)
 
 ### 3.0.3 Development
 

--- a/lib/rspec/mocks/argument_matchers.rb
+++ b/lib/rspec/mocks/argument_matchers.rb
@@ -1,3 +1,8 @@
+# This cannot take advantage of our relative requires, since this file is a
+# dependency of `rspec/mocks/argument_list_matcher.rb`. See comment there for
+# details.
+require 'rspec/support/matcher_definition'
+
 module RSpec
   module Mocks
 
@@ -244,6 +249,20 @@ module RSpec
         end
       end
 
+      matcher_namespace = name + '::'
+      ::RSpec::Support.register_matcher_definition do |object|
+        # This is the best we have for now. We should tag all of our matchers
+        # with a module or something so we can test for it directly.
+        #
+        # (Note Module#parent in ActiveSupport is defined in a similar way.)
+        begin
+          object.class.name.include?(matcher_namespace)
+        rescue NoMethodError
+          # Some objects, like BasicObject, don't implemented standard
+          # reflection methods.
+          false
+        end
+      end
     end
   end
 end

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -555,7 +555,7 @@ module RSpec
         block_signature = Support::BlockSignature.new(block)
 
         @args_to_yield.each do |args|
-          unless Support::MethodSignatureVerifier.new(block_signature, args).valid?
+          unless Support::StrictSignatureVerifier.new(block_signature, args).valid?
             @error_generator.raise_wrong_arity_error(args, block_signature)
           end
 

--- a/lib/rspec/mocks/verifying_message_expecation.rb
+++ b/lib/rspec/mocks/verifying_message_expecation.rb
@@ -35,18 +35,22 @@ module RSpec
             super
           end
 
-          validate_arguments!(expected_args)
+          validate_expected_arguments!(expected_args)
         end
         super
       end
 
     private
 
-      def validate_arguments!(actual_args)
+      def validate_expected_arguments!(actual_args)
         return if method_reference.nil?
 
         method_reference.with_signature do |signature|
-          verifier = Support::MethodSignatureVerifier.new(signature, actual_args)
+          verifier = Support::LooseSignatureVerifier.new(
+            signature,
+            actual_args
+          )
+
           unless verifier.valid?
             # Fail fast is required, otherwise the message expecation will fail
             # as well ("expected method not called") and clobber this one.

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -132,7 +132,7 @@ module RSpec
 
       def validate_arguments!(actual_args)
         @method_reference.with_signature do |signature|
-          verifier = Support::MethodSignatureVerifier.new(signature, actual_args)
+          verifier = Support::StrictSignatureVerifier.new(signature, actual_args)
           unless verifier.valid?
             raise ArgumentError, verifier.error_message
           end

--- a/spec/rspec/mocks/verifying_message_expecation_spec.rb
+++ b/spec/rspec/mocks/verifying_message_expecation_spec.rb
@@ -22,7 +22,7 @@ module RSpec
             args = ["abc123", "xyz987"]
             subject.method_reference = InstanceMethodReference.new(string_module_reference, :replace)
             expect(error_generator).to receive(:raise_invalid_arguments_error).
-              with(instance_of(Support::MethodSignatureVerifier))
+              with(instance_of(Support::LooseSignatureVerifier))
 
             subject.with(*args)
           end
@@ -48,7 +48,7 @@ module RSpec
           it 'matches arity to 0' do
             subject.method_reference = InstanceMethodReference.new(string_module_reference, :replace)
             expect(error_generator).to receive(:raise_invalid_arguments_error).
-              with(instance_of(Support::MethodSignatureVerifier))
+              with(instance_of(Support::LooseSignatureVerifier))
 
             subject.with(no_args)
           end


### PR DESCRIPTION
These specs fail:

```
Failures:

  1) verifying doubles instance doubles when doubled class is loaded for a method that accepts a mix of optional keyword and positional args allows hash matchers like `hash_including` to be used in place of the keywords arg hash
     Failure/Error: expect(o).to receive(:mixed_args_method).with(1, 2, hash_including(:optional_arg_1 => 1))
       Wrong number of arguments. Expected 2, got 3.
     # ./spec/rspec/mocks/verifying_double_spec.rb:263:in `block (5 levels) in <module:Mocks>'
     # /Users/myron/code/rspec-dev/repos/rspec-core/exe/rspec:4:in `<top (required)>'

  2) verifying doubles instance doubles when doubled class is loaded for a method that only accepts keyword args allows hash matchers like `hash_including` to be used in place of the keywords arg hash
     Failure/Error: expect(o).to receive(:kw_args_method).with(hash_including(:required_arg => 1))
       Missing required keyword arguments: required_arg
     # ./spec/rspec/mocks/verifying_double_spec.rb:255:in `block (5 levels) in <module:Mocks>'
     # /Users/myron/code/rspec-dev/repos/rspec-core/exe/rspec:4:in `<top (required)>'
```

The problem is that our method signature logic treats a `Hash` as keyword args but does not treat hash matchers the same:

https://github.com/rspec/rspec-support/blob/1e52a1ff545f9042fcc3c06d3febf2873defc4e6/lib/rspec/support/method_signature_verifier.rb#L61

Not sure what a good solution is yet.  Bringing it up for discussion.

/cc @xaviershay
