### PR TITLE
Specifying a negative receive expectation could be considered to break respond_to?

### DIFF
--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -210,6 +210,11 @@ module RSpec
             wrapped.to_not receive(:foo).never
           }.to raise_error(/trying to negate it again/)
         end
+
+        it 'does not break respond_to?' do
+          wrapped.to_not receive(:foo)
+          expect(receiver).to_not respond_to :foo
+        end
       end
 
       shared_examples "resets partial mocks cleanly" do


### PR DESCRIPTION
Specifying a negative receive expectation (`expect(...).to_not receive(:blah)`) could be considered to break `respond_to?`, as reported via twitter:

[![screen shot 2014-08-21 at 17 00 37](https://cloud.githubusercontent.com/assets/162976/3998951/5a6a2c22-294c-11e4-99e2-e5185f1ad5e9.png)
](https://twitter.com/damncabbage/status/502367823822213120)

I'm on the fence by this, it's slightly surprising but not unexpected given a knowledge of the internals, the fix is complicated because we can't just return false from `respond_to?` for negative expectations (that could be a lie).
