### PR TITLE
Fix ruby warning.

### DIFF
--- a/spec/rspec/mocks/and_wrap_original_spec.rb
+++ b/spec/rspec/mocks/and_wrap_original_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "and_wrap_original" do
     it "passes along any supplied block" do
       value = nil
       allow(instance).to receive(:results).and_wrap_original { |&b| value = b }
-      instance.results &(block = proc {})
+      instance.results(&(block = proc {}))
       expect(value).to eq block
     end
 


### PR DESCRIPTION
For rspec/rspec-support#106.  (Actually, it's what prompted me to make the change -- we keep having warnings creep up in our spec files!)
