### PR TITLE
Revert arg mutation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ class_spy("Invitation") # => same as `class_double("Invitation").as_null_object`
 object_spy("Invitation") # => same as `object_double("Invitation").as_null_object`
 ```
 
-Stubbing and verifying messages received in this way implements the Test Spy
-pattern.
+Verifying messages received in this way implements the Test Spy pattern.
 
 ```ruby
 invitation = spy('invitation')
@@ -155,6 +154,20 @@ expect(invitation).to_not have_received(:accept).with(mailer)
 invitation = spy('invitation', :accept => true)
 expect(invitation).to have_received(:accept).with(mailer)
 expect(invitation.accept).to eq(true)
+```
+
+Note that `have_received(...).with(...)` is unable to work properly when
+passed arguments are mutated after the spy records the received message.
+For example, this does not work properly:
+
+```ruby
+greeter = spy("greeter")
+
+message = "Hello"
+greeter.greet_with(message)
+message << ", World"
+
+expect(greeter).to have_received(:greet_with).with("Hello")
 ```
 
 ## Nomenclature

--- a/features/basics/spies.feature
+++ b/features/basics/spies.feature
@@ -13,6 +13,7 @@ Feature: Spies
   `have_received` supports the same fluent interface for [setting constraints](../setting-constraints) that normal message expectations do.
 
   Note: The `have_received` API shown here will only work if you are using rspec-expectations.
+  Note: `have_received(...).with(...)` is unable to work properly when passed arguments are mutated after the spy records the received message.
 
   Scenario: Using a spy
     Given a file named "spy_spec.rb" with:

--- a/lib/rspec/mocks/argument_matchers.rb
+++ b/lib/rspec/mocks/argument_matchers.rb
@@ -17,7 +17,6 @@ module RSpec
       # Acts like an arg splat, matching any number of args at any point in an arg list.
       #
       # @example
-      #
       #   expect(object).to receive(:message).with(1, 2, any_args)
       #
       #   # matches any of these:
@@ -31,7 +30,6 @@ module RSpec
       # Matches any argument at all.
       #
       # @example
-      #
       #   expect(object).to receive(:message).with(anything)
       def anything
         AnyArgMatcher::INSTANCE
@@ -40,7 +38,6 @@ module RSpec
       # Matches no arguments.
       #
       # @example
-      #
       #   expect(object).to receive(:message).with(no_args)
       def no_args
         NoArgsMatcher::INSTANCE
@@ -49,7 +46,6 @@ module RSpec
       # Matches if the actual argument responds to the specified messages.
       #
       # @example
-      #
       #   expect(object).to receive(:message).with(duck_type(:hello))
       #   expect(object).to receive(:message).with(duck_type(:hello, :goodbye))
       def duck_type(*args)
@@ -59,7 +55,6 @@ module RSpec
       # Matches a boolean value.
       #
       # @example
-      #
       #   expect(object).to receive(:message).with(boolean())
       def boolean
         BooleanMatcher::INSTANCE
@@ -69,7 +64,6 @@ module RSpec
       # Ignores any additional keys.
       #
       # @example
-      #
       #   expect(object).to receive(:message).with(hash_including(:key => val))
       #   expect(object).to receive(:message).with(hash_including(:key))
       #   expect(object).to receive(:message).with(hash_including(:key, :key2 => val2))
@@ -81,7 +75,6 @@ module RSpec
       # Ignores duplicates and additional values
       #
       # @example
-      #
       #   expect(object).to receive(:message).with(array_including(1,2,3))
       #   expect(object).to receive(:message).with(array_including([1,2,3]))
       def array_including(*args)
@@ -92,7 +85,6 @@ module RSpec
       # Matches a hash that doesn't include the specified key(s) or key/value.
       #
       # @example
-      #
       #   expect(object).to receive(:message).with(hash_excluding(:key => val))
       #   expect(object).to receive(:message).with(hash_excluding(:key))
       #   expect(object).to receive(:message).with(hash_excluding(:key, :key2 => :val2))
@@ -105,7 +97,6 @@ module RSpec
       # Matches if `arg.instance_of?(klass)`
       #
       # @example
-      #
       #   expect(object).to receive(:message).with(instance_of(Thing))
       def instance_of(klass)
         InstanceOf.new(klass)
@@ -114,8 +105,8 @@ module RSpec
       alias_method :an_instance_of, :instance_of
 
       # Matches if `arg.kind_of?(klass)`
-      # @example
       #
+      # @example
       #   expect(object).to receive(:message).with(kind_of(Thing))
       def kind_of(klass)
         KindOf.new(klass)

--- a/lib/rspec/mocks/configuration.rb
+++ b/lib/rspec/mocks/configuration.rb
@@ -19,7 +19,6 @@ module RSpec
       # Defaults to `true`.
       #
       # @example
-      #
       #   RSpec.configure do |rspec|
       #     rspec.mock_with :rspec do |mocks|
       #       mocks.yield_receiver_to_any_instance_implementation_blocks = false
@@ -35,7 +34,6 @@ module RSpec
       # the process.
       #
       # @example
-      #
       #   RSpec.configure do |rspec|
       #     rspec.mock_with :rspec do |mocks|
       #       mocks.add_stub_and_should_receive_to Delegator
@@ -55,7 +53,6 @@ module RSpec
       # disable `expect` syntax.
       #
       # @example
-      #
       #   RSpec.configure do |rspec|
       #     rspec.mock_with :rspec do |mocks|
       #       mocks.syntax = [:expect, :should]
@@ -81,7 +78,6 @@ module RSpec
       # that are enabled.
       #
       # @example
-      #
       #   unless RSpec::Mocks.configuration.syntax.include?(:expect)
       #     raise "this RSpec extension gem requires the rspec-mocks `:expect` syntax"
       #   end
@@ -107,7 +103,6 @@ module RSpec
       # Provides a way to perform customisations when verifying doubles.
       #
       # @example
-      #
       #  RSpec::Mocks.configuration.when_declaring_verifying_double do |ref|
       #    ref.some_method!
       #  end

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -18,6 +18,9 @@ module RSpec
     # Raised for situations that RSpec cannot support due to mutations made
     # externally on arguments that RSpec is holding onto to use for later
     # comparisons.
+    #
+    # @deprecated We no longer raise this error but the constant remains until
+    #   RSpec 4 for SemVer reasons.
     CannotSupportArgMutationsError = Class.new(StandardError)
 
     # @private

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -278,6 +278,9 @@ module RSpec
       #
       #   # You can also use most message expectations:
       #   expect(invitation).to have_received(:accept).with(mailer).once
+      #
+      # @note `have_received(...).with(...)` is unable to work properly when
+      #   passed arguments are mutated after the spy records the received message.
       def have_received(method_name, &block)
         Matchers::HaveReceived.new(method_name, &block)
       end

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -24,7 +24,6 @@ module RSpec
       # hash of message/return-value pairs.
       #
       # @example
-      #
       #   book = double("book", :title => "The RSpec Book")
       #   book.title #=> "The RSpec Book"
       #
@@ -219,7 +218,6 @@ module RSpec
       # @return [Object] the stubbed value of the constant
       #
       # @example
-      #
       #   stub_const("MyClass", Class.new) # => Replaces (or defines) MyClass with a new class object.
       #   stub_const("SomeModel::PER_PAGE", 5) # => Sets SomeModel::PER_PAGE to 5.
       #
@@ -253,7 +251,6 @@ module RSpec
       #   The current constant scoping at the point of call is not considered.
       #
       # @example
-      #
       #   hide_const("MyClass") # => MyClass is now an undefined constant
       def hide_const(constant_name)
         ConstantMutator.hide(constant_name)
@@ -271,7 +268,6 @@ module RSpec
       #   called.
       #
       # @example
-      #
       #   invitation = double('invitation', accept: true)
       #   user.accept_invitation(invitation)
       #   expect(invitation).to have_received(:accept)
@@ -290,7 +286,6 @@ module RSpec
       # on it.
       #
       # @example
-      #
       #   expect(obj).to receive(:foo).with(5).and_return(:return_value)
       #
       # @note This method is usually provided by rspec-expectations. However,
@@ -303,7 +298,6 @@ module RSpec
       # on it.
       #
       # @example
-      #
       #   allow(dbl).to receive(:foo).with(5).and_return(:return_value)
       #
       # @note If you disable the `:expect` syntax this method will be undefined.
@@ -313,7 +307,6 @@ module RSpec
       # on instances of it.
       #
       # @example
-      #
       #   expect_any_instance_of(MyClass).to receive(:foo)
       #
       # @note If you disable the `:expect` syntax this method will be undefined.
@@ -323,7 +316,6 @@ module RSpec
       # on instances of it.
       #
       # @example
-      #
       #   allow_any_instance_of(MyClass).to receive(:foo)
       #
       # @note This is only available when you have enabled the `expect` syntax.
@@ -336,7 +328,6 @@ module RSpec
       # times, and configure how the object should respond to the message.
       #
       # @example
-      #
       #   expect(obj).to receive(:hello).with("world").exactly(3).times
       #
       # @note If you disable the `:expect` syntax this method will be undefined.
@@ -349,7 +340,6 @@ module RSpec
       # interface.
       #
       # @example
-      #
       #   allow(obj).to receive_messages(:speak => "Hello World")
       #   allow(obj).to receive_messages(:speak => "Hello", :meow => "Meow")
       #
@@ -373,16 +363,15 @@ module RSpec
       # implementation calls `foo.baz.bar`, the stub will not work.
       #
       # @example
+      #   allow(double).to receive_message_chain("foo.bar") { :baz }
+      #   allow(double).to receive_message_chain(:foo, :bar => :baz)
+      #   allow(double).to receive_message_chain(:foo, :bar) { :baz }
       #
-      #     allow(double).to receive_message_chain("foo.bar") { :baz }
-      #     allow(double).to receive_message_chain(:foo, :bar => :baz)
-      #     allow(double).to receive_message_chain(:foo, :bar) { :baz }
+      #   # Given any of ^^ these three forms ^^:
+      #   double.foo.bar # => :baz
       #
-      #     # Given any of ^^ these three forms ^^:
-      #     double.foo.bar # => :baz
-      #
-      #     # Common use in Rails/ActiveRecord:
-      #     allow(Article).to receive_message_chain("recent.published") { [Article.new] }
+      #   # Common use in Rails/ActiveRecord:
+      #   allow(Article).to receive_message_chain("recent.published") { [Article.new] }
       #
       # @note If you disable the `:expect` syntax this method will be undefined.
 

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -510,17 +510,6 @@ module RSpec
           @actual_received_count += 1
         end
 
-        def fail_if_problematic_received_arg_mutations(received_arg_list)
-          return if @argument_list_matcher == ArgumentListMatcher::MATCH_ALL
-          return unless received_arg_list.has_mutations?
-
-          raise CannotSupportArgMutationsError,
-                "`have_received(...).with(...)` cannot be used when received " \
-                "message args have later been mutated. You can use a normal " \
-                "message expectation (`expect(...).to receive(...).with(...)`) " \
-                "instead."
-        end
-
       private
 
         def invoke_incrementing_actual_calls_by(increment, allowed_to_fail, parent_stub, *args, &block)

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -88,12 +88,7 @@ module RSpec
           @error_generator.raise_expectation_on_unstubbed_method(expected_method_name)
         end
 
-        @messages_received.each do |(actual_method_name, received_arg_list, _)|
-          if expectation.message == actual_method_name
-            expectation.fail_if_problematic_received_arg_mutations(received_arg_list)
-          end
-
-          args = received_arg_list.args
+        @messages_received.each do |(actual_method_name, args, _)|
           next unless expectation.matches?(actual_method_name, *args)
 
           expectation.safe_invoke(nil)
@@ -103,8 +98,7 @@ module RSpec
 
       # @private
       def check_for_unexpected_arguments(expectation)
-        @messages_received.each do |(method_name, received_arg_list, _)|
-          args = received_arg_list.args
+        @messages_received.each do |(method_name, args, _)|
           next unless expectation.matches_name_but_not_args(method_name, *args)
 
           raise_unexpected_message_args_error(expectation, *args)
@@ -144,11 +138,7 @@ module RSpec
 
       # @private
       def received_message?(method_name, *args, &block)
-        @messages_received.any? do |(received_method_name, received_arg_list, received_block)|
-          method_name == received_method_name &&
-            args == received_arg_list.args &&
-            block == received_block
-        end
+        @messages_received.any? { |array| array == [method_name, args, block] }
       end
 
       # @private
@@ -159,35 +149,7 @@ module RSpec
       # @private
       def record_message_received(message, *args, &block)
         @order_group.invoked SpecificMessage.new(object, message, args)
-        @messages_received << [message, ReceivedArgList.new(args), block]
-      end
-
-      class ReceivedArgList
-        attr_reader :args
-
-        def initialize(args)
-          @args          = args
-          @original_hash = hash_of(args)
-        end
-
-        def has_mutations?
-          @original_hash != hash_of(args)
-        end
-
-      private
-
-        def hash_of(arg)
-          arg.hash
-        rescue Exception
-          # While `Object#hash` is a built-in ruby method that we expect args to
-          # support, there's no guarantee that all args will. For example, a
-          # `BasicObject` instance will raise a `NoMethodError`. Given that
-          # we use the hash only to advise the user of a rare case we don't
-          # support involving mutations, it seems better to ignore this error
-          # and use a static value in its place (which will make us assume no
-          # mutation has occurred).
-          :failed_to_get_hash
-        end
+        @messages_received << [message, args, block]
       end
 
       # @private

