### PR TITLE
Add new argument matcher: any_of_the_following

### DIFF
--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -16,6 +16,7 @@ Feature: Matching arguments
   | A subset of a hash                                  | `with(hash_including(:a => 1))` | `foo(:a => 1, :b => 2)`               |
   | An excluded subset of a hash                        | `with(hash_excluding(:a => 1))` | `foo(:b => 2)`                        |
   | A subset of an array                                | `with(array_including(:a, :b))` | `foo([:a, :b, :c])`                   |
+  | One element of an array                             | `with(one_of([1, 2]))`          | `foo(2)`                              |
   | An instance of a specific class                     | `with(instance_of(Fixnum))`     | `foo(3)`                              |
   | An object with a given module in its ancestors list | `with(kind_of(Numeric))`        | `foo(3)`                              |
   | Any RSpec matcher                                   | `with(<matcher>)`               | `foo(<object that matches>)`          |

--- a/lib/rspec/mocks/argument_matchers.rb
+++ b/lib/rspec/mocks/argument_matchers.rb
@@ -120,11 +120,11 @@ module RSpec
       #
       # @example
       #
-      #   expect(object).to receive(:message).with(any_of_the_following(1,2,3))
-      #   expect(object).to receive(:message).with(any_of_the_following([1,2,3]))
-      def any_of_the_following(*args)
+      #   expect(object).to receive(:message).with(one_of(1,2,3))
+      #   expect(object).to receive(:message).with(one_of([1,2,3]))
+      def one_of(*args)
         actually_an_array = Array === args.first && args.count == 1 ? args.first : args
-        AnyOfTheFollowingMatcher.new(actually_an_array)
+        OneOfMatcher.new(actually_an_array)
       end
 
       # @private
@@ -242,7 +242,7 @@ module RSpec
       end
 
       # @private
-      class AnyOfTheFollowingMatcher
+      class OneOfMatcher
         def initialize(expected)
           @expected = expected
         end
@@ -252,7 +252,7 @@ module RSpec
         end
 
         def description
-          "any_of_the_following(#{@expected.join(", ")})"
+          "one_of(#{@expected.join(", ")})"
         end
       end
 

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -193,22 +193,22 @@ module RSpec
         end
       end
 
-      context "any_of_the_following" do
+      context "one_of" do
         let(:array) { [1, 2, 3] }
 
         it "accepts matches against any element of the array" do
-          expect(a_double).to receive(:msg).with(any_of_the_following array)
+          expect(a_double).to receive(:msg).with(one_of array)
           a_double.msg(2)
         end
 
         it "accepts a series of arguments too" do
-          expect(a_double).to receive(:msg).with(any_of_the_following(*array))
+          expect(a_double).to receive(:msg).with(one_of(*array))
           a_double.msg(3)
         end
 
         it "doesn't accept matches against elements not in the array" do
-          allow(a_double).to receive(:msg).with(any_of_the_following array)
-          expect { a_double.msg(5) }.to fail_matching "expected: (any_of_the_following(1, 2, 3))"
+          allow(a_double).to receive(:msg).with(one_of array)
+          expect { a_double.msg(5) }.to fail_matching "expected: (one_of(1, 2, 3))"
         end
       end
 


### PR DESCRIPTION
Usage:

```
expect(object).to receive(:message).with(any_of_the_following([1,2,3]))
```

My use case for this is if I have code which loops over an array sending
those elements to a third party. eg:

```
def a_method
  @array.each do |item|
    object.message(item)
  end
end
```

Currently to support this I could do:

```
array.each do |item|
  expect(object).to receive(:message).with(item)
end
```

Instead I would like to be able to:

```
expect(object).to receive(:message).
  with(any_of_the_following array).exactly(array.length).times
```

It also lets me more easily setup an expectation for random selection:

```
object.message(@array.sample)
```

Can have an expectation created like:

```
expect(object).to receive(:message).with(any_of_the_following array)
```

Instead of stubbing `array.sample` to have a deterministic response.
