### PR TITLE
Remove spy scenario that is wrong level of detail for relish docs.

### DIFF
--- a/features/basics/spies.feature
+++ b/features/basics/spies.feature
@@ -126,19 +126,3 @@ Feature: Spies
       |  2) An invitiation fails when an order constraint is not satisifed                               |
       |     Failure/Error: expect(invitation).to have_received(:deliver).with("foo@example.com").ordered |
       |       Double "invitation" received :deliver out of order                                         |
-
-  Scenario: `have_received` generates a good example description
-    Given a file named "generates_description_spec.rb" with:
-      """ruby
-      RSpec.describe "An invitation" do
-        subject(:invitation) { spy('invitation') }
-        before { invitation.deliver }
-        it { is_expected.to have_received(:deliver) }
-      end
-      """
-    When I run `rspec --format documentation generates_description_spec.rb`
-    Then it should pass with:
-      """
-      An invitation
-        should have received deliver(*(any args)) 1 time
-      """


### PR DESCRIPTION
Behaviour is already covered by specs: https://github.com/rspec/rspec-mocks/blob/master/spec/rspec/mocks/matchers/have_received_spec.rb#L128

@rspec/rspec 