--- a/lib/rspec/mocks/syntax.rb
+++ b/lib/rspec/mocks/syntax.rb
@@ -214,11 +214,10 @@ if defined?(BasicObject)
     # the end of the example.
     #
     # @example
-    #
-    #     logger = double('logger')
-    #     thing_that_logs = ThingThatLogs.new(logger)
-    #     logger.should_receive(:log)
-    #     thing_that_logs.do_something_that_logs_a_message
+    #   logger = double('logger')
+    #   thing_that_logs = ThingThatLogs.new(logger)
+    #   logger.should_receive(:log)
+    #   thing_that_logs.do_something_that_logs_a_message
     #
     # @note This is only available when you have enabled the `should` syntax.
     # @see RSpec::Mocks::ExampleMethods#expect
@@ -232,10 +231,9 @@ if defined?(BasicObject)
     # Tells the object to respond to the message with the specified value.
     #
     # @example
-    #
-    #     counter.stub(:count).and_return(37)
-    #     counter.stub(:count => 37)
-    #     counter.stub(:count) { 37 }
+    #   counter.stub(:count).and_return(37)
+    #   counter.stub(:count => 37)
+    #   counter.stub(:count) { 37 }
     #
     # @note This is only available when you have enabled the `should` syntax.
     # @see RSpec::Mocks::ExampleMethods#allow
