### PR TITLE
Docs for object references exposed by #832 callback

### DIFF
--- a/lib/rspec/mocks/object_reference.rb
+++ b/lib/rspec/mocks/object_reference.rb
@@ -41,45 +41,70 @@ module RSpec
 
     # Used when an object is passed to `object_double`.
     # Represents a reference to that object.
-    #
-    # @private
     class DirectObjectReference
+      # @param object to which this refers to.
       def initialize(object)
         @object = object
       end
 
+      # The object's description (via `#inspect`).
+      # @return String
       def description
         @object.inspect
       end
 
+      # Defined for interface parity with the other object reference
+      # implementations, it has no real relevance here.
       def const_to_replace
         raise ArgumentError,
               "Can not perform constant replacement with an object."
       end
 
+      # The target of the verifying double (the object's class).
+      #
+      # @return Class
       def target
         @object.class
       end
 
+      # Always returns true for an object as the class is defined.
+      #
+      # @return true
       def defined?
         true
       end
 
+      # Yields if the reference target is loaded, providing a generic mechanism
+      # to optionally run a bit of code only when a reference's target is
+      # loaded.
+      #
+      # This specific implementation always yields because direct references
+      # are always loaded.
+      #
+      # @yield object
       def when_loaded
         yield @object
       end
     end
 
-    # Used when an anonymous module is passed to `class_double` or `instance_double`.
-    # Represents a reference to that module.
-    #
-    # @private
+    # Used when an anonymous module is passed to `class_double` or
+    # `instance_double`. Represents a reference to that module.
     class AnonymousModuleReference < DirectObjectReference
+      # Returns the constant name to replace with a double.
+      #
+      # @return String the constant name
       def const_to_replace
         @object.name
       end
+
+      # Returns the module name.
+      #
+      # @return String the constant name
       alias description const_to_replace
 
+      # The target of the verifying double (the module).
+      #
+      # @return Module
       def target
         @object
       end
@@ -89,26 +114,43 @@ module RSpec
     # or `object_double`.
     # Represents a reference to the object named (via a constant lookup)
     # by the string.
-    #
-    # @private
     class NamedObjectReference
+      # @param const_name [String] constant name
       def initialize(const_name)
         @const_name = const_name
       end
 
+      # Returns true if the named constant is defined, false otherwise.
+      #
+      # @return Boolean
       def defined?
         !!object
       end
 
+      # Returns the constant name to replace with a double.
+      #
+      # @return String the constant name
       def const_to_replace
         @const_name
       end
+
+      # Returns the object constant name.
+      #
+      # @return String the constant name
       alias description const_to_replace
 
+      # The target of the verifying double (the object).
+      #
+      # @return object
       def target
         object
       end
 
+      # Yields if the reference target is loaded, providing a generic mechanism
+      # to optionally run a bit of code only when a reference's target is
+      # loaded.
+      #
+      # @yield object
       def when_loaded
         yield object if object
       end

--- a/lib/rspec/mocks/object_reference.rb
+++ b/lib/rspec/mocks/object_reference.rb
@@ -8,7 +8,7 @@ module RSpec
         case object_module_or_name
         when Module
           if anonymous_module?(object_module_or_name)
-            AnonymousModuleReference.new(object_module_or_name)
+            DirectObjectReference.new(object_module_or_name)
           else
             # Use a `NamedObjectReference` if it has a name because this
             # will use the original value of the constant in case it has
@@ -39,22 +39,26 @@ module RSpec
       private_class_method :anonymous_module?
     end
 
-    # Used when an object is passed to `object_double`.
+    # An implementation of rspec-mocks' reference interface.
+    # Used when an object is passed to {ExampleMethods#object_double}, or
+    # an anonymous class or module is passed to {ExampleMethods#instance_double}
+    # or {ExampleMethods#class_double}.
     # Represents a reference to that object.
+    # @see NamedObjectReference
     class DirectObjectReference
-      # @param object to which this refers to.
+      # @param object [Object] the object to which this refers
       def initialize(object)
         @object = object
       end
 
-      # The object's description (via `#inspect`).
-      # @return String
+      # @return [String] the object's description (via `#inspect`).
       def description
         @object.inspect
       end
 
       # Defined for interface parity with the other object reference
-      # implementations, it has no real relevance here.
+      # implementations. Raises an `ArgumentError` to indicate that `as_stubbed_const`
+      # is invalid when passing an object argument to `object_double`.
       def const_to_replace
         raise ArgumentError,
               "Can not perform constant replacement with an object."
@@ -62,14 +66,14 @@ module RSpec
 
       # The target of the verifying double (the object itself).
       #
