### PR TITLE
Preserve null objectness when copying test doubles.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,13 @@ Enhancements:
 * `have_received` matcher will raise "does not implement" errors correctly when
   used with verifying doubles and partial doubles. (Xavier Shay, #722)
 
+### 3.0.3 Development
+
+Bug Fixes:
+
+* Make `double.as_null_object.dup` and `double.as_null_object.clone`
+  make the copies be null objects. (Myron Marston, #732)
+
 ### 3.0.2 / 2014-06-19
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.0.1...v3.0.2)
 

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -119,6 +119,11 @@ module RSpec
         return false unless @__expired
         ErrorGenerator.new(self, @name).raise_expired_test_double_error
       end
+
+      def initialize_copy(other)
+        as_null_object if other.null_object?
+        super
+      end
     end
 
     # A generic test double object. `double`, `instance_double` and friends

--- a/spec/rspec/mocks/test_double_spec.rb
+++ b/spec/rspec/mocks/test_double_spec.rb
@@ -25,6 +25,17 @@ module RSpec
         end
       end
 
+      RSpec.shared_examples_for "a copy method" do |method|
+        it "copies the `as_null_object` state when #{method}'d" do
+          dbl = double.as_null_object
+          copy = dbl.__send__(method)
+          expect(copy.foo.bar).to be(copy)
+        end
+      end
+
+      include_examples "a copy method", :dup
+      include_examples "a copy method", :clone
+
       [[:should, :expect], [:expect], [:should]].each do |syntax|
         context "with syntax #{syntax.inspect}" do
           include_context "with syntax", syntax


### PR DESCRIPTION
Fixes #732.