@@ -269,10 +267,9 @@ if defined?(BasicObject)
     # implementation calls `foo.baz.bar`, the stub will not work.
     #
     # @example
-    #
-    #     double.stub_chain("foo.bar") { :baz }
-    #     double.stub_chain(:foo, :bar => :baz)
-    #     double.stub_chain(:foo, :bar) { :baz }
+    #   double.stub_chain("foo.bar") { :baz }
+    #   double.stub_chain(:foo, :bar => :baz)
+    #   double.stub_chain(:foo, :bar) { :baz }
     #
     #     # Given any of ^^ these three forms ^^:
     #     double.foo.bar # => :baz
@@ -311,15 +308,14 @@ class Class
   # class.
   #
   # @example
+  #   Car.any_instance.should_receive(:go)
+  #   race = Race.new
+  #   race.cars << Car.new
+  #   race.go # assuming this delegates to all of its cars
+  #           # this example would pass
   #
-  #     Car.any_instance.should_receive(:go)
-  #     race = Race.new
-  #     race.cars << Car.new
-  #     race.go # assuming this delegates to all of its cars
-  #             # this example would pass
-  #
-  #     Account.any_instance.stub(:balance) { Money.new(:USD, 25) }
-  #     Account.new.balance # => Money.new(:USD, 25))
+  #   Account.any_instance.stub(:balance) { Money.new(:USD, 25) }
+  #   Account.new.balance # => Money.new(:USD, 25))
   #
   # @return [Recorder]
   #

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -123,43 +123,6 @@ module RSpec
               expect(dbl).to have_received(:expected_method).with(:unexpected, :args)
             }.to raise_error(/with unexpected arguments/)
           end
