### PR TITLE
Provide a message if the wrong double is used.

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -104,9 +104,19 @@ module RSpec
       def raise_unimplemented_error(doubled_module, method_name, object)
         message = case object
                   when InstanceVerifyingDouble
-                    "the %s class does not implement the instance method: %s"
+                    "the %s class does not implement the instance method: %s" <<
+                      if ObjectMethodReference.for(doubled_module, method_name).implemented?
+                        ". Perhaps you meant to use `class_double` instead?"
+                      else
+                        ""
+                      end
                   when ClassVerifyingDouble
-                    "the %s class does not implement the class method: %s"
+                    "the %s class does not implement the class method: %s" <<
+                      if InstanceMethodReference.for(doubled_module, method_name).implemented?
+                        ". Perhaps you meant to use `instance_double` instead?"
+                      else
+                        ""
+                      end
                   else
                     "%s does not implement: %s"
                   end

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -28,6 +28,18 @@ module RSpec
         prevents { expect(o).to receive(:defined_instance_method) }
       end
 
+      USE_INSTANCE_DOUBLE_MSG = "Perhaps you meant to use `instance_double`"
+
+      it "suggests using `instance_double` when an instance method is stubbed" do
+        o = class_double("LoadedClass")
+        prevents(a_string_including(USE_INSTANCE_DOUBLE_MSG)) { allow(o).to receive(:defined_instance_method) }
+      end
+
+      it "doesn't suggest `instance_double` when a non-instance method is stubbed'" do
+        o = class_double("LoadedClass")
+        prevents(a_string_excluding(USE_INSTANCE_DOUBLE_MSG)) { allow(o).to receive(:undefined_instance_method) }
+      end
+
       it 'gives a descriptive error message for NoMethodError' do
         o = class_double("LoadedClass")
         expect {

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -28,6 +28,18 @@ module RSpec
         prevents { expect(o).to receive(:defined_class_method) }
       end
 
+      USE_CLASS_DOUBLE_MSG = "Perhaps you meant to use `class_double`"
+
+      it "suggests using `class_double` when a class method is stubbed" do
+        o = instance_double("LoadedClass")
+        prevents(a_string_including(USE_CLASS_DOUBLE_MSG)) { allow(o).to receive(:defined_class_method) }
+      end
+
+      it "doesn't suggest `class_double` when a non-class method is stubbed" do
+        o = instance_double("LoadedClass")
+        prevents(a_string_excluding(USE_CLASS_DOUBLE_MSG)) { allow(o).to receive(:undefined_class_method) }
+      end
+
       it 'allows `send` to be stubbed if it is defined on the class' do
         o = instance_double('LoadedClass')
         allow(o).to receive(:send).and_return("received")


### PR DESCRIPTION
If an undefined method is stubbed on an instance double, the error generator
will check to see if it is defined on the class level and provide a
message to indicate that this may be what was meant. It also does the
converse for class doubles and instance methods.

https://github.com/rspec/rspec-mocks/issues/838