### PR TITLE
Ensure negative expectations raise during RSpec verification time.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,9 @@ Bug Fixes:
   error in a situation we can't support) as our implementation has side
   effects on non-standard objects and there's no solution we could come
   up with that always works. (Myron Marston, #900)
+* Ensure expectations that raise eagerly also raise during RSpec verification.
+  This means that if exceptions are caught inside test execution the test will
+  still fail. (Sam Phippen, #884)
 
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.1.3...v3.2.0)

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -422,9 +422,8 @@ module RSpec
         end
 
         def verify_messages_received
-          InsertOntoBacktrace.line(@expected_from) do
-            generate_error unless expected_messages_received? || failed_fast?
-          end
+          return if expected_messages_received?
+          InsertOntoBacktrace.line(@expected_from) { generate_error }
         end
 
         def expected_messages_received?

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -380,7 +380,10 @@ module RSpec
       context "expect_any_instance_of(...).not_to receive" do
         it "fails if the method is called" do
           expect_any_instance_of(klass).not_to receive(:existing_method)
-          expect { klass.new.existing_method }.to raise_error(RSpec::Mocks::MockExpectationError)
+
+          expect_fast_failure_from(klass.new) do |instance|
+            instance.existing_method
+          end
         end
 
         it "passes if no method is called" do
@@ -398,15 +401,18 @@ module RSpec
           allow_any_instance_of(klass).to receive(:foo).and_return(1)
           expect(instance.foo).to eq(1)
           expect_any_instance_of(klass).not_to receive(:foo)
-          expect { instance.foo }.to fail
+
+          expect_fast_failure_from(instance) do
+            instance.foo
+          end
         end
 
         context "with constraints" do
           it "fails if the method is called with the specified parameters" do
             expect_any_instance_of(klass).not_to receive(:existing_method_with_arguments).with(:argument_one, :argument_two)
-            expect {
-              klass.new.existing_method_with_arguments(:argument_one, :argument_two)
-            }.to raise_error(RSpec::Mocks::MockExpectationError)
+            expect_fast_failure_from(klass.new) do |instance|
+              instance.existing_method_with_arguments(:argument_one, :argument_two)
+            end
           end
 
           it "passes if the method is called with different parameters" do
@@ -777,12 +783,12 @@ module RSpec
             end
 
             it "fails for more than one invocation" do
-              expect do
-                expect_any_instance_of(klass).to receive(:foo).once
-                instance = klass.new
+              expect_any_instance_of(klass).to receive(:foo).once
+
+              expect_fast_failure_from(klass.new) do |instance|
                 2.times { instance.foo }
                 verify instance
-              end.to raise_error(RSpec::Mocks::MockExpectationError)
+              end
             end
           end
 
@@ -794,12 +800,12 @@ module RSpec
             end
 
             it "fails for more than two invocations" do
-              expect do
-                expect_any_instance_of(klass).to receive(:foo).twice
-                instance = klass.new
+              expect_any_instance_of(klass).to receive(:foo).twice
+
+              expect_fast_failure_from(klass.new) do |instance|
                 3.times { instance.foo }
                 verify instance
-              end.to raise_error(RSpec::Mocks::MockExpectationError)
+              end
             end
           end
 
@@ -811,12 +817,11 @@ module RSpec
             end
 
             it "fails for more than three invocations" do
-              expect do
-                expect_any_instance_of(klass).to receive(:foo).thrice
-                instance = klass.new
+              expect_any_instance_of(klass).to receive(:foo).thrice
+              expect_fast_failure_from(klass.new) do |instance|
                 4.times { instance.foo }
                 verify instance
-              end.to raise_error(RSpec::Mocks::MockExpectationError)
+              end
             end
 
             it "fails for less than three invocations" do
@@ -846,12 +851,11 @@ module RSpec
             end
 
             it "fails for n invocations where n > 3" do
-              expect do
-                expect_any_instance_of(klass).to receive(:foo).exactly(3).times
-                instance = klass.new
+              expect_any_instance_of(klass).to receive(:foo).exactly(3).times
+              expect_fast_failure_from(klass.new) do |instance|
                 4.times { instance.foo }
                 verify instance
-              end.to raise_error(RSpec::Mocks::MockExpectationError)
+              end
             end
           end
 
@@ -892,12 +896,11 @@ module RSpec
             end
 
             it "fails for n invocations where n > 3" do
-              expect do
-                expect_any_instance_of(klass).to receive(:foo).at_most(3).times
-                instance = klass.new
+              expect_any_instance_of(klass).to receive(:foo).at_most(3).times
+              expect_fast_failure_from(klass.new) do |instance|
                 4.times { instance.foo }
                 verify instance
-              end.to raise_error(RSpec::Mocks::MockExpectationError)
+              end
             end
           end
 
@@ -908,10 +911,10 @@ module RSpec
             end
 
             it "fails on the first invocation" do
-              expect do
-                expect_any_instance_of(klass).to receive(:foo).never
-                klass.new.foo
-              end.to raise_error(RSpec::Mocks::MockExpectationError)
+              expect_any_instance_of(klass).to receive(:foo).never
+              expect_fast_failure_from(klass.new) do |instance|
+                instance.foo
+              end
             end
 
             context "when combined with other expectations" do

--- a/spec/rspec/mocks/at_most_spec.rb
+++ b/spec/rspec/mocks/at_most_spec.rb
@@ -76,26 +76,27 @@ module RSpec
         expect(@double).to receive(:do_something).at_most(2).times
         @double.do_something
         @double.do_something
-        expect {
+
+        expect_fast_failure_from(@double, /expected: at most 2 times.*received: 3 times/m) do
           @double.do_something
-        }.to raise_error(/expected: at most 2 times.*received: 3 times/m)
+        end
       end
 
       it "fails fast when at_most(:once) and is called twice" do
         expect(@double).to receive(:do_something).at_most(:once)
         @double.do_something
-        expect {
+        expect_fast_failure_from(@double, /expected: at most 1 time.*received: 2 times/m) do
           @double.do_something
-        }.to raise_error(/expected: at most 1 time.*received: 2 times/m)
+        end
       end
 
       it "fails fast when at_most(:twice) and is called three times" do
         expect(@double).to receive(:do_something).at_most(:twice)
         @double.do_something
         @double.do_something
-        expect {
+        expect_fast_failure_from(@double, /expected: at most 2 times.*received: 3 times/m) do
           @double.do_something
-        }.to raise_error(/expected: at most 2 times.*received: 3 times/m)
+        end
       end
 
       it "fails fast when at_most(:thrice) and is called four times" do
@@ -103,11 +104,10 @@ module RSpec
         @double.do_something
         @double.do_something
         @double.do_something
-        expect {
+        expect_fast_failure_from(@double, /expected: at most 3 times.*received: 4 times/m) do
           @double.do_something
-        }.to raise_error(/expected: at most 3 times.*received: 4 times/m)
+        end
       end
-
     end
   end
 end

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -183,17 +183,17 @@ module RSpec
         it 'sets up a negative message expectation that fails if the message is received' do
           wrapped.not_to receive(:foo)
 
-          expect {
+          expect_fast_failure_from(receiver, /expected: 0 times.*received: 1 time/m) do
             receiver.foo
-          }.to raise_error(/expected: 0 times.*received: 1 time/m)
+          end
         end
 
         it 'supports `to_not` as an alias for `not_to`' do
           wrapped.to_not receive(:foo)
 
-          expect {
+          expect_fast_failure_from(receiver, /expected: 0 times.*received: 1 time/m) do
             receiver.foo
-          }.to raise_error(/expected: 0 times.*received: 1 time/m)
+          end
         end
 
         it 'allows the caller to constrain the received arguments' do
@@ -204,9 +204,9 @@ module RSpec
             receiver.foo(:b)
           }.not_to raise_error
 