-
-          context "when a passed arg is later mutated before the `have_received(...).with(...)` expectation" do
-            it 'gives the user a clear error since we cannot support mutations' do
-              dbl = spy
-              dbl.foo(arg = "bar")
-              arg << "bazz"
-
-              expect {
-                expect(dbl).to have_received(:foo).with("bar")
-              }.to raise_error(CannotSupportArgMutationsError)
-            end
-
-            it 'does not prevent `have_received` without `with`' do
-              dbl = spy
-              dbl.foo(arg = "bar")
-              arg << "bazz"
-
-              expect(dbl).to have_received(:foo)
-            end
-
-             it 'does not prevent `have_received(...).with(...)` for a different method that has had no arg mutations' do
-               dbl = spy
-               dbl.foo(arg = "foo")
-               arg << "foo"
-               dbl.bar("bar")
-
-               expect(dbl).to have_received(:bar).with("bar")
-             end
-          end
-
-          it 'does not blow up when objects that do not support `#hash` are passed as args', :if => defined?(::BasicObject) do
-            dbl = spy
-            dbl.foo(arg = ::BasicObject.new)
-            expect { arg.hash }.to raise_error(NoMethodError)
-
-            expect(dbl).to have_received(:foo).with(arg)
-          end
         end
 
         it 'generates a useful description' do

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -102,6 +102,26 @@ module RSpec
         end
       end
 
