### PR TITLE
Improve warning message when using `and_call_original` with a stub block...

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -560,7 +560,8 @@ module RSpec
 
       def warn_about_stub_override
         RSpec.warning(
-          "You're overriding a previous stub implementation of `#{@message}`. " \
+          "You're overriding a previous stub block implementation of `#{@message}` with `and_call_original`. " \
+          "The block in this case will never be called. " \
           "Called from #{CallerFilter.first_non_rspec_line}."
         )
       end

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "and_call_original" do
     end
 
     it 'warns when you override an existing implementation' do
-      expect(RSpec).to receive(:warning).with(/overriding a previous stub implementation of `meth_1`.*#{__FILE__}:#{__LINE__ + 1}/)
+      expect(RSpec).to receive(:warning).with(/overriding a previous stub block implementation of `meth_1` with `and_call_original`. The block in this case will never be called.*#{__FILE__}:#{__LINE__ + 1}/)
       expect(instance).to receive(:meth_1) { true }.and_call_original
       instance.meth_1
     end

--- a/spec/rspec/mocks/combining_implementation_instructions_spec.rb
+++ b/spec/rspec/mocks/combining_implementation_instructions_spec.rb
@@ -154,7 +154,7 @@ module RSpec
       end
 
       it 'warns when the inner implementation block is overriden' do
-        expect(RSpec).to receive(:warning).with(/overriding a previous stub implementation of `foo`.*#{__FILE__}:#{__LINE__ + 1}/)
+        expect(RSpec).to receive(:warning).with(/overriding a previous stub block implementation of `foo` with `and_call_original`. The block in this case will never be called.*#{__FILE__}:#{__LINE__ + 1}/)
         allow(double).to receive(:foo).with(:arg) { :with_block }.at_least(:once) { :at_least_block }
       end
 


### PR DESCRIPTION
as we can see in #774 