-          expect {
+          expect_fast_failure_from(receiver, /expected: 0 times.*received: 1 time/m) do
             receiver.foo(:a)
-          }.to raise_error(/expected: 0 times.*received: 1 time/m)
+          end
         end
 
         it 'prevents confusing double-negative expressions involving `never`' do
@@ -453,23 +453,23 @@ module RSpec
         end
 
         it 'supports `expect(...).not_to receive`' do
-          dbl = double
+          expect_fast_failure_from(double) do |dbl|
+            framework.new.instance_exec do
+              expect(dbl).not_to receive(:foo)
+            end
 
-          framework.new.instance_exec do
-            expect(dbl).not_to receive(:foo)
+            dbl.foo
           end
-
-          expect { dbl.foo }.to raise_error(RSpec::Mocks::MockExpectationError)
         end
 
         it 'supports `expect(...).to_not receive`' do
-          dbl = double
+          expect_fast_failure_from(double) do |dbl|
+            framework.new.instance_exec do
+              expect(dbl).to_not receive(:foo)
+            end
 
-          framework.new.instance_exec do
-            expect(dbl).to_not receive(:foo)
+            dbl.foo
           end
-
-          expect { dbl.foo }.to raise_error(RSpec::Mocks::MockExpectationError)
         end
       end
 

--- a/spec/rspec/mocks/mock_expectation_error_spec.rb
+++ b/spec/rspec/mocks/mock_expectation_error_spec.rb
@@ -11,9 +11,10 @@ module RSpec
 
       it 'is not caught by StandardError rescue blocks' do
         expect(Foo).not_to receive(:bar)
