### PR TITLE
Rework spec.

### DIFF
--- a/spec/rspec/mocks/combining_implementation_instructions_spec.rb
+++ b/spec/rspec/mocks/combining_implementation_instructions_spec.rb
@@ -124,21 +124,25 @@ module RSpec
         expect(block_called).to be_truthy
       end
 
-      it 'allows the terminal action to be overriden' do
-        dbl = double
-        stubbed_double = allow(dbl).to receive(:foo)
+      describe "a double that already has a terminal `and_return(x)` action" do
+        let(:dbl) { double }
+        let(:stubbed_double) { allow(dbl).to receive(:foo) }
+        before { stubbed_double.and_return(1) }
 
-        stubbed_double.and_return(1)
-        expect(dbl.foo).to eq(1)
+        it 'allows the terminal action to be overriden to `and_return(y)`' do
+          stubbed_double.and_return(3)
+          expect(dbl.foo).to eq(3)
+        end
 
-        stubbed_double.and_return(3)
-        expect(dbl.foo).to eq(3)
+        it 'allows the terminal action to be overriden to `and_raise(y)`' do
+          stubbed_double.and_raise("boom")
+          expect { dbl.foo }.to raise_error("boom")
+        end
 
-        stubbed_double.and_raise("boom")
-        expect { dbl.foo }.to raise_error("boom")
-
-        stubbed_double.and_throw(:bar)
-        expect { dbl.foo }.to throw_symbol(:bar)
+        it 'allows the terminal action to be overriden to `and_throw(y)`' do
+          stubbed_double.and_throw(:bar)
+          expect { dbl.foo }.to throw_symbol(:bar)
+        end
       end
 
       it 'allows the inner implementation block to be overriden' do


### PR DESCRIPTION
Before, it mutated the message expectation after it
had already been used. This was just done as a matter
of convenience in the spec, and wasn’t the core point
of it. (Honestly, I didn’t think about mutation-after-use
at the time).

Now, it still verifies that it can be overridden in
all the same ways, but doesn’t use the expectation
before overriding it. This preserves the important
behavior while opening the door for #778.

/cc @samphippen 
