### PR TITLE
Fix standalone so it doesn’t infect other objects.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,14 @@ Bug Fixes:
 * Fix `RSpec::Mocks::Constant.original` when called with an invalid
   constant to return an object indicating the constant name is invalid,
   rather than blowing up. (Myron Marston, #833)
+* Make `extend RSpec::Mocks::ExampleMethods` on any object work properly
+  to add the rspec-mocks API to that object. Previously, `expect` would
+  be undefined. (Myron Marston, #846)
+* Fix `require 'rspec/mocks/standalone'` so that it only affects `main`
+  and not every object. It's really only intended to be used in a REPL
+  like IRB, but some gems have loaded it, thinking it needs to be loaded
+  when using rspec-mocks outside the context of rspec-core.
+  (Myron Marston, #846)
 
 ### 3.1.3 / 2014-10-08
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.1.2...v3.1.3)

--- a/features/outside_rspec/standalone.feature
+++ b/features/outside_rspec/standalone.feature
@@ -1,7 +1,7 @@
 Feature: Standalone
 
   `require "rspec/mocks/standalone"` to expose the API at the top level (e.g. `main`) outside
-  the RSpec environment. This is especially useful for exploring rspec-mocks in irb.
+  the RSpec environment in a REPL like IRB or in a one-off script.
 
   Scenario: Allow a message outside RSpec
     Given a file named "example.rb" with:

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -393,6 +393,13 @@ module RSpec
       end
 
       # @private
+      def self.extended(object)
+        # This gets extended in so that if `RSpec::Matchers` is included in
+        # `klass` later, it's definition of `expect` will take precedence.
+        object.extend ExpectHost unless object.respond_to?(:expect)
+      end
+
+      # @private
       def self.declare_verifying_double(type, ref, *args)
         if RSpec::Mocks.configuration.verify_doubled_constant_names? &&
           !ref.defined?

--- a/lib/rspec/mocks/standalone.rb
+++ b/lib/rspec/mocks/standalone.rb
@@ -1,3 +1,3 @@
 require 'rspec/mocks'
-include RSpec::Mocks::ExampleMethods
+extend RSpec::Mocks::ExampleMethods
 RSpec::Mocks.setup

--- a/spec/rspec/mocks/example_methods_spec.rb
+++ b/spec/rspec/mocks/example_methods_spec.rb
@@ -6,6 +6,33 @@ module RSpec
          'them' do
         expect(ExampleMethods.private_instance_methods).to eq([])
       end
+
+      def test_extend_on_new_object(*to_extend, &block)
+        host = Object.new
+        to_extend.each { |mod| host.extend mod }
+        host.instance_eval do
+          dbl = double
+          expect(dbl).to receive(:foo).at_least(:once).and_return(1)
+          dbl.foo
+          instance_exec(dbl, &block) if block
+        end
+      end
+
+      it 'works properly when extended onto an object' do
+        test_extend_on_new_object ExampleMethods
+      end
+
+      it 'works properly when extended onto an object that has previous extended `RSpec::Matchers`' do
+        test_extend_on_new_object RSpec::Matchers, ExampleMethods do |dbl|
+          expect(dbl.foo).to eq(1)
+        end
+      end
+
+      it 'works properly when extended onto an object that later extends `RSpec::Matchers`' do
+        test_extend_on_new_object ExampleMethods, RSpec::Matchers do |dbl|
+          expect(dbl.foo).to eq(1)
+        end
+      end
     end
   end
 end

--- a/spec/rspec/mocks/standalone_spec.rb
+++ b/spec/rspec/mocks/standalone_spec.rb
@@ -1,0 +1,27 @@
+require 'rspec/support/spec/in_sub_process'
+main = self
+
+RSpec.describe "Loading rspec/mocks/standalone" do
+  include RSpec::Support::InSubProcess
+
+  it "exposes the RSpec::Mocks API on `main`" do
+    in_sub_process do
+      require 'rspec/mocks/standalone'
+      main.instance_eval do
+        dbl = double
+        expect(dbl).to receive(:foo)
+        dbl.foo
+        RSpec::Mocks.verify
+        RSpec::Mocks.teardown
+      end
+    end
+  end
+
+  it "does not infect other objects with the RSpec::Mocks API" do
+    in_sub_process do
+      require 'rspec/mocks/standalone'
+      object = Object.new
+      expect(object).not_to respond_to(:double, :expect)
+    end
+  end
+end


### PR DESCRIPTION
This also makes `extend RSpec::Mocks::ExampleMethods`
work properly.

Fixes #845.
