### PR TITLE
Refactor odd memoization.

### DIFF
--- a/lib/rspec/mocks/matchers/have_received.rb
+++ b/lib/rspec/mocks/matchers/have_received.rb
@@ -44,7 +44,7 @@ module RSpec
         end
 
         def description
-          expect.description_for("have received")
+          (@expectation ||= expect).description_for("have received")
         end
 
         CONSTRAINTS.each do |expectation|
@@ -75,11 +75,9 @@ module RSpec
         end
 
         def expect
-          @expectation ||= begin
-            expectation = mock_proxy.build_expectation(@method_name)
-            apply_constraints_to expectation
-            expectation
-          end
+          expectation = mock_proxy.build_expectation(@method_name)
+          apply_constraints_to expectation
+          expectation
         end
 
         def apply_constraints_to(expectation)


### PR DESCRIPTION
It is odd here because within the matcher, we call
`@expectation = expect`, and within `expect` it was
internally memoizing, which means `@expectation`
was being assigned twice. It’s also dubious to
do so because we want to minimize internal memoization
since a matcher can be re-used against a different
target.