-        expect {
+
+        expect_fast_failure_from(Foo) do
           Foo.foo
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        end
       end
     end
   end

--- a/spec/rspec/mocks/multiple_return_value_spec.rb
+++ b/spec/rspec/mocks/multiple_return_value_spec.rb
@@ -123,7 +123,10 @@ module RSpec
         @double.do_something
         @double.do_something
         @double.do_something
-        expect { @double.do_something }.to raise_error
+
+        expect_fast_failure_from(@double) do
+          @double.do_something
+        end
       end
     end
   end

--- a/spec/rspec/mocks/once_counts_spec.rb
+++ b/spec/rspec/mocks/once_counts_spec.rb
@@ -34,9 +34,9 @@ module RSpec
       it "fails fast when called twice" do
         expect(@double).to receive(:do_something).once
         @double.do_something
-        expect {
+        expect_fast_failure_from(@double) do
           @double.do_something
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        end
       end
 
       it "fails when not called" do

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -45,12 +45,12 @@ module RSpec
 
       it "can disallow messages from being received" do
         expect(object).not_to receive(:fuhbar)
-        expect {
-          object.fuhbar
-        }.to raise_error(
-          RSpec::Mocks::MockExpectationError,
+        expect_fast_failure_from(
+          object,
           /expected\: 0 times with any arguments\n    received\: 1 time/
-        )
+        ) do
+          object.fuhbar
+        end
       end
 
       it "can expect a message and set a return value" do
@@ -88,9 +88,10 @@ module RSpec
 
       it "can accept the string form of a message for a negative message expectation" do
         expect(object).not_to receive('foobar')
-        expect {
+
+        expect_fast_failure_from(object) do
           object.foobar
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        end
       end
 
       it "uses reports nil in the error message" do
@@ -360,6 +361,7 @@ module RSpec
 
       it 'verifies arity range when matching arguments' do
         prevents { expect(object).to receive(:implemented).with('bogus') }
+        reset object
       end
 
       it 'allows a method defined with method_missing to be expected' do

--- a/spec/rspec/mocks/precise_counts_spec.rb
+++ b/spec/rspec/mocks/precise_counts_spec.rb
@@ -19,9 +19,9 @@ module RSpec
         @double.do_something
         @double.do_something
         @double.do_something
-        expect {
+        expect_fast_failure_from(@double) do
           @double.do_something
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        end
       end
 
       it "fails when exactly n times method is never called" do

--- a/spec/rspec/mocks/reraising_eager_raises_spec.rb
+++ b/spec/rspec/mocks/reraising_eager_raises_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+RSpec.describe "Reraising eager raises during the verify step" do
+  it "does not reraise when a double receives a message that hasn't been allowed/expected" do
+    with_unfulfilled_double do |dbl|
+      expect { dbl.foo }.to fail
+      expect { verify_all }.not_to raise_error
+    end
+  end
+
+  it "reraises when a negative expectation receives a call" do
+    with_unfulfilled_double do |dbl|
+      expect(dbl).not_to receive(:foo)
+      expect { dbl.foo }.to fail
+      expect { verify_all }.to fail_with(/expected: 0 times with any arguments/)
+    end
+  end
+
+  it "reraises when an expectation with a count is exceeded" do
+    with_unfulfilled_double do |dbl|
+      expect(dbl).to receive(:foo).exactly(2).times
+
+      dbl.foo
+      dbl.foo
+
+      expect { dbl.foo }.to fail
+      expect { verify_all }.to fail_with(/expected: 2 times with any arguments/)
+    end
+  end
+
+  it "reraises when an expectation is called with the wrong arguments" do
+    with_unfulfilled_double do |dbl|
+      expect(dbl).to receive(:foo).with(1,2,3)
+      expect { dbl.foo(1,2,4) }.to fail
+      expect { RSpec::Mocks.verify }.to fail_with(/expected: 1 time with arguments: \(1, 2, 3\)/)
+    end
+  end
+
+  it "reraises when an expectation is called out of order",
+     :pending => "Says bar was called 0 times when it was, see: http://git.io/pjTq" do
+    with_unfulfilled_double do |dbl|
+      expect(dbl).to receive(:foo).ordered
+      expect(dbl).to receive(:bar).ordered
+      expect { dbl.bar }.to fail
+      dbl.foo # satisfy the `foo` expectation so that only the bar one fails below
+      expect { RSpec::Mocks.verify }.to fail_with(/received :bar out of order/)
+    end
+  end
+end

--- a/spec/rspec/mocks/should_syntax_spec.rb
+++ b/spec/rspec/mocks/should_syntax_spec.rb
@@ -192,9 +192,10 @@ RSpec.describe "Using the legacy should syntax" do
     end
 
     it 'fails when the message is received' do
-      dbl = double
-      dbl.should_not_receive(:foo)
-      expect { dbl.foo }.to raise_error(RSpec::Mocks::MockExpectationError)
+      with_unfulfilled_double do |dbl|
+        dbl.should_not_receive(:foo)
+        expect { dbl.foo }.to raise_error(RSpec::Mocks::MockExpectationError)
+      end
     end
 
     it 'does not fail on verification if the message is not received' do
@@ -339,7 +340,10 @@ RSpec.describe "Using the legacy should syntax" do
       describe "#should_not_receive" do
         it "fails if the method is called" do
           klass.any_instance.should_not_receive(:existing_method)
-          expect { klass.new.existing_method }.to raise_error(RSpec::Mocks::MockExpectationError)
+          instance = klass.new
+          expect_fast_failure_from(instance) do
+            instance.existing_method
+          end
         end
 
         it "passes if no method is called" do
@@ -354,9 +358,10 @@ RSpec.describe "Using the legacy should syntax" do
         context "with constraints" do
           it "fails if the method is called with the specified parameters" do
             klass.any_instance.should_not_receive(:existing_method_with_arguments).with(:argument_one, :argument_two)
-            expect {
-              klass.new.existing_method_with_arguments(:argument_one, :argument_two)
-            }.to raise_error(RSpec::Mocks::MockExpectationError)
+            instance = klass.new
+            expect_fast_failure_from(instance) do
+              instance.existing_method_with_arguments(:argument_one, :argument_two)
+            end
           end
 
           it "passes if the method is called with different parameters" do

--- a/spec/rspec/mocks/syntax_agnostic_message_matchers_spec.rb
+++ b/spec/rspec/mocks/syntax_agnostic_message_matchers_spec.rb
@@ -59,10 +59,10 @@ module RSpec
       end
 
       it "fails if never is specified and the message is called" do
-        expect {
+        expect_fast_failure_from(subject, /expected.*0 times/) do
           ::RSpec::Mocks.expect_message(subject, :foo).never
           subject.foo
-        }.to raise_error(/expected.*0 times/)
+        end
       end
 
       it "sets up basic message expectation, verifies as called" do

--- a/spec/rspec/mocks/thrice_counts_spec.rb
+++ b/spec/rspec/mocks/thrice_counts_spec.rb
@@ -28,9 +28,9 @@ module RSpec
       it "fails fast when call count is higher than expected" do
         expect(@double).to receive(:do_something).thrice
         3.times { @double.do_something }
-        expect {
+        expect_fast_failure_from(@double) do
           @double.do_something
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        end
       end
 
       it "fails when call count is lower than expected" do

--- a/spec/rspec/mocks/twice_counts_spec.rb
+++ b/spec/rspec/mocks/twice_counts_spec.rb
@@ -30,9 +30,9 @@ module RSpec
         expect(@double).to receive(:do_something).twice
         @double.do_something
         @double.do_something
-        expect {
+        expect_fast_failure_from(@double) do
           @double.do_something
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        end
       end
 
       it "fails when call count is lower than expected" do

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -72,6 +72,8 @@ module RSpec
         prevents {
           expect(o).to receive(:defined_instance_method).with(:a)
         }
+
+        reset o
       end
 
       it 'checks that stubbed methods are invoked with the correct arity' do
@@ -108,6 +110,7 @@ module RSpec
               expect(o).to receive(:kw_args_method).
                 with(1, 2, 3, hash_including(:required_arg => 1))
             }
+            reset o
           end
 
           it 'does not allow matchers to be used in an actual method call' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,13 @@ module VerifyAndResetHelpers
   def with_unfulfilled_double
     d = double("double")
     yield d
+  ensure
     reset d
+  end
+
+  def expect_fast_failure_from(double, *fail_with_args, &blk)
+    expect { blk.call(double) }.to fail_with(*fail_with_args)
+    reset double
   end
 end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -4,7 +4,7 @@ module RSpec
       raise_error(RSpec::Mocks::MockExpectationError)
     end
 
-    def fail_with(message)
+    def fail_with(message=nil)
       raise_error(RSpec::Mocks::MockExpectationError, message)
     end
 


### PR DESCRIPTION
During the execution of an example  (as noted in #874) it is possible
for a framework that wraps a mocked object to catch the
RSpec::Mocks::MockExpectationError raised by a negative expectation. This
exception is thrown immediately and so if it is caught the running
example will pass.

This patch causes message expectations to also raise the same error at
verification time.

This commit does not have a passing spec suite, that is intentional. I
want to get feedback on the implementation before I go through all the
broken tests and fix them. The relevant new test can be found on lines
228 to 239 of receive_spec.rb