### PR TITLE
WIP: Add failing spec for a case that does not work right.

### DIFF
--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -414,6 +414,25 @@ module RSpec
             }.to raise_error(/received :two out of order/m)
           end
 
+          context "when multiple calls to the same method are interleaved with other method calls" do
+            before do
+              the_dbl.one
+              the_dbl.one
+              the_dbl.two
+              the_dbl.one
+              the_dbl.two
+            end
+
+            it 'passes when appropriate' do
+              expect(the_dbl).to have_received(:one).twice.ordered
+              expect(the_dbl).to have_received(:two).once.ordered
+              expect(the_dbl).to have_received(:one).once.ordered
+              expect(the_dbl).to have_received(:two).once.ordered
+            end
+
+            it 'fails when appropriate'
+          end
+
           context "when used with `with`" do
             before do
               the_dbl.one(1)


### PR DESCRIPTION
This is an isolated failing spec for a bug that @avdi uncovered:

https://twitter.com/avdi/status/560885309114961920
https://gist.github.com/avdi/b3f0e675553ec22c9d5d

The failure I get from the spec below is:

```
  1) RSpec::Mocks::Matchers::HaveReceived expect(...).to have_received ordered when multiple calls to the same method are interleaved with other method calls passes when appropriate
     Failure/Error: expect(the_dbl).to have_received(:one).twice.ordered
       (Double).one(*(any args))
           expected: 2 times with any arguments
           received: 3 times with any arguments
     # ./spec/rspec/mocks/matchers/have_received_spec.rb:427:in `block (5 levels) in <module:Mocks>'
```

For the failing case, I haven't written the spec yet since the passing case isn't passing, but we'd probably want that before merging a fix so that we have both sides.

@avdi -- this works if you use ahead-of-time message expectations. It's just with after-the-fact spies that it fails.  We'll have to dig into why.  Unless you want to roll up your sleeves and fix it yourself?  Could make a fun ruby tapas episode :).