### PR TITLE
Improve documentation for dynamic classes.

### DIFF
--- a/features/verifying_doubles/dynamic_classes.feature
+++ b/features/verifying_doubles/dynamic_classes.feature
@@ -2,12 +2,16 @@ Feature: Dynamic classes
 
   Verifying instance doubles do not support methods which the class reports to not exist
   since an actual instance of the class would be required to verify against. This is commonly
-  the case when `method_missing` is used. `ActiveRecord` does this to define methods from
-  database columns. If the object has already been loaded you may consider using an
-  [`object_double`](./using-an-object-double), but that cannot work if you are testing in isolation.
+  the case when `method_missing` is used. For example, `ActiveRecord` does this to define
+  methods from database columns.
 
-  These types of methods are supported at class level, since `respond_to?` can be queried
-  directly on the class.
+  There are a few ways to work around this. If the object has already been loaded you may
+  consider using an [`object_double`](./using-an-object-double), but that cannot work if you
+  are testing in isolation. Alternatively you could implement the methods directly (calling
+  `super` to return the `method_missing` definition).
+
+  These types of methods are supported at class level (with `class_double`) however, since
+  `respond_to?` can be queried directly on the class.
 
   Background:
     Given a file named "lib/fake_active_record.rb" with:


### PR DESCRIPTION
An attempt to improve the clarity of the documentation for using verifying doubles with dynamic classes.
