### PR TITLE
Fixes issue 915 - displaying invalid counts instead of irrelevant arguments

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -32,6 +32,9 @@ module RSpec
           end
         end
       end
+
+      def unadvise(_)
+      end
     end
 
     # Represents an individual method stub or message expectation. The methods
@@ -457,6 +460,10 @@ module RSpec
 
         def advise(*args)
           similar_messages << args
+        end
+
+        def unadvise(args)
+          similar_messages.delete_if { |message| args.include?(message) }
         end
 
         def generate_error

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -104,9 +104,8 @@ module RSpec
         return if @messages_received.any? do |(method_name, args, _)|
                     !expectation.matches_name_but_not_args(method_name, *args)
                   end
-        unexpected_args = @messages_received.map { |_, args, _| args }
 
-        raise_unexpected_message_args_error(expectation, *unexpected_args)
+        raise_unexpected_message_args_error(expectation, *messages_arg_list)
       end
 
       # @private
@@ -146,6 +145,11 @@ module RSpec
       end
 
       # @private
+      def messages_arg_list
+        @messages_received.map { |_, args, _| args }
+      end
+
+      # @private
       def has_negative_expectation?(message)
         method_double_for(message).expectations.find { |expectation| expectation.negative_expectation_for?(message) }
       end
@@ -170,6 +174,7 @@ module RSpec
           end
           stub.invoke(nil, *args, &block)
         elsif expectation
+          expectation.unadvise(messages_arg_list)
           expectation.invoke(stub, *args, &block)
         elsif (expectation = find_almost_matching_expectation(message, *args))
           expectation.advise(*args) if null_object? unless expectation.expected_messages_received?

--- a/spec/rspec/mocks/once_counts_spec.rb
+++ b/spec/rspec/mocks/once_counts_spec.rb
@@ -45,6 +45,29 @@ module RSpec
           verify @double
         }.to raise_error(RSpec::Mocks::MockExpectationError)
       end
+
+      context "when called with the wrong number of times with the specified args and also called with different args" do
+        it "mentions the wrong call count in the failure message rather than the different args" do
+          allow(@double).to receive(:do_something) # allow any args...
+          expect(@double).to receive(:do_something).with(:args, 1).once
+
+          @double.do_something(:args, 2)
+          @double.do_something(:args, 1)
+
+          expect {
+            # we've grouped these lines because it should probably fail fast
+            # on the first line (since our expectation above only allows one
+            # call with these args), but currently it fails with a confusing
+            # message on verification, and ultimately we care more about
+            # what the message is than when it is raised. Still, it would be
+            # preferrable for the error to be triggered on the first line,
+            # so it'd be good to update this spec to enforce that once we
+            # get the failure message right.
+            @double.do_something(:args, 1)
+            verify @double
+          }.to fail_with(a_string_including("expected: 1 time", "received: 2 times"))
+        end
+      end
     end
   end
 end

--- a/spec/rspec/mocks/stubbed_message_expectations_spec.rb
+++ b/spec/rspec/mocks/stubbed_message_expectations_spec.rb
@@ -13,7 +13,13 @@ RSpec.describe "expection set on previously stubbed method" do
     dbl.foo('third')
     expect {
       verify dbl
-    }.to raise_error(%Q|Double "double" received :foo with unexpected arguments\n  expected: ("first")\n       got: ("second"), ("third")|)
+    }.to raise_error(
+      RSpec::Mocks::MockExpectationError,
+      a_string_including(
+        %Q|Double "double" received :foo with unexpected arguments|,
+        "expected: (\"first\")",
+        "got:","(\"second\")",
+               "(\"third\")"))
     reset dbl
   end
 
@@ -52,5 +58,17 @@ RSpec.describe "expection set on previously stubbed method" do
         expect(e.message).to include('expected: ("a", ["b"])', 'got: (["a"], "b")')
       }
     end
+
+    it 'distinguishes between duplicate individual values and arrays properly' do
+      dbl = double
+      allow(dbl).to receive(:foo).with('a', ['b'], 'b')
+
+      expect {
+        dbl.foo(['a'], 'b', 'b')
+      }.to raise_error { |e|
+        expect(e.message).to include('expected: ("a", ["b"], "b")', 'got: (["a"], "b", "b")')
+      }
+    end
+
   end
 end

--- a/spec/rspec/mocks/twice_counts_spec.rb
+++ b/spec/rspec/mocks/twice_counts_spec.rb
@@ -59,6 +59,23 @@ module RSpec
         }.to raise_error(RSpec::Mocks::MockExpectationError)
         reset @double
       end
+
+      context "when called with the wrong number of times with the specified args and also called with different args" do
+        it "mentions the wrong call count in the failure message rather than the different args" do
+          allow(@double).to receive(:do_something) # allow any args...
+          expect(@double).to receive(:do_something).with(:args, 1).twice
+
+          @double.do_something(:args, 2)
+          @double.do_something(:args, 1)
+          @double.do_something(:args, 2)
+          @double.do_something(:args, 1)
+
+          expect {
+            @double.do_something(:args, 1)
+            verify @double
+          }.to fail_with(a_string_including("expected: 2 times", "received: 3 times"))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Why?
Fix for issue #915 - Confusing failure message when other arguments involved with received messages. Invalid counts more relevant in situations where multiple arguments in play. 

# What Changed?
Previously, an exception was raised immediately after a received message did not match one of items in the argument list. Now the standard invalid count message is returned unless there is no match in the entire list. Tests by @myronmarston copied from #841 added in.




# What Else Changed?
(updated 04/03/2015 with code refactor, adding in suggestions from @myronmarston and @JonRowe)
- Took out new method and rolled it into existing `raise_unexpected_message_args_error` method
- DRY'd up some error methods by adding common code to `message_error` (name to generic?)
- Rolled up `received_arg_list` into `format_received_args` and setup to handle single/multiple messages with single/multiple arguments.
- Removed a few splat operators so a more standardized messages list can be sent for single and multiple messages.

(updated 04/05/2015)
- Added fix for 2nd part of ticket. Display errors fixed for expect to receive messages.
- A couple of different options on this one, so took the path of least resistance.  Added similar_messages to SimpleMessageExpectation should allow the removal of (defined?) check. Adding check for similar_messages.blank? is not necessary, but would reduce redundant calls to unadvise method. Open to suggestions if not matching existing patterns.

(updated 04/08/2015)
- Added no-op to SimpleMessageExpectation (This removed the previous complexity warning I was getting earlier, so I removed the rubocop disable I had to add in earlier)
- Using existing `format_args` instead of using new method
- Making distinctions between args and args_with_mulitple_calls for clarity. 