+      context "when the stubbed method is called" do
+        it "does not call any methods on the passed args, since that could mutate them", :issue => 892 do
+          recorder = Class.new(defined?(::BasicObject) ? ::BasicObject : ::Object) do
+            def called_methods
+              @called_methods ||= []
+            end
+
+            def method_missing(name, *)
+              called_methods << name
+              self
+            end
+          end.new
+
+          allow(@stub).to receive(:foo)
+          expect {
+            @stub.foo(recorder)
+          }.not_to change(recorder, :called_methods)
+        end
+      end
+
       context "stubbing with prepend", :if => Support::RubyFeatures.module_prepends_supported? do
         module ToBePrepended
           def value

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -27,7 +27,7 @@ module RSpec
         @stub = Object.new
       end
 
-      describe "using stub" do
+      describe "using `and_return`" do
         it "returns declared value when message is received" do
           allow(@instance).to receive(:msg).and_return(:return_value)
           expect(@instance.msg).to equal(:return_value)


### PR DESCRIPTION
Stop calling methods on args passed to a stubbed method.

Any method call may mutate an object, so we can't safely call anything on a passed argument.

This reverts the following PRs and commits:

* #871:
  * 8a0962a6b8a896b1f1f2806a1282f29cde7d2baa ("Reword comment to not use “external” twice.")
  * 52c69f1ef8ac2c0de5ec08c72df709593a6a8ba5 ("Just use `Array#hash`.")
* #868:
  * ed3fb3b1ac9e1187eeb44f4a68dd9878f9ce3ec6 ("Provide a clear error when received message args are mutated.")
  * fc9e9a59904ec52fa8e26e07ee65c41029ef18d0 ("Ignore arg mutations for method calls we are not concerned with.")

This adds notes to the docs about using mutated args with `have_received(…).with(…)`.

Fixes #892.

(Also, I noticed that our `@example` formatting could use some improvements so I did that real quick.  Later realized that I should have made that a separate PR but don't feel like putting the effort into splitting it...sorry).

/cc @xaviershay 