### PR TITLE
Fix inaccurate doc string in cucumber scenario.

### DIFF
--- a/features/basics/test_doubles.feature
+++ b/features/basics/test_doubles.feature
@@ -13,7 +13,7 @@ Feature: Test Doubles
   Scenario: Doubles are strict by default
     Given a file named "double_spec.rb" with:
       """ruby
-      RSpec.describe "double" do
+      RSpec.describe "A test double" do
         it "raises errors when messages not allowed or expected are received" do
           dbl = double("Some Collaborator")
           dbl.foo
@@ -29,8 +29,8 @@ Feature: Test Doubles
   Scenario: A hash can be used to define allowed messages and return values
     Given a file named "double_spec.rb" with:
       """ruby
-      RSpec.describe "double" do
-        it "raises errors when messages not allowed or expected are received" do
+      RSpec.describe "A test double" do
+        it "returns canned responses from the methods named in the provided hash" do
           dbl = double("Some Collaborator", :foo => 3, :bar => 4)
           expect(dbl.foo).to eq(3)
           expect(dbl.bar).to eq(4)


### PR DESCRIPTION
This was apparently a copy/paste error.

Thanks to @aruprakshit for notifying me of this problem.