### PR TITLE
Fix regexp warnings on 1.8.7.

### DIFF
--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -274,14 +274,14 @@ module RSpec
           expect(a_double).to receive(:random_call).with(:a => "b", :c => "d")
           expect do
             a_double.random_call(:a => "b", :c => "e")
-          end.to fail_matching(/expected: \({(:a=>\"b\", :c=>\"d\"|:c=>\"d\", :a=>\"b\")}\)/)
+          end.to fail_matching(/expected: \(\{(:a=>\"b\", :c=>\"d\"|:c=>\"d\", :a=>\"b\")\}\)/)
         end
 
         it "fails for a hash w/ wrong keys", :reset => true do
           expect(a_double).to receive(:random_call).with(:a => "b", :c => "d")
           expect do
             a_double.random_call("a" => "b", "c" => "d")
-          end.to fail_matching(/expected: \({(:a=>\"b\", :c=>\"d\"|:c=>\"d\", :a=>\"b\")}\)/)
+          end.to fail_matching(/expected: \(\{(:a=>\"b\", :c=>\"d\"|:c=>\"d\", :a=>\"b\")\}\)/)
         end
 
         it "matches a class against itself" do


### PR DESCRIPTION
```
./spec/rspec/mocks/argument_matchers_spec.rb:277: warning: regexp has invalid interval
./spec/rspec/mocks/argument_matchers_spec.rb:277: warning: regexp has `}' without escape
./spec/rspec/mocks/argument_matchers_spec.rb:284: warning: regexp has invalid interval
./spec/rspec/mocks/argument_matchers_spec.rb:284: warning: regexp has `}' without escape
```
