### PR TITLE
Add more specific "does not implement" messages.

### DIFF
--- a/features/verifying_doubles/class_doubles.feature
+++ b/features/verifying_doubles/class_doubles.feature
@@ -67,4 +67,4 @@ Feature: Using a class double
       """
     When I run `rspec spec/user_spec.rb`
     Then the output should contain "1 example, 1 failure"
-    And the output should contain "ConsoleNotifier does not implement:"
+    And the output should contain "the ConsoleNotifier class does not implement the class method:"

--- a/features/verifying_doubles/instance_doubles.feature
+++ b/features/verifying_doubles/instance_doubles.feature
@@ -87,7 +87,7 @@ Feature: Using an instance double
       """
     When I run `rspec -r./spec/spec_helper spec/unit/user_spec.rb`
     Then the output should contain "1 example, 1 failure"
-    And the output should contain "ConsoleNotifier does not implement:"
+    And the output should contain "ConsoleNotifier class does not implement the instance method:"
 
   Scenario: spec fails with dependencies loaded and incorrect arity
     Given a file named "app/models/console_notifier.rb" with:

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -98,11 +98,17 @@ module RSpec
       # rubocop:enable Style/ParameterLists
 
       # @private
-      def raise_unimplemented_error(doubled_module, method_name)
-        __raise "%s does not implement: %s" % [
-          doubled_module.description,
-          method_name
-        ]
+      def raise_unimplemented_error(doubled_module, method_name, object)
+        message = case object
+                  when InstanceVerifyingDouble
+                    "the %s class does not implement the instance method: %s"
+                  when ClassVerifyingDouble
+                    "the %s class does not implement the class method: %s"
+                  else
+                    "%s does not implement: %s"
+                  end
+
+        __raise message % [doubled_module.description, method_name]
       end
 
       # @private

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -25,7 +25,8 @@ module RSpec
 
         @error_generator.raise_unimplemented_error(
           @doubled_module,
-          method_name
+          method_name,
+          @object
         )
       end
 

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -147,7 +147,7 @@ module RSpec
             end
 
             o = class_double(klass)
-            prevents(/does not implement/) { allow(o).to receive(:new).with(1, 2) }
+            prevents(/does not implement the class method/) { allow(o).to receive(:new).with(1, 2) }
           end
         end
 

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -13,8 +13,8 @@ module RSpec
         o = instance_double('LoadedClass', :defined_instance_method => 1)
         expect(o.defined_instance_method).to eq(1)
 
-        prevents { allow(o).to receive(:undefined_instance_method) }
-        prevents { allow(o).to receive(:defined_class_method) }
+        prevents(/does not implement the instance method/) { allow(o).to receive(:undefined_instance_method) }
+        prevents(/does not implement the instance method/) { allow(o).to receive(:defined_class_method) }
       end
 
       it 'only allows instance methods that exist to be expected' do


### PR DESCRIPTION
The unimplemented error message gives no indication of whether the
object is a class or instance double. This change passes that object to
the error generator so that it can create a more specific message
depending on whether it is an instance or class double. It defaults to
the original "<object> does not implement <method>" for anything else.

https://github.com/rspec/rspec-mocks/issues/838