### PR TITLE
Make and_wrap_original work with any_instance

### DIFF
--- a/lib/rspec/mocks/any_instance/chain.rb
+++ b/lib/rspec/mocks/any_instance/chain.rb
@@ -34,6 +34,7 @@ module RSpec
           record :and_throw
           record :and_yield
           record :and_call_original
+          record :and_wrap_original
           record :with
           record :once
           record :twice

--- a/lib/rspec/mocks/any_instance/stub_chain.rb
+++ b/lib/rspec/mocks/any_instance/stub_chain.rb
@@ -31,7 +31,8 @@ module RSpec
             :and_return => [:with, nil],
             :and_raise => [:with, nil],
             :and_yield => [:with, nil],
-            :and_call_original => [:with, nil]
+            :and_call_original => [:with, nil],
+            :and_wrap_original => [:with, nil]
           }
         end
 

--- a/spec/rspec/mocks/and_wrap_original_spec.rb
+++ b/spec/rspec/mocks/and_wrap_original_spec.rb
@@ -10,54 +10,68 @@ RSpec.describe "and_wrap_original" do
 
     let(:instance) { klass.new }
 
-    it "allows us to modify the results of the original method" do
-      expect {
-        allow(instance).to receive(:results).and_wrap_original do |m|
-          m.call.first(10)
-        end
-      }.to change { instance.results.size }.from(100).to(10)
+    shared_examples "using and_wrap_original" do
+      it "allows us to modify the results of the original method" do
+        expect {
+          allow_it.to receive(:results).and_wrap_original do |m|
+            m.call.first(10)
+          end
+        }.to change { instance.results.size }.from(100).to(10)
+      end
+
+      it "raises a name error if the method does not exist" do
+        expect {
+          allow_it.to receive(:no_results).and_wrap_original { |m| m.call }
+          instance.no_results
+        }.to raise_error NameError
+      end
+
+      it "passes in the original method" do
+        value = nil
+        original_method = instance.method(:results)
+        allow_it.to receive(:results).and_wrap_original { |m| value = m }
+        instance.results
+        expect(value).to eq original_method
+      end
+
+      it "passes along the message arguments" do
+        values = nil
+        allow_it.to receive(:results).and_wrap_original { |_, *args| values  = args }
+        instance.results(1, 2, 3)
+        expect(values).to eq [1, 2, 3]
+      end
+
+      it "passes along any supplied block" do
+        value = nil
+        allow_it.to receive(:results).and_wrap_original { |&b| value = b }
+        instance.results(&(block = proc {}))
+        expect(value).to eq block
+      end
+
+      it "ignores previous stubs" do
+        allow_it.to receive(:results) { "results" }
+        allow_it.to receive(:results).and_wrap_original { |m| m.call }
+        expect(instance.results).to_not eq "results"
+      end
+
+      it "can be constrained by specific arguments" do
+        allow_it.to receive(:results) { :all }
+        allow_it.to receive(:results).with(5).and_wrap_original { |m, n| m.call.first(n) }
+        expect(instance.results 5).to eq [1,2,3,4,5]
+        expect(instance.results).to eq :all
+      end
     end
 
-    it "raises a name error if the method does not exist" do
-      expect {
-        allow(instance).to receive(:no_results).and_wrap_original { |m| m.call }
-        instance.no_results
-      }.to raise_error NameError
+    describe "allow(...).to receive(...).and_wrap_original" do
+      it_behaves_like "using and_wrap_original" do
+        let(:allow_it) { allow(instance) }
+      end
     end
 
-    it "passes in the original method" do
-      value = nil
-      original_method = instance.method(:results)
-      allow(instance).to receive(:results).and_wrap_original { |m| value = m }
-      instance.results
-      expect(value).to eq original_method
-    end
-
-    it "passes along the message arguments" do
-      values = nil
-      allow(instance).to receive(:results).and_wrap_original { |_, *args| values  = args }
-      instance.results(1, 2, 3)
-      expect(values).to eq [1, 2, 3]
-    end
-
-    it "passes along any supplied block" do
-      value = nil
-      allow(instance).to receive(:results).and_wrap_original { |&b| value = b }
-      instance.results(&(block = proc {}))
-      expect(value).to eq block
-    end
-
-    it "ignores previous stubs" do
-      allow(instance).to receive(:results) { "results" }
-      allow(instance).to receive(:results).and_wrap_original { |m| m.call }
-      expect(instance.results).to_not eq "results"
-    end
-
-    it "can be constrained by specific arguments" do
-      allow(instance).to receive(:results) { :all }
-      allow(instance).to receive(:results).with(5).and_wrap_original { |m, n| m.call.first(n) }
-      expect(instance.results 5).to eq [1,2,3,4,5]
-      expect(instance.results).to eq :all
+    describe "allow_any_instance_of(...).to receive(...).and_wrap_original" do
+      it_behaves_like "using and_wrap_original" do
+        let(:allow_it) { allow_any_instance_of(klass) }
+      end
     end
   end
 end


### PR DESCRIPTION
There were a couple of different issues preventing `and_wrap_original`
from working when used with `any_instance`. Both of these changes were
necessary to make the test case pass, and I wasn't able to find any
other code that looked like it needed to be updated (except for
`receive_message_chain`, which [apparently doesn't work] with
`and_call_original` either).

This fixes #867.

[apparently doesn't work]: https://github.com/rspec/rspec-mocks/pull/467#issuecomment-28631621