### PR TITLE
Add precision to failures for Time, DateTime, and BigDecimal

### DIFF
--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -2,6 +2,7 @@ require 'rspec/support'
 RSpec::Support.require_rspec_support 'caller_filter'
 RSpec::Support.require_rspec_support 'warnings'
 RSpec::Support.require_rspec_support 'ruby_features'
+RSpec::Support.require_rspec_support 'output_formatter'
 
 RSpec::Support.define_optimized_require_for_rspec(:mocks) { |f| require_relative f }
 

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -267,7 +267,7 @@ module RSpec
       end
 
       def arg_list(*args)
-        args.map { |arg| arg_has_valid_description?(arg) ? arg.description : arg.inspect }.join(", ")
+        args.map { |arg| arg_has_valid_description?(arg) ? arg.description : RSpec::Support::OutputFormatter.format(arg) }.join(", ")
       end
 
       def arg_has_valid_description?(arg)
@@ -279,7 +279,7 @@ module RSpec
       end
 
       def received_arg_list(*args)
-        args.map(&:inspect).join(", ")
+        args.map { |arg| RSpec::Support::OutputFormatter.format(arg) }.join(", ")
       end
 
       def count_message(count, expectation_count_type=nil)


### PR DESCRIPTION
Part of rspec/rspec-mocks#898 to add precise output for failures around Time, DateTime, and BigDecimal.