### PR TITLE
Avoid using bare raise_error

### DIFF
--- a/spec/rspec/mocks/and_yield_spec.rb
+++ b/spec/rspec/mocks/and_yield_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe RSpec::Mocks::Double do
             # foo is not called here
           end
 
-          expect { verify configured_eval_context }.to raise_error(RSpec::Mocks::MockExpectationError)
+          expect { verify configured_eval_context }.to fail
         end
 
       end
@@ -150,8 +150,8 @@ RSpec.describe RSpec::Mocks::Double do
             # foo is not called here
           end
 
-          expect { verify configured_eval_context }.to raise_error(RSpec::Mocks::MockExpectationError)
-          expect { verify yielded_arg }.to raise_error(RSpec::Mocks::MockExpectationError)
+          expect { verify configured_eval_context }.to fail
+          expect { verify yielded_arg }.to fail
         end
 
       end

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -160,7 +160,7 @@ module RSpec
           it "fails the spec with an expectation error when the arguments do not match" do
             expect do
               klass.new.foo(:param_one, :param_three)
-            end.to(raise_error(RSpec::Mocks::MockExpectationError))
+            end.to fail
           end
         end
 
@@ -584,14 +584,14 @@ module RSpec
               expect_any_instance_of(klass).to receive(:foo)
               klass.new
               verify_all
-            end.to raise_error(RSpec::Mocks::MockExpectationError, foo_expectation_error_message)
+            end.to fail_with foo_expectation_error_message
           end
 
           it "fails if no instance is created" do
             expect do
               expect_any_instance_of(klass).to receive(:foo).and_return(1)
               verify_all
-            end.to raise_error(RSpec::Mocks::MockExpectationError, foo_expectation_error_message)
+            end.to fail_with foo_expectation_error_message
           end
 
           it "fails if no instance is created and there are multiple expectations" do
@@ -599,7 +599,7 @@ module RSpec
               expect_any_instance_of(klass).to receive(:foo)
               expect_any_instance_of(klass).to receive(:bar)
               verify_all
-            end.to raise_error(RSpec::Mocks::MockExpectationError, 'Exactly one instance should have received the following message(s) but didn\'t: bar, foo')
+            end.to fail_with 'Exactly one instance should have received the following message(s) but didn\'t: bar, foo'
           end
 
           it "allows expectations on instances to take priority" do
@@ -626,7 +626,7 @@ module RSpec
 
                 instance_one.foo
                 instance_two.foo
