### PR TITLE
Fix `with` bug for verifying doubles.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ Bug Fixes:
   `expect_any_instance_of(...)` with the `have_received` matcher (they are
   not intended to be used together and previously caused an odd internal
   failure in rspec-mocks). (Jon Rowe, #799)
+* Fix verified double `with` verification so that it applies to method
+  stubs. (Myron Marston, #790)
 * Provide a clear error when users wrongly combine `no_args` with
   additional arguments (e.g. `expect().to receive().with(no_args, 1)`).
   (Myron Marston, #786)

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -121,6 +121,11 @@ module RSpec
         super(*args, &block).tap { |x| x.method_reference = @method_reference }
       end
 
+      def add_stub(*args, &block)
+        # explict params necessary for 1.8.7 see #626
+        super(*args, &block).tap { |x| x.method_reference = @method_reference }
+      end
+
       def proxy_method_invoked(obj, *args, &block)
         validate_arguments!(args)
         super

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -106,6 +106,13 @@ module RSpec
         expect(o.defined_class_method).to eq(o)
         prevents { o.undefined_method }
       end
+
+      it 'validates `with` args against the method signature when stubbing a method' do
+        dbl = class_double(LoadedClass)
+        prevents(/Wrong number of arguments. Expected 0, got 2./) {
+          allow(dbl).to receive(:defined_class_method).with(2, :args)
+        }
+      end
     end
   end
 end

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -132,6 +132,13 @@ module RSpec
         end
       end
 
+      it 'validates `with` args against the method signature when stubbing a method' do
+        dbl = instance_double(LoadedClass)
+        prevents(/Wrong number of arguments. Expected 2, got 3./) {
+          allow(dbl).to receive(:instance_method_with_two_args).with(3, :foo, :args)
+        }
+      end
+
       it 'allows class to be specified by constant' do
         o = instance_double(LoadedClass, :defined_instance_method => 1)
         expect(o.defined_instance_method).to eq(1)

--- a/spec/rspec/mocks/verifying_doubles/object_double_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/object_double_spec.rb
@@ -56,6 +56,13 @@ module RSpec
       it 'is not a module' do
         expect(object_double("LoadedClass::INSTANCE")).to_not be_a(Module)
       end
+
+      it 'validates `with` args against the method signature when stubbing a method' do
+        dbl = object_double(LoadedClass.new)
+        prevents(/Wrong number of arguments. Expected 2, got 3./) {
+          allow(dbl).to receive(:instance_method_with_two_args).with(3, :foo, :args)
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
`with` arg validation appears to not be working.

@xaviershay do you want to take a look at this?
