### PR TITLE
Fix an error when a test double was deserialized from YAML

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### 2.99.3 Development
+[Full Changelog](http://github.com/rspec/rspec-mocks/compare/v2.99.2...v2.99.3)
+
+Bug Fixes:
+
+* Fix regression that caused an error when a test double was deserialized from YAML. (Yuji Nakayama, #777)
+
 ### 2.99.2 / 2014-07-21
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v2.99.1...v2.99.2)
 

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -140,7 +140,7 @@ module RSpec
       end
 
       def __warn_of_expired_use_if_expired
-        if @__unfrozen_attributes[:expired]
+        if @__unfrozen_attributes && @__unfrozen_attributes[:expired]
           RSpec.deprecate "Continuing to use a test double after it has been reset (e.g. in a subsequent example)"
         end
       end

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -88,4 +88,12 @@ describe "double" do
       end
     end
   end
+
+  context 'when being deserialized from YAML' do
+    let(:yaml) { YAML.dump(double) }
+
+    it 'does not raise error' do
+      expect { YAML.load(yaml) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
This fixes #777.

The ivar `@__unfrozen_attributes` was properly serialized with YAML.

``` ruby
"--- !ruby/object:RSpec::Mocks::Double\n__null_object: false\n__unfrozen_attributes: {}\nname: something\noptions:\n  :__declared_as: Double\n"
```

However the error was caused by [the invocation of `#respond_to?`](https://github.com/ruby/ruby/blob/v2_1_5/ext/psych/lib/psych/visitors/to_ruby.rb#L345) in the middle of the deserialization (i.e. before the ivar is restored).
