### PR TITLE
Fix prepended module detection on Ruby 2.0

### DIFF
--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -208,8 +208,12 @@ module RSpec
         def prepended_modules_of_singleton_class
           @prepended_modules_of_singleton_class ||= begin
             singleton_class = @object.singleton_class
-            singleton_class.ancestors.take_while do |mod|
-              !(Class === mod || @object.equal?(mod))
+            if singleton_class.ancestors.include?(singleton_class)
+              singleton_class.ancestors.take_while do |mod|
+                !(Class === mod || @object.equal?(mod))
+              end
+            else
+              []
             end
           end
         end

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -155,6 +155,16 @@ module RSpec
           }.not_to change { mod.singleton_class.ancestors }
         end
 
+        it 'does not unnecessarily prepend a module when the module was included' do
+          object = Object.new
+          def object.value; :original; end
+          object.singleton_class.send(:include, ToBePrepended)
+
+          expect {
+            allow(object).to receive(:value) { :stubbed }
+          }.not_to change { object.singleton_class.ancestors }
+        end
+
         it 'reuses our prepend module so as not to keep mutating the ancestors' do
           object = Object.new
           def object.value; :original; end


### PR DESCRIPTION
Ruby's behaviour when prepending a module to a singleton class differs between 2.0 and 2.1. I wrote a test case to illustrate the differences: https://gist.github.com/eugeneius/884873965f90092fc50c

On Ruby 2.1, the singleton class always appears in its own ancestors chain. Prepended modules come before it, and included modules after it. This is consistent with how the ancestors chain works for normal classes and modules.

On Ruby 2.0, the singleton class only appears in its own ancestors chain if a module has been prepended to it. This means we can't find the prepended modules by just iterating over its ancestors until some stopping condition. Right now included modules are being incorrectly classified as prepended modules on Ruby 2.0 - I've included a spec here capturing the bug that fails on master.

If the singleton class is not in its own ancestors chain, we know there aren't any prepended modules, so we don't need to check for them. The existing code works in all other cases.

This makes #746 pass, although I'm not 100% convinced it fixes the underlying issue.
