### PR TITLE
824 followups

### DIFF
--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -405,9 +405,9 @@ module RSpec
           !ref.defined?
 
           raise VerifyingDoubleNotDefinedError,
-                "#{ref.description} is not a defined constant. " \
+                "#{ref.description.inspect} is not a defined constant. " \
                 "Perhaps you misspelt it? " \
-                "Disable check with verify_doubled_constant_names configuration option."
+                "Disable check with `verify_doubled_constant_names` configuration option."
         end
 
         RSpec::Mocks.configuration.verifying_double_declaration_callbacks.each do |block|

--- a/lib/rspec/mocks/object_reference.rb
+++ b/lib/rspec/mocks/object_reference.rb
@@ -13,7 +13,7 @@ module RSpec
             # Use a `NamedObjectReference` if it has a name because this
             # will use the original value of the constant in case it has
             # been stubbed.
-            NamedObjectReference.new(object_module_or_name.name)
+            NamedObjectReference.new(name_of(object_module_or_name))
           end
         when String
           NamedObjectReference.new(object_module_or_name)
@@ -29,14 +29,22 @@ module RSpec
 
       if Module.new.name.nil?
         def self.anonymous_module?(mod)
-          !mod.name
+          !name_of(mod)
         end
       else # 1.8.7
         def self.anonymous_module?(mod)
-          mod.name == ""
+          name_of(mod) == ""
         end
       end
       private_class_method :anonymous_module?
+
+      def self.name_of(mod)
+        MODULE_NAME_METHOD.bind(mod).call
+      end
+      private_class_method :name_of
+
+      # @private
+      MODULE_NAME_METHOD = Module.instance_method(:name)
     end
 
     # An implementation of rspec-mocks' reference interface.

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -124,6 +124,22 @@ module RSpec
         end
       end
 
+      context "when given a class that has an overriden `#name` method" do
+        it "properly verifies" do
+          check_verification class_double(LoadedClassWithOverridenName)
+        end
+
+        it "can still stub the const" do
+          class_double(LoadedClassWithOverridenName).as_stubbed_const
+          check_verification LoadedClassWithOverridenName
+        end
+
+        def check_verification(o)
+          allow(o).to receive(:defined_class_method)
+          prevents { allow(o).to receive(:undefined_method) }
+        end
+      end
+
       context "when the class const has been previously stubbed" do
         before { stub_const("LoadedClass", Class.new) }
 

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -153,6 +153,14 @@ module RSpec
         end
       end
 
+      context "when given a class that has an overriden `#name` method" do
+        it "properly verifies" do
+          o = instance_double(LoadedClassWithOverridenName)
+          allow(o).to receive(:defined_instance_method)
+          prevents { allow(o).to receive(:undefined_method) }
+        end
+      end
+
       context 'for null objects' do
         let(:obj) { instance_double('LoadedClass').as_null_object }
 

--- a/spec/support/doubled_classes.rb
+++ b/spec/support/doubled_classes.rb
@@ -78,3 +78,9 @@ private
     "wink wink ;)"
   end
 end
+
+class LoadedClassWithOverridenName < LoadedClass
+  def self.name
+    "Overriding name is not a good idea but we can't count on users not doing this"
+  end
+end


### PR DESCRIPTION
    Deal with verified doubles for classes that redefined `name`.

    These sorts of classes worked fine before #824 was
    merged, and the switch to using a NamedObjectReference
    based on the name broke things for them. This restores
    support.