### PR TITLE
Include details on how to run against `master`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ alike.
     gem install rspec       # for rspec-core, rspec-expectations, rspec-mocks
     gem install rspec-mocks # for rspec-mocks only
 
+Want to run against the `master` branch? You'll need to include the dependent
+RSpec repos as well. Add the following to your `Gemfile`:
+
+```ruby
+%w[rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
+  gem lib, :git => "git://github.com/rspec/#{lib}.git", :branch => 'master'
+end
+```
+
 ## Test Doubles
 
 A test double is an object that stands in for another object in your system


### PR DESCRIPTION
A very common issue is when a user attempts to run against the `master`
branch. Simply pointing to `master` doesn't work. This adds the steps
necessary to use `master`.

We need all of the repos in order to also satisfy any other gems which
may have a dependency on the `rspec` gem.

[ci skip]