### PR TITLE
Explicitly tag pending specs for ordered/vague count combinations.

### DIFF
--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -352,7 +352,7 @@ module RSpec
             expect(the_dbl).to have_received(:three).once.ordered
           end
 
-          pending 'passes with at most receive counts when received in order' do
+          it 'passes with at most receive counts when received in order', :ordered_and_vauge_counts_unsupported do
             the_dbl.one
             the_dbl.one
             the_dbl.two
@@ -362,7 +362,7 @@ module RSpec
             expect(the_dbl).to have_received(:two).once.ordered
           end
 
-          pending 'passes with at least receive counts when received in order' do
+          it 'passes with at least receive counts when received in order', :ordered_and_vauge_counts_unsupported do
             the_dbl.one
             the_dbl.one
             the_dbl.two
@@ -382,7 +382,7 @@ module RSpec
             }.to raise_error(/received :two out of order/m)
           end
 
-          pending "fails with at most receive counts when recieved out of order" do
+          it "fails with at most receive counts when recieved out of order", :ordered_and_vauge_counts_unsupported do
             the_dbl.one
             the_dbl.two
             the_dbl.one
@@ -393,7 +393,7 @@ module RSpec
             }.to raise_error(/received :two out of order/m)
           end
 
-          pending "fails with at least receive counts when recieved out of order" do
+          it "fails with at least receive counts when recieved out of order", :ordered_and_vauge_counts_unsupported do
             the_dbl.one
             the_dbl.two
             the_dbl.one

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -344,7 +344,7 @@ module RSpec
             dbl.two
           end
 
-          pending "fails with at least when the ordering is incorrect" do
+          it "fails with at least when the ordering is incorrect", :ordered_and_vauge_counts_unsupported do
             expect {
               expect(dbl).to receive(:one).at_least(2).times.ordered
               expect(dbl).to receive(:two).once.ordered
@@ -364,7 +364,7 @@ module RSpec
             dbl.two
           end
 
-          pending "fails with at most when the ordering is incorrect" do
+          it "fails with at most when the ordering is incorrect", :ordered_and_vauge_counts_unsupported do
             expect {
               expect(dbl).to receive(:one).at_most(2).times.ordered
               expect(dbl).to receive(:two).once.ordered

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,6 +104,15 @@ RSpec.configure do |config|
   config.extend RSpec::Support::RubyFeatures
   config.include RSpec::Support::RubyFeatures
 
+  config.define_derived_metadata :ordered_and_vauge_counts_unsupported do |meta|
+    meta[:pending] = "`.ordered` combined with a vauge count (e.g. `at_least` or `at_most`) is not yet supported (see #713)"
+  end
+
+  # We have yet to try to address this issue, and it's just noise in our output,
+  # so skip it locally. However, on CI we want it to still run them so that if
+  # we do something that makes these specs pass, we are notified.
+  config.filter_run_excluding :ordered_and_vauge_counts_unsupported unless ENV['CI']
+
   RSpec::Matchers.define_negated_matcher :a_string_excluding, :include
 end
 


### PR DESCRIPTION
This will now print the reason it is pending on CI and skip
them locally since it adds a lot of noise to our output
and we have yet to attempt to address them.