### PR TITLE
When stubbing `MyClass.new` verify against `MyClass#initialize`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+### 3.3.0 Development
+[Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.2.0...master)
+
+Enhancements:
+
+* When stubbing `new` on `MyClass` or `class_double(MyClass)`, use the
+  method signature from `MyClass#initialize` to verify arguments.
+  (Myron Marston, #886)
+
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.1.3...v3.2.0)
 

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -448,6 +448,8 @@ module RSpec
 
         context "on a class with a private `new`" do
           it 'uses the method signature from `#initialize` for arg verification' do
+            pending "Failing on JRuby due to https://github.com/jruby/jruby/issues/2565" if RSpec::Support::Ruby.jruby?
+
             subclass = Class.new(klass) do
               private_class_method :new
             end

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -309,6 +309,9 @@ module RSpec
             "works"
           end
 
+          def initialize(a, b)
+          end
+
           def respond_to?(method_name, include_all=false)
             method_name.to_s == "dynamic_method" || super
           end
@@ -329,7 +332,7 @@ module RSpec
         end
       end
 
-      let(:object) { klass.new }
+      let(:object) { klass.new(1, 2) }
 
       before do
         RSpec::Mocks.configuration.verify_partial_doubles = true
@@ -410,6 +413,50 @@ module RSpec
         expect(object.implemented).to eq(:value)
       end
 
+      context "when `.new` is stubbed" do
+        before do
+          expect(klass.instance_method(:initialize).arity).to eq(2)
+        end
+
+        it 'uses the method signature from `#initialize` for arg verification' do
+          prevents(/arguments/) { allow(klass).to receive(:new).with(1) }
+          allow(klass).to receive(:new).with(1, 2)
+        end
+
+        context "on a class that has redefined `new`" do
+          it "uses the method signature of the redefined `new` for arg verification" do
+            subclass = Class.new(klass) do
+              def self.new(a); end
+            end
+
+            prevents(/arguments/) { allow(subclass).to receive(:new).with(1, 2) }
+            allow(subclass).to receive(:new).with(1)
+          end
+        end
+
+        context "on a class that has undefined `new`" do
+          it "prevents it from being stubbed" do
+            subclass = Class.new(klass) do
+              class << self
+                undef new
+              end
+            end
+
+            prevents(/does not implement/) { allow(subclass).to receive(:new).with(1, 2) }
+          end
+        end
+
+        context "on a class with a private `new`" do
+          it 'uses the method signature from `#initialize` for arg verification' do
+            subclass = Class.new(klass) do
+              private_class_method :new
+            end
+
+            prevents(/arguments/) { allow(subclass).to receive(:new).with(1) }
+            allow(subclass).to receive(:new).with(1, 2)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -153,6 +153,8 @@ module RSpec
 
         context "on a class with a private `new`" do
           it 'uses the method signature from `#initialize` for arg verification' do
+            pending "Failing on JRuby due to https://github.com/jruby/jruby/issues/2565" if RSpec::Support::Ruby.jruby?
+
             klass = Class.new(LoadedClass) do
               private_class_method :new
             end

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -115,6 +115,55 @@ module RSpec
         }
       end
 
+      context "when `.new` is stubbed" do
+        before do
+          expect(LoadedClass.instance_method(:initialize).arity).to eq(2)
+        end
+
+        it 'uses the method signature from `#initialize` for arg verification' do
+          o = class_double(LoadedClass)
+          prevents(/arguments/) { allow(o).to receive(:new).with(1) }
+          allow(o).to receive(:new).with(1, 2)
+        end
+
+        context "on a class that has redefined `new`" do
+          it "uses the method signature of the redefined `new` for arg verification" do
+            klass = Class.new(LoadedClass) do
+              def self.new(a); end
+            end
+
+            o = class_double(klass)
+            prevents(/arguments/) { allow(o).to receive(:new).with(1, 2) }
+            allow(o).to receive(:new).with(1)
+          end
+        end
+
+        context "on a class that has undefined `new`" do
+          it "prevents it from being stubbed" do
+            klass = Class.new(LoadedClass) do
+              class << self
+                undef new
+              end
+            end
+
+            o = class_double(klass)
+            prevents(/does not implement/) { allow(o).to receive(:new).with(1, 2) }
+          end
+        end
+
+        context "on a class with a private `new`" do
+          it 'uses the method signature from `#initialize` for arg verification' do
+            klass = Class.new(LoadedClass) do
+              private_class_method :new
+            end
+
+            o = class_double(klass)
+            prevents(/arguments/) { allow(o).to receive(:new).with(1) }
+            allow(o).to receive(:new).with(1, 2)
+          end
+        end
+      end
+
       context "when given an anonymous class" do
         it 'properly verifies' do
           subclass = Class.new(LoadedClass)

--- a/spec/rspec/mocks/verifying_doubles/object_double_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/object_double_spec.rb
@@ -3,6 +3,8 @@ require 'support/doubled_classes'
 module RSpec
   module Mocks
     RSpec.describe 'An object double' do
+      let(:loaded_instance) { LoadedClass.new(1, 2) }
+
       it 'can replace an unloaded constant' do
         o = object_double("LoadedClass::NOINSTANCE").as_stubbed_const
 
@@ -28,7 +30,7 @@ module RSpec
       end
 
       it 'can create a double that matches the interface of any arbitrary object' do
-        o = object_double(LoadedClass.new)
+        o = object_double(loaded_instance)
 
         prevents { expect(o).to receive(:undefined_instance_method) }
         prevents { expect(o).to receive(:defined_class_method) }
@@ -49,7 +51,7 @@ module RSpec
 
       it 'does not allow as_stubbed_constant for real objects' do
         expect {
-          object_double(LoadedClass.new).as_stubbed_const
+          object_double(loaded_instance).as_stubbed_const
         }.to raise_error(/Can not perform constant replacement with an anonymous object/)
       end
 
@@ -58,7 +60,7 @@ module RSpec
       end
 
       it 'validates `with` args against the method signature when stubbing a method' do
-        dbl = object_double(LoadedClass.new)
+        dbl = object_double(loaded_instance)
         prevents(/Wrong number of arguments. Expected 2, got 3./) {
           allow(dbl).to receive(:instance_method_with_two_args).with(3, :foo, :args)
         }

--- a/spec/support/doubled_classes.rb
+++ b/spec/support/doubled_classes.rb
@@ -5,6 +5,9 @@ class LoadedClass
   N = :n
   INSTANCE = LoadedClass.new
 
+  def initialize(a, b)
+  end
+
   class << self
 
     def respond_to?(method_name, include_all = false)


### PR DESCRIPTION
Closes #883.