### PR TITLE
Add failing specs for when `with` is combined with count constraints.

### DIFF
--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -141,9 +141,38 @@ module RSpec
           let(:the_dbl) { double(:expected_method => nil) }
 
           before do
-            the_dbl.expected_method
-            the_dbl.expected_method
-            the_dbl.expected_method
+            the_dbl.expected_method(:one)
+            the_dbl.expected_method(:two)
+            the_dbl.expected_method(:one)
+          end
+
+          context "when constrained by `with`" do
+            it 'only considers the calls with matching args' do
+              expect(the_dbl).to have_received(:expected_method).with(:one).twice
+              expect(the_dbl).to have_received(:expected_method).with(:two).once
+            end
+
+            context "when the message is received too many times" do
+              it 'includes the counts of calls with matching args in the error message' do
+                expect {
+                  expect(the_dbl).to have_received(:expected_method).with(:one).once
+                }.to fail_with(a_string_including(
+                  "expected: 1 time",
+                  "received: 2 times"
+                ))
+              end
+            end
+
+            context "when the message is received too few times" do
+              it 'includes the counts of calls with matching args in the error message' do
+                expect {
+                  expect(the_dbl).to have_received(:expected_method).with(:two).twice
+                }.to fail_with(a_string_including(
+                  "expected: 2 times",
+                  "received: 1 time"
+                ))
+              end
+            end
           end
 
           context "exactly" do

--- a/spec/rspec/mocks/once_counts_spec.rb
+++ b/spec/rspec/mocks/once_counts_spec.rb
@@ -45,6 +45,29 @@ module RSpec
           verify @double
         }.to raise_error(RSpec::Mocks::MockExpectationError)
       end
+
+      context "when called with the wrong number of times with the specified args and also called with different args" do
+        it "mentions the wrong call count in the failure message rather than the different args" do
+          allow(@double).to receive(:do_something) # allow any args...
+          expect(@double).to receive(:do_something).with(:args, 1).once
+
+          @double.do_something(:args, 2)
+          @double.do_something(:args, 1)
+
+          expect {
+            # we've grouped these lines because it should probably fail fast
+            # on the first line (since our expectation above only allows one
+            # call with these args), but currently it fails with a confusing
+            # message on verification, and ultimately we care more about
+            # what the message is than when it is raised. Still, it would be
+            # preferrable for the error to be triggered on the first line,
+            # so it'd be good to update this spec to enforce that once we
+            # get the failure message right.
+            @double.do_something(:args, 1)
+            verify @double
+          }.to fail_with(a_string_including("expected: 1 time", "received: 2 times"))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When the message is also received with other arguments,
the other arguments are included in the failure message
rather than the invalid counts, which is confusing.

Note that when the message is _never_ received with the specified args (but is received with other args), it probably makes sense to keep the failure message how it is now (where it mentions the unexpected args), but when it is received with the specified args, I think it makes sense to mention the wrong count.  We may need to add some additional specs for this.

I discovered this when working on some rspec-core stuff.  I may come back to this later but for now I wanted to just open a PR with failing specs so we don't forget about it.  Anyone else can feel free to take it :).