-              end.to raise_error(RSpec::Mocks::MockExpectationError, /The message 'foo' was received by .*#{instance_two.object_id}.* but has already been received by #{instance_one.inspect}/)
+              end.to fail_with(/The message 'foo' was received by .*#{instance_two.object_id}.* but has already been received by #{instance_one.inspect}/)
             end
           end
 
@@ -637,7 +637,7 @@ module RSpec
                 expect(klass).to receive(:woot)
                 klass.new.foo
                 verify_all
-              end.to(raise_error(RSpec::Mocks::MockExpectationError) do |error|
+              end.to(fail do |error|
                 expect(error.message).not_to eq(existing_method_expectation_error_message)
               end)
             end
@@ -662,14 +662,14 @@ module RSpec
               expect_any_instance_of(klass).to receive(:existing_method)
               klass.new
               verify_all
-            end.to raise_error(RSpec::Mocks::MockExpectationError, existing_method_expectation_error_message)
+            end.to fail_with existing_method_expectation_error_message
           end
 
           it "fails if no instance is created" do
             expect do
               expect_any_instance_of(klass).to receive(:existing_method)
               verify_all
-            end.to raise_error(RSpec::Mocks::MockExpectationError, existing_method_expectation_error_message)
+            end.to fail_with existing_method_expectation_error_message
           end
 
           it "fails if no instance is created and there are multiple expectations" do
@@ -677,7 +677,7 @@ module RSpec
               expect_any_instance_of(klass).to receive(:existing_method)
               expect_any_instance_of(klass).to receive(:another_existing_method)
               verify_all
-            end.to raise_error(RSpec::Mocks::MockExpectationError, 'Exactly one instance should have received the following message(s) but didn\'t: another_existing_method, existing_method')
+            end.to fail_with 'Exactly one instance should have received the following message(s) but didn\'t: another_existing_method, existing_method'
           end
 
           context "after any one instance has received a message" do
@@ -695,7 +695,7 @@ module RSpec
 
                 instance_one.existing_method
                 instance_two.existing_method
-              end.to raise_error(RSpec::Mocks::MockExpectationError, /The message 'existing_method' was received by .*#{instance_two.object_id}.* but has already been received by #{instance_one.inspect}/)
+              end.to fail_with(/The message 'existing_method' was received by .*#{instance_two.object_id}.* but has already been received by #{instance_one.inspect}/)
             end
           end
         end
@@ -736,7 +736,7 @@ module RSpec
             expect do
               expect(instances[0].foo(:param_one, :param_two)).to eq(:result_one)
               expect(instances[1].foo(:param_three, :param_four)).to eq(:result_two)
-            end.to raise_error(RSpec::Mocks::MockExpectationError)
+            end.to fail
 
             # ignore the fact that should_receive expectations were not met
             instances.each { |instance| reset instance }
@@ -753,7 +753,7 @@ module RSpec
             instance = klass.new
             expect do
               instance.foo(:param_one, :param_three)
-            end.to raise_error(RSpec::Mocks::MockExpectationError)
+            end.to fail
 
             # ignore the fact that should_receive expectations were not met
             reset instance
@@ -771,7 +771,7 @@ module RSpec
               expect do
                 expect_any_instance_of(klass).to receive(:foo).once
                 verify_all
-              end.to raise_error(RSpec::Mocks::MockExpectationError, foo_expectation_error_message)
+              end.to fail_with foo_expectation_error_message
             end
 
             it "fails when an instance is declared but there are no invocations" do
@@ -779,7 +779,7 @@ module RSpec
                 expect_any_instance_of(klass).to receive(:foo).once
                 klass.new
                 verify_all
-              end.to raise_error(RSpec::Mocks::MockExpectationError, foo_expectation_error_message)
+              end.to fail_with foo_expectation_error_message
             end
 
             it "fails for more than one invocation" do
@@ -830,7 +830,7 @@ module RSpec
                 instance = klass.new
                 2.times { instance.foo }
                 verify instance
-              end.to raise_error(RSpec::Mocks::MockExpectationError)
+              end.to fail
             end
           end
 
@@ -847,7 +847,7 @@ module RSpec
                 instance = klass.new
                 2.times { instance.foo }
                 verify instance
-              end.to raise_error(RSpec::Mocks::MockExpectationError)
+              end.to fail
             end
 
             it "fails for n invocations where n > 3" do
@@ -872,7 +872,7 @@ module RSpec
                 instance = klass.new
                 2.times { instance.foo }
                 verify instance
-              end.to raise_error(RSpec::Mocks::MockExpectationError)
+              end.to fail
             end
 
             it "passes for n invocations where n > 3" do
@@ -929,7 +929,7 @@ module RSpec
                   expect_any_instance_of(klass).to receive(:foo).never
                   expect_any_instance_of(klass).to receive(:existing_method).and_return(5)
                   verify_all
-                end.to raise_error(RSpec::Mocks::MockExpectationError, existing_method_expectation_error_message)
+                end.to fail_with existing_method_expectation_error_message
               end
             end
           end
@@ -1195,7 +1195,7 @@ module RSpec
             expect_any_instance_of(klass).to receive(:existing_method)
             instance_one.existing_method
             instance_two.existing_method
-          end.to raise_error(RSpec::Mocks::MockExpectationError, /The message 'existing_method' was received by .*#{instance_two.object_id}.* but has already been received by #{instance_one.inspect}/)
+          end.to fail_with(/The message 'existing_method' was received by .*#{instance_two.object_id}.* but has already been received by #{instance_one.inspect}/)
         end
       end
 

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -776,7 +776,7 @@ module RSpec
               expect(@double).to receive(:foo).with('bar')
               expect do
                 @double.foo('baz')
-              end.to raise_error
+              end.to fail
               reset @double
             end
           end
@@ -788,7 +788,7 @@ module RSpec
               expect(@double).to receive(:foo).with(d1)
               expect do
                 @double.foo(d2)
-              end.to raise_error
+              end.to fail
               reset @double
             end
           end
@@ -800,7 +800,7 @@ module RSpec
               expect(@double).to receive(:foo).with(d1)
               expect do
                 @double.foo(d2)
-              end.to raise_error
+              end.to fail
               reset @double
             end
           end

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -41,7 +41,7 @@ module RSpec
           b = double('b')
           expect(a).to receive(:append).with(b)
           verify_all
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it 'allows string representation of methods in constructor' do
@@ -78,7 +78,7 @@ module RSpec
         expected_error_line = __LINE__; expect(@double).to receive(:wont_happen).with("x", 3)
         expect {
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError) { |e|
+        }.to fail { |e|
           # NOTE - this regexp ended w/ $, but jruby adds extra info at the end of the line
           expect(e.backtrace[0]).to match(/#{File.basename(__FILE__)}:#{expected_error_line}/)
         }
@@ -89,7 +89,7 @@ module RSpec
         expected_error_line = __LINE__; expect(@double).to receive(:wont_happen).with("x", 3)
         expect {
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError) { |e|
+        }.to fail { |e|
           # NOTE - this regexp ended w/ $, but jruby adds extra info at the end of the line
           expect(e.backtrace[0]).to match(/#{File.basename(__FILE__)}:#{expected_error_line}/)
         }
@@ -217,7 +217,7 @@ module RSpec
         expect(@double).to receive(:something).with("a","b","c").and_return("booh")
         expect {
           @double.something("a","d","c")
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")")
+        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")"
       end
 
       describe "even when a similar expectation with different arguments exist" do
@@ -227,7 +227,7 @@ module RSpec
           expect {
             @double.something("a","b","c")
             @double.something("z","x","g")
-          }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :something with unexpected arguments\n  expected: (\"z\", \"x\", \"c\")\n       got: (\"z\", \"x\", \"g\")")
+          }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (\"z\", \"x\", \"c\")\n       got: (\"z\", \"x\", \"g\")"
         end
       end
 
@@ -237,7 +237,7 @@ module RSpec
         expect {
           @double.something("a","d","c")
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")")
+        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")"
       end
 
       it "raises exception if args don't match when method called even when using null_object" do
@@ -246,7 +246,7 @@ module RSpec
         expect {
           @double.something("a","d","c")
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")")
+        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")"
       end
 
       describe 'with a method that has a default argument' do
@@ -257,14 +257,14 @@ module RSpec
           expect {
             @double.method_with_default_argument(nil)
             verify @double
-          }.to raise_error(RSpec::Mocks::MockExpectationError, a_string_starting_with("Double \"test double\" received :method_with_default_argument with unexpected arguments\n  expected: ({})\n       got: (nil)"))
+          }.to fail_with a_string_starting_with("Double \"test double\" received :method_with_default_argument with unexpected arguments\n  expected: ({})\n       got: (nil)")
         end
       end
 
       it "fails if unexpected method called" do
         expect {
           @double.something("a","b","c")
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received unexpected message :something with (\"a\", \"b\", \"c\")")
+        }.to fail_with "Double \"test double\" received unexpected message :something with (\"a\", \"b\", \"c\")"
       end
 
       it "uses block for expectation if provided" do
@@ -336,9 +336,7 @@ module RSpec
       it "fails right away when method defined as never is received" do
         expect(@double).to receive(:not_expected).never
         expect { @double.not_expected }.
-          to raise_error(RSpec::Mocks::MockExpectationError,
-                         %Q|(Double "test double").not_expected(no args)\n    expected: 0 times with any arguments\n    received: 1 time|
-        )
+          to fail_with %Q|(Double "test double").not_expected(no args)\n    expected: 0 times with any arguments\n    received: 1 time|
       end
 
       it "raises RuntimeError by default" do
@@ -389,7 +387,7 @@ module RSpec
         expect(@double).to receive(:something).with(2).and_raise(RuntimeError)
         expect {
           @double.something 1
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "throws when told to" do
@@ -412,14 +410,14 @@ module RSpec
         expect(@double).to receive(:something).with(no_args())
         expect {
           @double.something 1
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :something with unexpected arguments\n  expected: (no args)\n       got: (1)")
+        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (no args)\n       got: (1)"
       end
 
       it "fails when args are expected but none are received" do
         expect(@double).to receive(:something).with(1)
         expect {
           @double.something
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :something with unexpected arguments\n  expected: (1)\n       got: (no args)")
+        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (1)\n       got: (no args)"
       end
 
       it "returns value from block by default" do
@@ -523,7 +521,7 @@ module RSpec
         expect(@double).to receive(:yield_back).with(no_args()).once.and_yield('wha', 'zup')
         expect {
           @double.yield_back {|a|}
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" yielded |\"wha\", \"zup\"| to block with arity of 1")
+        }.to fail_with "Double \"test double\" yielded |\"wha\", \"zup\"| to block with arity of 1"
       end
 
       if kw_args_supported?
@@ -531,8 +529,7 @@ module RSpec
           expect(@double).to receive(:yield_back).and_yield(:x => 1, :y => 2)
           expect {
             eval("@double.yield_back { |x: 1| }")
-          }.to raise_error(RSpec::Mocks::MockExpectationError,
-                           'Double "test double" yielded |{:x=>1, :y=>2}| to block with optional keyword args (:x)')
+          }.to fail_with 'Double "test double" yielded |{:x=>1, :y=>2}| to block with optional keyword args (:x)'
         end
       end
 
@@ -543,14 +540,14 @@ module RSpec
         expect {
           c = []
           @double.yield_back {|a,b| c << [a, b]}
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" yielded |\"down\"| to block with arity of 2")
+        }.to fail_with "Double \"test double\" yielded |\"down\"| to block with arity of 2"
       end
 
       it "fails when calling yielding method without block" do
         expect(@double).to receive(:yield_back).with(no_args()).once.and_yield('wha', 'zup')
         expect {
           @double.yield_back
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" asked to yield |[\"wha\", \"zup\"]| but no block was passed")
+        }.to fail_with "Double \"test double\" asked to yield |[\"wha\", \"zup\"]| but no block was passed"
       end
 
       it "is able to double send" do
@@ -577,7 +574,7 @@ module RSpec
         verify @double
         expect {
           @double.foobar
-        }.to raise_error(RSpec::Mocks::MockExpectationError, %q|Double "test double" received unexpected message :foobar with (no args)|)
+        }.to fail_with %q|Double "test double" received unexpected message :foobar with (no args)|
       end
 
       it "restores objects to their original state on rspec_reset" do
@@ -608,7 +605,7 @@ module RSpec
       it "raises an error when a previously stubbed method has a negative expectation" do
         allow(@double).to receive(:msg).and_return(:stub_value)
         expect(@double).not_to receive(:msg)
-        expect { @double.msg(:arg) }.to raise_error(RSpec::Mocks::MockExpectationError)
+        expect { @double.msg(:arg) }.to fail
       end
 
       it "temporarily replaces a method stub on a non-double" do

--- a/spec/rspec/mocks/matchers/receive_message_chain_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_message_chain_spec.rb
@@ -123,7 +123,7 @@ module RSpec::Mocks::Matchers
           expect(object).to receive_message_chain(:to_a, :farce, :length => 3)
           object.to_a
           verify_all
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "raises when expect is used and all but the last message in the chain are called" do
@@ -131,7 +131,7 @@ module RSpec::Mocks::Matchers
           expect(object).to receive_message_chain(:foo, :bar, :baz)
           object.foo.bar
           verify_all
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "does not raise when expect is used and the entire chain is called" do
@@ -163,7 +163,7 @@ module RSpec::Mocks::Matchers
         expect {
           expect_any_instance_of(Object).to receive_message_chain(:to_a, :length => 3)
           verify_all
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "affects previously stubbed instances when `expect_any_instance_of` is called" do

--- a/spec/rspec/mocks/matchers/receive_messages_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_messages_spec.rb
@@ -81,7 +81,7 @@ module RSpec
       it "sets up multiple expectations" do
         expect(obj).to receive_messages(:a => 1, :b => 2)
         obj.a
-        expect { verify_all }.to raise_error RSpec::Mocks::MockExpectationError
+        expect { verify_all }.to fail
       end
 
       it 'fails with a sensible message' do
@@ -112,7 +112,7 @@ module RSpec
       it "sets up multiple expectations" do
         expect_any_instance_of(Object).to receive_messages(:a => 1, :b => 2)
         obj.a
-        expect { RSpec::Mocks.space.verify_all }.to raise_error RSpec::Mocks::MockExpectationError
+        expect { RSpec::Mocks.space.verify_all }.to fail
         RSpec::Mocks.space.reset_all
       end
 

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -152,7 +152,7 @@ module RSpec
 
           expect {
             verify_all
-          }.to raise_error(RSpec::Mocks::MockExpectationError)
+          }.to fail
         end
 
         it "reports the line number of expectation of unreceived message", :pending => options.include?(:does_not_report_line_num) do
@@ -449,7 +449,7 @@ module RSpec
             expect(dbl).to receive(:foo)
           end
 
-          expect { verify dbl }.to raise_error(RSpec::Mocks::MockExpectationError)
+          expect { verify dbl }.to fail
         end
 
         it 'supports `expect(...).not_to receive`' do

--- a/spec/rspec/mocks/mock_ordering_spec.rb
+++ b/spec/rspec/mocks/mock_ordering_spec.rb
@@ -41,7 +41,7 @@ module RSpec
         expect(@double).to receive(:two).ordered
         expect {
           @double.two
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :two out of order")
+        }.to fail_with "Double \"test double\" received :two out of order"
       end
 
       it "fails when messages are received out of order (3rd message 1st)" do
@@ -51,7 +51,7 @@ module RSpec
         @double.one
         expect {
           @double.three
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :three out of order")
+        }.to fail_with "Double \"test double\" received :three out of order"
       end
 
       it "fails when messages are received out of order (3rd message 2nd)" do
@@ -61,7 +61,7 @@ module RSpec
         @double.one
         expect {
           @double.three
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :three out of order")
+        }.to fail_with "Double \"test double\" received :three out of order"
       end
 
       it "fails when messages are out of order across objects" do
@@ -73,7 +73,7 @@ module RSpec
         a.one
         expect {
           a.three
-        }.to raise_error(RSpec::Mocks::MockExpectationError, "Double \"test double\" received :three out of order")
+        }.to fail_with "Double \"test double\" received :three out of order"
         reset a
         reset b
       end

--- a/spec/rspec/mocks/multiple_return_value_spec.rb
+++ b/spec/rspec/mocks/multiple_return_value_spec.rb
@@ -38,7 +38,7 @@ module RSpec
       it "fails when there are too few calls (if there is no stub)" do
         @double.do_something
         @double.do_something
-        expect { verify @double }.to raise_error
+        expect { verify @double }.to fail
       end
 
       it "fails when there are too many calls (if there is no stub)" do
@@ -46,7 +46,7 @@ module RSpec
         @double.do_something
         @double.do_something
         @double.do_something
-        expect { verify @double }.to raise_error
+        expect { verify @double }.to fail
       end
     end
 
@@ -116,7 +116,7 @@ module RSpec
       it "fails when called less than the specified number" do
         @double.do_something
         @double.do_something
-        expect { verify @double }.to raise_error
+        expect { verify @double }.to fail
       end
 
       it "fails fast when called greater than the specified number" do

--- a/spec/rspec/mocks/multiple_return_value_spec.rb
+++ b/spec/rspec/mocks/multiple_return_value_spec.rb
@@ -80,7 +80,7 @@ module RSpec
 
       it "fails when called less than the specified number" do
         expect(@double.do_something).to equal(11)
-        expect { verify @double }.to raise_error(RSpec::Mocks::MockExpectationError)
+        expect { verify @double }.to fail
       end
 
       context "when method is stubbed too" do
@@ -95,7 +95,7 @@ module RSpec
 
         it "fails when called less than the specified number" do
           expect(@double.do_something).to equal(11)
-          expect { verify @double }.to raise_error(RSpec::Mocks::MockExpectationError)
+          expect { verify @double }.to fail
         end
       end
     end

--- a/spec/rspec/mocks/null_object_double_spec.rb
+++ b/spec/rspec/mocks/null_object_double_spec.rb
@@ -63,7 +63,7 @@ module RSpec
         expect {
           expect(@double).to receive(:something)
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "ignores unexpected methods" do

--- a/spec/rspec/mocks/once_counts_spec.rb
+++ b/spec/rspec/mocks/once_counts_spec.rb
@@ -27,7 +27,7 @@ module RSpec
         expect(@double).to receive(:do_something).once.with("a", "b", "c")
         expect {
           @double.do_something("d", "e", "f")
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
         reset @double
       end
 
@@ -43,7 +43,7 @@ module RSpec
         expect(@double).to receive(:do_something).once
         expect {
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       context "when called with the wrong number of times with the specified args and also called with different args" do

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -13,14 +13,14 @@ module RSpec
         expect(object).to receive(:foo)
         expect do
           verify object
-        end.to raise_error(RSpec::Mocks::MockExpectationError, /\(#<Object:.*>\).foo/)
+        end.to fail_with(/\(#<Object:.*>\).foo/)
       end
 
       it "names the class in the failure message when expectation is on class" do
         expect(Object).to receive(:foo)
         expect {
           verify Object
-        }.to raise_error(RSpec::Mocks::MockExpectationError, /<Object \(class\)>/)
+        }.to fail_with(/<Object \(class\)>/)
       end
 
       it "does not conflict with @options in the object" do
@@ -78,7 +78,7 @@ module RSpec
         expect(object).to receive(:foobar).with(:test_param).and_return(1)
         expect {
           verify object
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "can accept the string form of a message for a positive message expectation" do
@@ -119,7 +119,7 @@ module RSpec
 
         expect {
           klazz.bar(2)
-        }.to raise_error(RSpec::Mocks::MockExpectationError, /MyClass/)
+        }.to fail_with(/MyClass/)
       end
 
       it "shares message expectations with clone" do
@@ -134,7 +134,7 @@ module RSpec
         expect(object).to receive(:foobar)
         duplicate = object.dup
         expect{ duplicate.foobar }.to raise_error(NoMethodError, /foobar/)
-        expect{ verify object }.to raise_error(RSpec::Mocks::MockExpectationError, /foobar/)
+        expect{ verify object }.to fail_with(/foobar/)
       end
     end
 

--- a/spec/rspec/mocks/partial_double_using_mocks_directly_spec.rb
+++ b/spec/rspec/mocks/partial_double_using_mocks_directly_spec.rb
@@ -29,14 +29,14 @@ module RSpec::Mocks
       expect(obj).to receive(:msg)
       expect {
         verify obj
-      }.to raise_error(RSpec::Mocks::MockExpectationError)
+      }.to fail
     end
 
     it "fails when message is received with incorrect args" do
       expect(obj).to receive(:msg).with(:correct_arg)
       expect {
         obj.msg(:incorrect_arg)
-      }.to raise_error(RSpec::Mocks::MockExpectationError)
+      }.to fail
       obj.msg(:correct_arg)
     end
 

--- a/spec/rspec/mocks/precise_counts_spec.rb
+++ b/spec/rspec/mocks/precise_counts_spec.rb
@@ -11,7 +11,7 @@ module RSpec
         @double.do_something
         expect {
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "fails fast when exactly n times method is called more than n times" do
@@ -28,7 +28,7 @@ module RSpec
         expect(@double).to receive(:do_something).exactly(3).times
         expect {
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "passes if exactly n times method is called exactly n times" do

--- a/spec/rspec/mocks/should_syntax_spec.rb
+++ b/spec/rspec/mocks/should_syntax_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Using the legacy should syntax" do
       expect(dbl.foo.bar.baz).to eq(17)
       expect {
         dbl.foo.baz.bar
-      }.to raise_error(RSpec::Mocks::MockExpectationError)
+      }.to fail
     end
 
     include_examples "fails in a before(:all) block" do
@@ -125,7 +125,7 @@ RSpec.describe "Using the legacy should syntax" do
       obj = Object.new
       expect {
         obj.unstub(:foo)
-      }.to raise_error(RSpec::Mocks::MockExpectationError)
+      }.to fail
     end
   end
 
@@ -133,7 +133,7 @@ RSpec.describe "Using the legacy should syntax" do
     it 'fails on verification if the message is not received' do
       dbl = double
       dbl.should_receive(:foo)
-      expect { verify_all }.to raise_error(RSpec::Mocks::MockExpectationError)
+      expect { verify_all }.to fail
     end
 
     it 'does not fail on verification if the message is received' do
@@ -194,7 +194,7 @@ RSpec.describe "Using the legacy should syntax" do
     it 'fails when the message is received' do
       with_unfulfilled_double do |dbl|
         dbl.should_not_receive(:foo)
-        expect { dbl.foo }.to raise_error(RSpec::Mocks::MockExpectationError)
+        expect { dbl.foo }.to fail
       end
     end
 
@@ -242,7 +242,7 @@ RSpec.describe "Using the legacy should syntax" do
     it 'can mock a method' do
       klass.any_instance.should_receive(:foo)
       klass.new
-      expect { verify_all }.to raise_error(RSpec::Mocks::MockExpectationError)
+      expect { verify_all }.to fail
     end
 
     it 'can get method objects for the fluent interface', :if => RUBY_VERSION.to_f > 1.8 do
@@ -443,7 +443,7 @@ RSpec.describe "Using the legacy should syntax" do
         it "raises a MockExpectationError if the method has not been stubbed" do
           expect {
             klass.any_instance.unstub(:existing_method)
-          }.to raise_error(RSpec::Mocks::MockExpectationError, 'The method `existing_method` was not stubbed or was already unstubbed')
+          }.to fail_with 'The method `existing_method` was not stubbed or was already unstubbed'
         end
 
         it 'does not get confused about string vs symbol usage for the message' do

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -519,7 +519,7 @@ module RSpec
         @stub.foo("baz")
         expect {
           @stub.foo("other")
-        }.to raise_error
+        }.to fail
       end
 
       it 'uses the correct stubbed response when responding to a mock expectation' do

--- a/spec/rspec/mocks/stubbed_message_expectations_spec.rb
+++ b/spec/rspec/mocks/stubbed_message_expectations_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "expection set on previously stubbed method" do
     dbl = double(:msg => nil)
     dbl.msg
     expect(dbl).to receive(:msg)
-    expect { verify dbl }.to raise_error(RSpec::Mocks::MockExpectationError)
+    expect { verify dbl }.to fail
   end
 
   it "outputs arguments of similar calls" do

--- a/spec/rspec/mocks/syntax_agnostic_message_matchers_spec.rb
+++ b/spec/rspec/mocks/syntax_agnostic_message_matchers_spec.rb
@@ -55,7 +55,7 @@ module RSpec
           subject.respond_to?(:basic)
         }.to(true)
 
-        expect { verify subject }.to raise_error(RSpec::Mocks::MockExpectationError)
+        expect { verify subject }.to fail
       end
 
       it "fails if never is specified and the message is called" do

--- a/spec/rspec/mocks/thrice_counts_spec.rb
+++ b/spec/rspec/mocks/thrice_counts_spec.rb
@@ -38,14 +38,14 @@ module RSpec
         @double.do_something
         expect {
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "fails when called with wrong args on the first call" do
         expect(@double).to receive(:do_something).thrice.with("1", 1)
         expect {
           @double.do_something(1, "1")
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
         reset @double
       end
 
@@ -54,7 +54,7 @@ module RSpec
         @double.do_something("1", 1)
         expect {
           @double.do_something(1, "1")
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
         reset @double
       end
 
@@ -64,7 +64,7 @@ module RSpec
         @double.do_something("1", 1)
         expect {
           @double.do_something(1, "1")
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
         reset @double
       end
     end

--- a/spec/rspec/mocks/twice_counts_spec.rb
+++ b/spec/rspec/mocks/twice_counts_spec.rb
@@ -40,14 +40,14 @@ module RSpec
         @double.do_something
         expect {
           verify @double
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
       end
 
       it "fails when called with wrong args on the first call" do
         expect(@double).to receive(:do_something).twice.with("1", 1)
         expect {
           @double.do_something(1, "1")
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
         reset @double
       end
 
@@ -56,7 +56,7 @@ module RSpec
         @double.do_something("1", 1)
         expect {
           @double.do_something(1, "1")
-        }.to raise_error(RSpec::Mocks::MockExpectationError)
+        }.to fail
         reset @double
       end
 

--- a/spec/rspec/mocks_spec.rb
+++ b/spec/rspec/mocks_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RSpec::Mocks do
       expect(foo).to receive(:bar)
       expect do
         RSpec::Mocks.verify
-      end.to raise_error(RSpec::Mocks::MockExpectationError)
+      end.to fail
 
       RSpec::Mocks.teardown # so the mocks aren't re-verified after this example
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,8 +55,7 @@ end
 
 module VerificationHelpers
   def prevents(msg = //, &block)
-    expect(&block).to \
-      raise_error(RSpec::Mocks::MockExpectationError, msg)
+    expect(&block).to fail_with msg
   end
 end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,11 +1,11 @@
 module RSpec
   module Matchers
-    def fail
-      raise_error(RSpec::Mocks::MockExpectationError)
+    def fail(&block)
+      raise_error(RSpec::Mocks::MockExpectationError, &block)
     end
 
-    def fail_with(*args)
-      raise_error(RSpec::Mocks::MockExpectationError, *args)
+    def fail_with(*args, &block)
+      raise_error(RSpec::Mocks::MockExpectationError, *args, &block)
     end
 
     def fail_including(*snippets)


### PR DESCRIPTION
We (or are going to) recommend people don't use a bare `raise_error` so we shouldn't either :D 