-      # @return Object
+      # @return [Object]
       def target
         @object
       end
 
       # Always returns true for an object as the class is defined.
       #
-      # @return true
+      # @return [true]
       def defined?
         true
       end
@@ -81,67 +85,38 @@ module RSpec
       # This specific implementation always yields because direct references
       # are always loaded.
       #
-      # @yield object
+      # @yield [Object] the target of this reference.
       def when_loaded
         yield @object
       end
     end
 
-    # Used when an anonymous module is passed to `class_double` or
-    # `instance_double`. Represents a reference to that module.
-    class AnonymousModuleReference < DirectObjectReference
-      # Returns the constant name to replace with a double.
-      #
-      # @return String the constant name
-      def const_to_replace
-        @object.name
-      end
-
-      # Returns the module name.
-      #
-      # @return String the constant name
-      alias description const_to_replace
-
-      # The target of the verifying double (the module).
-      #
-      # @return Module
-      def target
-        @object
-      end
-    end
-
-    # Used when a string is passed to `class_double`, `instance_double`
-    # or `object_double`.
+    # An implementation of rspec-mocks' reference interface.
+    # Used when a string is passed to {ExampleMethods#object_double},
+    # and when a string, named class or named module is passed to
+    # {ExampleMethods#instance_double}, or {ExampleMethods#class_double}.
     # Represents a reference to the object named (via a constant lookup)
     # by the string.
+    # @see DirectObjectReference
     class NamedObjectReference
       # @param const_name [String] constant name
       def initialize(const_name)
         @const_name = const_name
       end
 
-      # Returns true if the named constant is defined, false otherwise.
-      #
-      # @return Boolean
+      # @return [Boolean] true if the named constant is defined, false otherwise.
       def defined?
         !!object
       end
 
-      # Returns the constant name to replace with a double.
-      #
-      # @return String the constant name
+      # @return [String] the constant name to replace with a double.
       def const_to_replace
         @const_name
       end
-
-      # Returns the object constant name.
-      #
-      # @return String the constant name
       alias description const_to_replace
 
-      # The target of the verifying double (the object).
-      #
-      # @return object
+      # @return [Object, nil] the target of the verifying double (the named object), or
+      #   nil if it is not defined.
       def target
         object
       end
@@ -150,7 +125,7 @@ module RSpec
       # to optionally run a bit of code only when a reference's target is
       # loaded.
       #
-      # @yield object
+      # @yield [Object] the target object
       def when_loaded
         yield object if object
       end

--- a/lib/rspec/mocks/object_reference.rb
+++ b/lib/rspec/mocks/object_reference.rb
@@ -60,11 +60,11 @@ module RSpec
               "Can not perform constant replacement with an object."
       end
 
-      # The target of the verifying double (the object's class).
+      # The target of the verifying double (the object itself).
       #
-      # @return Class
+      # @return Object
       def target
-        @object.class
+        @object
       end
 
       # Always returns true for an object as the class is defined.

--- a/lib/rspec/mocks/object_reference.rb
+++ b/lib/rspec/mocks/object_reference.rb
@@ -61,7 +61,7 @@ module RSpec
       # is invalid when passing an object argument to `object_double`.
       def const_to_replace
         raise ArgumentError,
-              "Can not perform constant replacement with an object."
+              "Can not perform constant replacement with an anonymous object."
       end
 
       # The target of the verifying double (the object itself).

--- a/spec/rspec/mocks/verifying_doubles/construction_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/construction_spec.rb
@@ -91,12 +91,14 @@ module RSpec
 
       describe 'object doubles' do
         it 'declares the class to verifying double callbacks' do
+          object = Object.new
+
           expect { |probe|
             RSpec.configuration.mock_with(:rspec) do |config|
               config.when_declaring_verifying_double(&probe)
             end
-            object_double Object.new
-          }.to yield_with_args(have_attributes :target => Object)
+            object_double object
+          }.to yield_with_args(have_attributes :target => object)
         end
       end
 

--- a/spec/rspec/mocks/verifying_doubles/object_double_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/object_double_spec.rb
@@ -50,7 +50,7 @@ module RSpec
       it 'does not allow as_stubbed_constant for real objects' do
         expect {
           object_double(LoadedClass.new).as_stubbed_const
-        }.to raise_error(/Can not perform constant replacement with an object/)
+        }.to raise_error(/Can not perform constant replacement with an anonymous object/)
       end
 
       it 'is not a module' do


### PR DESCRIPTION
This expands the documentation of the objects now exposed to the public via #832 /cc @myronmarston 