### PR TITLE
Issue 916 - Fixes bug for ordered spies and alternating calls

### DIFF
--- a/features/basics/spies.feature
+++ b/features/basics/spies.feature
@@ -125,5 +125,5 @@ Feature: Spies
       |           received: 2 times with any arguments                                                   |
       |                                                                                                  |
       |  2) An invitiation fails when an order constraint is not satisifed                               |
-      |     Failure/Error: expect(invitation).to have_received(:deliver).with("foo@example.com").ordered |
+      |     Failure/Error: expect(invitation).to have_received(:deliver).with("bar@example.com").ordered |
       |       Double "invitation" received :deliver out of order                                         |

--- a/lib/rspec/mocks/matchers/have_received.rb
+++ b/lib/rspec/mocks/matchers/have_received.rb
@@ -107,7 +107,11 @@ module RSpec
 
         def expected_messages_received_in_order?
           mock_proxy.replay_received_message_on @expectation, &@block
-          @expectation.expected_messages_received? && @expectation.ensure_expected_ordering_received!
+          if @expectation.ordered?
+            @expectation.ensure_expected_ordering_received! && @expectation.expected_messages_received?
+          else
+            @expectation.expected_messages_received? && @expectation.ensure_expected_ordering_received!
+          end
         end
 
         def mock_proxy

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -487,8 +487,8 @@ module RSpec
           )
         end
 
-        def raise_out_of_order_error
-          @error_generator.raise_out_of_order_error @message
+        def raise_out_of_order_error(message=nil)
+          @error_generator.raise_out_of_order_error(message || @message)
         end
 
         def additional_expected_calls

--- a/lib/rspec/mocks/order_group.rb
+++ b/lib/rspec/mocks/order_group.rb
@@ -41,7 +41,8 @@ module RSpec
       end
 
       def verify_invocation_order(expectation)
-        expectation.raise_out_of_order_error unless expectations_invoked_in_order?
+        message = @invocation_order[@index] ? @invocation_order[@index].message : nil
+        expectation.raise_out_of_order_error(message) unless expectations_invoked_in_order?
         true
       end
 
@@ -55,6 +56,10 @@ module RSpec
         @expectations.empty?
       end
 
+      def message_range
+        (@index..end_range)
+      end
+
     private
 
       def remaining_expectations
@@ -66,15 +71,27 @@ module RSpec
       end
 
       def invoked_expectations
-        @expectations.select { |e| e.ordered? && @invocation_order.include?(e) }
+        @expectations[order_range].select { |e| e.ordered? && @invocation_order.include?(e) }
       end
 
       def expected_invocations
-        @invocation_order.map { |invocation| expectation_for(invocation) }.compact
+        @invocation_order[order_range].map { |invocation| expectation_for(invocation) }.compact
       end
 
       def expectation_for(message)
-        @expectations.find { |e| message == e }
+        @expectations[order_range].find { |e| message == e }
+      end
+
+      def order_range
+        (start_range..end_range)
+      end
+
+      def start_range
+        @index - (@index.zero? ? 0 : 1)
+      end
+
+      def end_range
+        @expectations.size - 1
       end
     end
   end

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -88,7 +88,7 @@ module RSpec
           @error_generator.raise_expectation_on_unstubbed_method(expected_method_name)
         end
 
-        @messages_received.each do |(actual_method_name, args, _)|
+        @messages_received[with_range(expectation)].each do |(actual_method_name, args, _)|
           next unless expectation.matches?(actual_method_name, *args)
 
           expectation.safe_invoke(nil)
@@ -265,6 +265,10 @@ module RSpec
 
       def find_almost_matching_stub(method_name, *args)
         method_double_for(method_name).stubs.find { |stub| stub.matches_name_but_not_args(method_name, *args) }
+      end
+
+      def with_range(expectation)
+        expectation.expectation_count_type || !expectation.ordered? ? (0..-1) : @order_group.message_range
       end
     end
 

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -459,6 +459,73 @@ module RSpec
             }.to raise_error(/received :two out of order/m)
           end
 
+          context "Specifying ordering for calls that are interleaved with each other" do
+            it 'passes when using `have_received`' do
+              dbl = spy
+
+              dbl.one
+              dbl.one
+              dbl.two
+              dbl.one
+              dbl.two
+
+              expect(dbl).to have_received(:one).twice.ordered
+              expect(dbl).to have_received(:two).once.ordered
+              expect(dbl).to have_received(:one).once.ordered
+              expect(dbl).to have_received(:two).once.ordered
+            end
+
+            it 'fails when using `have_received` with out of order interleaved messages' do
+              dbl = spy
+
+              dbl.one
+              dbl.one
+              dbl.two
+              dbl.one
+              dbl.two
+
+              expect {
+                expect(dbl).to have_received(:two).once.ordered
+                expect(dbl).to have_received(:one).twice.ordered
+                expect(dbl).to have_received(:one).once.ordered
+                expect(dbl).to have_received(:two).once.ordered
+              }.to raise_error(/received :one out of order/m)
+            end
+
+            it 'passes when using `receive`' do
+              dbl = double
+
+              expect(dbl).to receive(:one).twice.ordered
+              expect(dbl).to receive(:two).once.ordered
+              expect(dbl).to receive(:one).once.ordered
+              expect(dbl).to receive(:two).once.ordered
+
+              dbl.one
+              dbl.one
+              dbl.two
+              dbl.one
+              dbl.two
+            end
+
+            it 'fails when using `receive` with out of order interleaved messages' do
+              pending "Getting expected 1 got 0 error instead of order error"
+              expect {
+                dbl = double
+
+                expect(dbl).to receive(:two).once.ordered
+                expect(dbl).to receive(:one).twice.ordered
+                expect(dbl).to receive(:one).once.ordered
+                expect(dbl).to receive(:two).once.ordered
+
+                dbl.one
+                dbl.one
+                dbl.two
+                dbl.one
+                dbl.two
+              }.to raise_error(/received :one out of order/m)
+            end
+          end
+
           context "when used with `with`" do
             before do
               the_dbl.one(1)


### PR DESCRIPTION
# Why?
Fix for Issue #916 - Spies were not tracking order properly and raised error incorrectly for alternating groups. It was including all messages/expectations/invocations when evaluating order on each expectation.

# What Changed?
Added limiting range for messages/expectations/invocations for order checks so just current expectations from group are evaluated. Tests by @myronmarston in issue added in.
