### PR TITLE
Prefer `anything == object` over `object == anything`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,9 @@ Bug Fixes:
   arguments. Previously it confusingly listed the arguments as being
   mis-matched (even when the double was allowed to receive with any
   args) rather than listing the count. (John Ceh, #918)
+* Fix `any_args`/`anything` support so that we avoid calling `obj == anything`
+  on user objects that may have improperly implemented `==` in a way that
+  raises errors. (Myron Marston, #924)
 
 ### 3.2.1 / 2015-02-23
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.2.0...v3.2.1)

--- a/lib/rspec/mocks/argument_list_matcher.rb
+++ b/lib/rspec/mocks/argument_list_matcher.rb
@@ -64,7 +64,7 @@ module RSpec
       def resolve_expected_args_based_on(actual_args)
         return [] if [ArgumentMatchers::NoArgsMatcher::INSTANCE] == expected_args
 
-        any_args_index = expected_args.index(ArgumentMatchers::AnyArgsMatcher::INSTANCE)
+        any_args_index = expected_args.index { |a| ArgumentMatchers::AnyArgsMatcher::INSTANCE == a }
         return expected_args unless any_args_index
 
         replace_any_args_with_splat_of_anything(any_args_index, actual_args.count)
@@ -81,10 +81,10 @@ module RSpec
       end
 
       def ensure_expected_args_valid!
-        if expected_args.count(ArgumentMatchers::AnyArgsMatcher::INSTANCE) > 1
+        if expected_args.count { |a| ArgumentMatchers::AnyArgsMatcher::INSTANCE == a } > 1
           raise ArgumentError, "`any_args` can only be passed to " \
                 "`with` once but you have passed it multiple times."
-        elsif expected_args.count > 1 && expected_args.include?(ArgumentMatchers::NoArgsMatcher::INSTANCE)
+        elsif expected_args.count > 1 && expected_args.any? { |a| ArgumentMatchers::NoArgsMatcher::INSTANCE == a }
           raise ArgumentError, "`no_args` can only be passed as a " \
                 "singleton argument to `with` (i.e. `with(no_args)`), " \
                 "but you have passed additional arguments."

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -321,6 +321,40 @@ module RSpec
         end
       end
 
+      context "handling objects with a wrong definition of `==` that raises errors for other types" do
+        Color = Struct.new(:r, :g, :b) do
+          def ==(other)
+            other.r == r && other.g == g && other.b == b
+          end
+        end
+
+        before(:context) do
+          expect { Color.new(0, 0, 0) == Object.new }.to raise_error(NoMethodError)
+        end
+
+        it 'matches against an equal instance of the same type' do
+          expect(a_double).to receive(:random_call).with(Color.new(0, 0, 0))
+          a_double.random_call(Color.new(0, 0, 0))
+        end
+
+        it 'fails when matched against an unequal instance of the same class', :reset do
+          expect(a_double).to receive(:random_call).with(Color.new(0, 0, 0))
+          expect { a_double.random_call(Color.new(0, 1, 0)) }.to fail
+        end
+
+        it 'can match multiple instances of the type against multiple equal instances of the type' do
+          expect(a_double).to receive(:random_call).with(
+            Color.new(0, 0, 0),
+            Color.new(0, 1, 0)
+          )
+
+          a_double.random_call(
+            Color.new(0, 0, 0),
+            Color.new(0, 1, 0)
+          )
+        end
+      end
+
       context "handling non-matcher arguments" do
         it "matches string against regexp" do
           expect(a_double).to receive(:random_call).with(/bcd/)


### PR DESCRIPTION
Many users have objects that implement `==` wrongly
in a way that can raise errors when given an object
of an unexpected type.  This avoids that situation
by checking equality with `anything` instead.

See rspec/rspec-expectations#732 for one case of this.