### PR TITLE
Failing spec for bug: Wrong error message generated by have_received matcher when method was called 2 or more times than expected

### DIFF
--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -151,10 +151,17 @@ module RSpec
               expect(dbl).to have_received(:expected_method).exactly(3).times
             end
 
-            it 'fails when the message was received more times' do
+            it 'fails when the message was received one more time than expected' do
               expect {
                 expect(dbl).to have_received(:expected_method).exactly(2).times
               }.to raise_error(/expected: 2 times.*received: 3 times/m)
+            end
+
+            it 'fails when the message was received 2 or more times than expected' do
+              pending 'The generated error message is wrong'
+              expect {
+                expect(dbl).to have_received(:expected_method).once
+              }.to raise_error(/expected: 1 times.*received: 3 times/m)
             end
 
             it 'fails when the message was received fewer times' do


### PR DESCRIPTION
```
 it do
    obj = Object.new
    allow(obj).to receive(:enqueue_alert)
    5.times{ obj.enqueue_alert }
    expect(obj).to have_received(:enqueue_alert).thrice
  end
```

fails with:

```
           expected: 3 times with any arguments
           received: 4 times
```

The message should say `received: 5 times`
