### PR TITLE
Provide a clear error when received message args are mutated.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -49,6 +49,8 @@ Bug Fixes:
   external to RSpec monkeying with the method definition. This can
   happen, for example, when you `file.reopen(io)` after previously
   stubbing a method on the `file` object. (Myron Marston, #853)
+* Provide a clear error when received message args are mutated before
+  a `have_received(...).with(...)` expectation. (Myron Marston, #868)
 
 ### 3.1.3 / 2014-10-08
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.1.2...v3.1.3)

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -15,6 +15,10 @@ module RSpec
     # invoked.
     MockExpectationAlreadyInvokedError = Class.new(Exception)
 
+    # Raised for situations that RSpec cannot support due to external mutations
+    # made externally on arguments that RSpec is holding onto to use for later comparisons.
+    CannotSupportArgMutationsError = Class.new(StandardError)
+
     # @private
     UnsupportedMatcherError  = Class.new(StandardError)
     # @private

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -510,6 +510,17 @@ module RSpec
           @actual_received_count += 1
         end
 
+        def fail_if_problematic_received_arg_mutations(received_arg_list)
+          return if @argument_list_matcher == ArgumentListMatcher::MATCH_ALL
+          return unless received_arg_list.has_mutations?
+
+          raise CannotSupportArgMutationsError,
+                "`have_received(...).with(...)` cannot be used when received " \
+                "message args have later been mutated. You can use a normal " \
+                "message expectation (`expect(...).to receive(...).with(...)`) " \
+                "instead."
+        end
+
       private
 
         def invoke_incrementing_actual_calls_by(increment, allowed_to_fail, parent_stub, *args, &block)

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -163,12 +163,12 @@ module RSpec
         attr_reader :args
 
         def initialize(args)
-          @args = args
-          @original_hashes = args.map { |arg| [arg, hash_of(arg)] }
+          @args          = args
+          @original_hash = hash_of(args)
         end
 
         def has_mutations?
-          @original_hashes.any? { |(arg, hash)| hash != hash_of(arg) }
+          @original_hash != hash_of(args)
         end
 
       private

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -88,7 +88,9 @@ module RSpec
           @error_generator.raise_expectation_on_unstubbed_method(expected_method_name)
         end
 
-        @messages_received.each do |(actual_method_name, args, _)|
+        @messages_received.each do |(actual_method_name, received_arg_list, _)|
+          expectation.fail_if_problematic_received_arg_mutations(received_arg_list)
+          args = received_arg_list.args
           next unless expectation.matches?(actual_method_name, *args)
 
           expectation.safe_invoke(nil)
@@ -98,7 +100,8 @@ module RSpec
 
       # @private
       def check_for_unexpected_arguments(expectation)
-        @messages_received.each do |(method_name, args, _)|
+        @messages_received.each do |(method_name, received_arg_list, _)|
+          args = received_arg_list.args
           next unless expectation.matches_name_but_not_args(method_name, *args)
 
           raise_unexpected_message_args_error(expectation, *args)
@@ -138,7 +141,11 @@ module RSpec
 
       # @private
       def received_message?(method_name, *args, &block)
-        @messages_received.any? { |array| array == [method_name, args, block] }
+        @messages_received.any? do |(received_method_name, received_arg_list, received_block)|
+          method_name == received_method_name &&
+            args == received_arg_list.args &&
+            block == received_block
+        end
       end
 
       # @private
@@ -149,7 +156,35 @@ module RSpec
       # @private
       def record_message_received(message, *args, &block)
         @order_group.invoked SpecificMessage.new(object, message, args)
-        @messages_received << [message, args, block]
+        @messages_received << [message, ReceivedArgList.new(args), block]
+      end
+
+      class ReceivedArgList
+        attr_reader :args
+
+        def initialize(args)
+          @args = args
+          @original_hashes = args.map { |arg| [arg, hash_of(arg)] }
+        end
+
+        def has_mutations?
+          @original_hashes.any? { |(arg, hash)| hash != hash_of(arg) }
+        end
+
+      private
+
+        def hash_of(arg)
+          arg.hash
+        rescue Exception
+          # While `Object#hash` is a built-in ruby method that we expect args to
+          # support, there's no guarantee that all args will. For example, a
+          # `BasicObject` instance will raise a `NoMethodError`. Given that
+          # we use the hash only to advise the user of a rare case we don't
+          # support involving mutations, it seems better to ignore this error
+          # and use a static value in its place (which will make us assume no
+          # mutation has occurred).
+          :failed_to_get_hash
+        end
       end
 
       # @private


### PR DESCRIPTION
...before a `have_received(...).with(...)` expectation.

Fixes #865.