### PR TITLE
Stubbing a method on any_instance_of(SomeModule) gives spurious error about prepended modules

### DIFF
--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -248,7 +248,7 @@ module RSpec
 
         if Support::RubyFeatures.module_prepends_supported?
           def allow_no_prepended_module_definition_of(method_name)
-            prepended_modules = @klass.ancestors.take_while { |mod| !(Class === mod) }
+            prepended_modules = RSpec::Mocks::Proxy.prepended_modules_of(@klass)
             problem_mod = prepended_modules.find { |mod| mod.method_defined?(method_name) }
             return unless problem_mod
 

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -205,17 +205,18 @@ module RSpec
       end
 
       if Support::RubyFeatures.module_prepends_supported?
+        def self.prepended_modules_of(klass)
+          ancestors = klass.ancestors
+
+          # `|| 0` is necessary for Ruby 2.0, where the singleton class
+          # is only in the ancestor list when there are prepended modules.
+          singleton_index = ancestors.index(klass) || 0
+
+          ancestors[0, singleton_index]
+        end
+
         def prepended_modules_of_singleton_class
-          @prepended_modules_of_singleton_class ||= begin
-            singleton_class = @object.singleton_class
-            ancestors       = singleton_class.ancestors
-
-            # `|| 0` is necessary for Ruby 2.0, where the singleton class
-            # is only in the ancestor list when there are prepended modules.
-            singleton_index = ancestors.index(singleton_class) || 0
-
-            ancestors[0, singleton_index]
-          end
+          @prepended_modules_of_singleton_class ||= RSpec::Mocks::Proxy.prepended_modules_of(@object.singleton_class)
         end
       end
 

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -523,6 +523,16 @@ module RSpec
           end
         end
 
+        context "when the class has an included module" do
+          it 'allows mocking a method that is defined on the module' do
+            mod = Module.new { def foo; end }
+            klass.class_eval { include mod }
+            expect_any_instance_of(mod).to receive(:foo).and_return(45)
+
+            expect(klass.new.foo).to eq(45)
+          end
+        end
+
         context "when an instance has been directly stubbed" do
           it "fails when a second instance to receive the message" do
             expect_any_instance_of(klass).to receive(:foo)


### PR DESCRIPTION
fixes #781
