### PR TITLE
Validate invocation args for verified null object doubles.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@ Bug Fixes:
   work properly when `SomeConst` has previously been stubbed.
   `(instance|class)_double("SomeClass")` already worked properly.
   (Myron Marston, #824)
+* Validate invocation args for null object verified doubles.
+  (Myron Marston, #829)
 
 ### 3.1.3 / 2014-10-08
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.1.2...v3.1.3)

--- a/lib/rspec/mocks/verifying_double.rb
+++ b/lib/rspec/mocks/verifying_double.rb
@@ -28,6 +28,8 @@ module RSpec
           else
             __mock_proxy.ensure_publicly_implemented(message, self)
           end
+
+          __mock_proxy.validate_arguments!(message, args)
         end
 
         super

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -78,6 +78,10 @@ module RSpec
       def visibility_for(method_name)
         method_reference[method_name].visibility
       end
+
+      def validate_arguments!(method_name, args)
+        @method_doubles[method_name].validate_arguments!(args)
+      end
     end
 
     # @private
@@ -130,8 +134,6 @@ module RSpec
         validate_arguments!(args)
         super
       end
-
-    private
 
       def validate_arguments!(actual_args)
         @method_reference.with_signature do |signature|

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -107,6 +107,14 @@ module RSpec
         prevents { o.undefined_method }
       end
 
+      it 'verifies arguments for null objects' do
+        o = class_double('LoadedClass').as_null_object
+
+        expect {
+          o.defined_class_method(:too, :many, :args)
+        }.to raise_error(ArgumentError, "Wrong number of arguments. Expected 0, got 3.")
+      end
+
       it 'validates `with` args against the method signature when stubbing a method' do
         dbl = class_double(LoadedClass)
         prevents(/Wrong number of arguments. Expected 0, got 2./) {

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -170,6 +170,12 @@ module RSpec
           prevents { o.__send__(:undefined_method) }
         end
 
+        it 'verifies arguments' do
+          expect {
+            o.defined_instance_method(:too, :many, :args)
+          }.to raise_error(ArgumentError, "Wrong number of arguments. Expected 0, got 3.")
+        end
+
         it "includes the double's name in a private method error" do
           expect {
             o.rand


### PR DESCRIPTION
I noticed this when playing around with #826.
