### PR TITLE
Removed rubysl from the Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,4 @@ platforms :jruby do
   gem "jruby-openssl"
 end
 
-platforms :rbx do
-  gem 'rubysl'
-end
-
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')


### PR DESCRIPTION
This hasn't been required anymore since quite a while. Starting with 2.2.0 (if I
remember correctly) Rubinius takes care of ensuring the rubysl Gems are always
available, with or without Bundler.