### PR TITLE
Improve how doubles are represented in failures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ Enhancements:
   level methods. (Tim Wade, #896, #908)
 * Improve mock expectation failure messages so that it combines both
   number of times and the received arguments in the output. (John Ceh, #918)
+* Improve how test doubles are represented in failure messages.
+  (@sivagollapalli, Myron Marston, #932)
 
 Bug Fixes:
 

--- a/features/basics/scope.feature
+++ b/features/basics/scope.feature
@@ -92,8 +92,8 @@ Feature: Scope
       """
     When I run `rspec leak_test_double_spec.rb`
     Then it should fail with the following output:
-      | 2 examples, 1 failure                                                                                                      |
-      |                                                                                                                            |
-      |  1) Account keeps track of the balance                                                                                     |
-      |     Failure/Error: self.class.logger.log("Credited $#{amount}")                                                            |
-      |       Double "Logger" was originally created in one example but has leaked into another example and can no longer be used. |
+      | 2 examples, 1 failure                                                                                                         |
+      |                                                                                                                               |
+      |  1) Account keeps track of the balance                                                                                        |
+      |     Failure/Error: self.class.logger.log("Credited $#{amount}")                                                               |
+      |       #<Double "Logger"> was originally created in one example but has leaked into another example and can no longer be used. |

--- a/features/basics/spies.feature
+++ b/features/basics/spies.feature
@@ -79,7 +79,7 @@ Feature: Spies
       """
         2) failure when the message has not been received for a partial double
            Failure/Error: expect(Invitation).to have_received(:deliver)
-             (<Invitation (class)>).deliver(*(any args))
+             (Invitation (class)).deliver(*(any args))
                  expected: 1 time with any arguments
                  received: 0 times with any arguments
       """
@@ -116,14 +116,14 @@ Feature: Spies
       """
     When I run `rspec setting_constraints_spec.rb --order defined`
     Then it should fail with the following output:
-      | 4 examples, 2 failures                                                                           |
-      |                                                                                                  |
-      |  1) An invitiation fails when a count constraint is not satisfied                                |
-      |     Failure/Error: expect(invitation).to have_received(:deliver).at_least(3).times               |
-      |       (Double "invitation").deliver(*(any args))                                                 |
-      |           expected: at least 3 times with any arguments                                          |
-      |           received: 2 times with any arguments                                                   |
-      |                                                                                                  |
-      |  2) An invitiation fails when an order constraint is not satisifed                               |
-      |     Failure/Error: expect(invitation).to have_received(:deliver).with("foo@example.com").ordered |
-      |       Double "invitation" received :deliver out of order                                         |
+      | 4 examples, 2 failures                                                                              |
+      |                                                                                                     |
+      |  1) An invitiation fails when a count constraint is not satisfied                                   |
+      |     Failure/Error: expect(invitation).to have_received(:deliver).at_least(3).times                  |
+      |       (Double "invitation").deliver(*(any args))                                                    |
+      |           expected: at least 3 times with any arguments                                             |
+      |           received: 2 times with any arguments                                                      |
+      |                                                                                                     |
+      |  2) An invitiation fails when an order constraint is not satisifed                                  |
+      |     Failure/Error: expect(invitation).to have_received(:deliver).with("foo@example.com").ordered    |
+      |       #<Double "invitation"> received :deliver out of order                                         |

--- a/features/basics/test_doubles.feature
+++ b/features/basics/test_doubles.feature
@@ -23,7 +23,7 @@ Feature: Test Doubles
      When I run `rspec double_spec.rb`
      Then it should fail with:
       """
-      Double "Some Collaborator" received unexpected message :foo with (no args)
+      #<Double "Some Collaborator"> received unexpected message :foo with (no args)
       """
 
   Scenario: A hash can be used to define allowed messages and return values

--- a/features/configuring_responses/yielding.feature
+++ b/features/configuring_responses/yielding.feature
@@ -37,7 +37,7 @@ Feature: Yielding
      When I run `rspec no_caller_block_spec.rb`
      Then it should fail with:
       """
-      Double asked to yield |[2, 3]| but no block was passed
+      #<Double (anonymous)> asked to yield |[2, 3]| but no block was passed
       """
 
   Scenario: It fails when the caller's block does not accept the provided arguments
@@ -54,7 +54,7 @@ Feature: Yielding
      When I run `rspec arg_mismatch_spec.rb`
      Then it should fail with:
       """
-      Double yielded |2, 3| to block with arity of 1
+      #<Double (anonymous)> yielded |2, 3| to block with arity of 1
       """
 
   Scenario: Yield multiple times

--- a/features/outside_rspec/minitest.feature
+++ b/features/outside_rspec/minitest.feature
@@ -65,16 +65,16 @@ Feature: Integrate with Minitest
       """
      When I run `ruby -Itest test/rspec_mocks_test.rb`
      Then it should fail with the following output:
-       |   1) Error:                                                       |
-       | RSpecMocksTest#test_failing_negative_expectation:                 |
-       | RSpec::Mocks::MockExpectationError: (Double).message(no args)     |
-       |     expected: 0 times with any arguments                          |
-       |     received: 1 time                                              |
-       |                                                                   |
-       |   2) Error:                                                       |
-       | RSpecMocksTest#test_failing_positive_expectation:                 |
-       | RSpec::Mocks::MockExpectationError: (Double).message(*(any args)) |
-       |     expected: 1 time with any arguments                           |
-       |     received: 0 times with any arguments                          |
-       |                                                                   |
-       |  4 runs, 0 assertions, 0 failures, 2 errors, 0 skips              |
+       |   1) Error:                                                                   |
+       | RSpecMocksTest#test_failing_negative_expectation:                             |
+       | RSpec::Mocks::MockExpectationError: (Double (anonymous)).message(no args)     |
+       |     expected: 0 times with any arguments                                      |
+       |     received: 1 time                                                          |
+       |                                                                               |
+       |   2) Error:                                                                   |
+       | RSpecMocksTest#test_failing_positive_expectation:                             |
+       | RSpec::Mocks::MockExpectationError: (Double (anonymous)).message(*(any args)) |
+       |     expected: 1 time with any arguments                                       |
+       |     received: 0 times with any arguments                                      |
+       |                                                                               |
+       |  4 runs, 0 assertions, 0 failures, 2 errors, 0 skips                          |

--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -39,12 +39,12 @@ Feature: Matching arguments
       """
     When I run `rspec basic_example_spec.rb`
     Then it should fail with the following output:
-      | 2 examples, 1 failure                            |
-      |                                                  |
-      | Failure/Error: dbl.foo(1, nil, "other")          |
-      |   Double received :foo with unexpected arguments |
-      |     expected: (1, anything, /bar/)               |
-      |          got: (1, nil, "other")                  |
+      | 2 examples, 1 failure                                           |
+      |                                                                 |
+      | Failure/Error: dbl.foo(1, nil, "other")                         |
+      |   #<Double (anonymous)> received :foo with unexpected arguments |
+      |     expected: (1, anything, /bar/)                              |
+      |          got: (1, nil, "other")                                 |
 
   Scenario: Using a RSpec matcher
     Given a file named "rspec_matcher_spec.rb" with:
@@ -64,12 +64,12 @@ Feature: Matching arguments
       """
     When I run `rspec rspec_matcher_spec.rb`
     Then it should fail with the following output:
-      | 2 examples, 1 failure                               |
-      |                                                     |
-      | Failure/Error: dbl.foo([1, 3])                      |
-      | Double received :foo with unexpected arguments      |
-      | expected: (a collection containing exactly 1 and 2) |
-      | got: ([1, 3])                                       |
+      | 2 examples, 1 failure                                         |
+      |                                                               |
+      | Failure/Error: dbl.foo([1, 3])                                |
+      | #<Double (anonymous)> received :foo with unexpected arguments |
+      | expected: (a collection containing exactly 1 and 2)           |
+      | got: ([1, 3])                                                 |
 
   Scenario: Using a custom matcher
     Given a file named "custom_matcher_spec.rb" with:
@@ -93,12 +93,12 @@ Feature: Matching arguments
       """
     When I run `rspec custom_matcher_spec.rb`
     Then it should fail with the following output:
-      | 2 examples, 1 failure                            |
-      |                                                  |
-      | Failure/Error: dbl.foo(13)                       |
-      |   Double received :foo with unexpected arguments |
-      |     expected: (a multiple of 3)                  |
-      |          got: (13)                               |
+      | 2 examples, 1 failure                                           |
+      |                                                                 |
+      | Failure/Error: dbl.foo(13)                                      |
+      |   #<Double (anonymous)> received :foo with unexpected arguments |
+      |     expected: (a multiple of 3)                                 |
+      |          got: (13)                                              |
 
   Scenario: Responding differently based on the arguments
     Given a file named "responding_differently_spec.rb" with:

--- a/features/setting_constraints/message_order.feature
+++ b/features/setting_constraints/message_order.feature
@@ -56,8 +56,8 @@ Feature: Message Order
     Then the examples should all fail, producing the following output:
       |  1) Constraining order fails when messages are received out of order on one collaborator   |
       |     Failure/Error: collaborator_1.step_2                                                   |
-      |       Double "Collaborator 1" received :step_2 out of order                                |
+      |       #<Double "Collaborator 1"> received :step_2 out of order                             |
       |                                                                                            |
       |  2) Constraining order fails when messages are received out of order between collaborators |
       |     Failure/Error: collaborator_2.step_2                                                   |
-      |       Double "Collaborator 2" received :step_2 out of order                                |
+      |       #<Double "Collaborator 2"> received :step_2 out of order                             |

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -2,6 +2,7 @@ require 'rspec/support'
 RSpec::Support.require_rspec_support 'caller_filter'
 RSpec::Support.require_rspec_support 'warnings'
 RSpec::Support.require_rspec_support 'ruby_features'
+RSpec::Support.require_rspec_support 'object_inspector'
 
 RSpec::Support.define_optimized_require_for_rspec(:mocks) { |f| require_relative f }
 

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -248,16 +248,11 @@ module RSpec
       end
 
       def intro
-        if @name
-          "Double #{@name.inspect}"
-        elsif TestDouble === @target
-          "Double"
-        elsif Class === @target
-          "<#{@target.inspect} (class)>"
-        elsif @target
-          @target
-        else
-          "nil"
+        case @target
+        when TestDouble then TestDoubleFormatter.format(@target, :unwrapped)
+        when Class      then "<#{@target.inspect} (class)>"
+        when NilClass   then "nil"
+        else @target
         end
       end
 

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -80,7 +80,7 @@ module RSpec
       def raise_expectation_error(message, expected_received_count, argument_list_matcher, actual_received_count, expectation_count_type, args)
         expected_part = expected_part_of_expectation_error(expected_received_count, expectation_count_type, argument_list_matcher)
         received_part = received_part_of_expectation_error(actual_received_count, args)
-        __raise "(#{intro}).#{message}#{format_args(args)}\n    #{expected_part}\n    #{received_part}"
+        __raise "(#{intro(:unwrapped)}).#{message}#{format_args(args)}\n    #{expected_part}\n    #{received_part}"
       end
       # rubocop:enable Style/ParameterLists
 
@@ -246,11 +246,14 @@ module RSpec
         RSpec::Support::Differ.new(:color => RSpec::Mocks.configuration.color?)
       end
 
-      def intro
+      def intro(unwrapped=false)
         case @target
-        when TestDouble then TestDoubleFormatter.format(@target, :unwrapped)
-        when Class      then "<#{@target.inspect} (class)>"
-        when NilClass   then "nil"
+        when TestDouble then TestDoubleFormatter.format(@target, unwrapped)
+        when Class then
+          formatted = "#{@target.inspect} (class)"
+          return formatted if unwrapped
+          "#<#{formatted}>"
+        when NilClass then "nil"
         else @target
         end
       end

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -34,9 +34,8 @@ module RSpec
     class ErrorGenerator
       attr_writer :opts
 
-      def initialize(target, name)
+      def initialize(target)
         @target = target
-        @name = name
       end
 
       # @private

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -14,11 +14,10 @@ module RSpec
       end
 
       # @private
-      def initialize(object, order_group, name=nil, options={})
+      def initialize(object, order_group, options={})
         @object = object
         @order_group = order_group
-        @name = name
-        @error_generator = ErrorGenerator.new(object, name)
+        @error_generator = ErrorGenerator.new(object)
         @messages_received = []
         @options = options
         @null_object = false

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -129,6 +129,10 @@ module RSpec
     # A generic test double object. `double`, `instance_double` and friends
     # return an instance of this.
     class Double
+      RSpec::Support::ObjectInspector.register TestDouble do |dbl|
+        "Double (#{dbl.instance_variable_get('@name')})"
+      end
+
       include TestDouble
     end
   end

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -39,7 +39,7 @@ module RSpec
 
       # @private
       def inspect
-        "#<#{self.class}:#{'0x%x' % object_id} @name=#{@name.inspect}>"
+        TestDoubleFormatter.format(self)
       end
 
       # @private
@@ -165,10 +165,6 @@ module RSpec
           name.inspect
         end
       end
-    end
-
-    RSpec::Support::ObjectInspector.register TestDouble do |dbl|
-      TestDoubleFormatter.format(dbl)
     end
   end
 end

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -91,7 +91,7 @@ module RSpec
         # https://github.com/jruby/jruby/issues/1398
         visibility = proxy.visibility_for(message)
         if visibility == :private || visibility == :protected
-          ErrorGenerator.new(self, @name).raise_non_public_error(
+          ErrorGenerator.new(self).raise_non_public_error(
             message, visibility
           )
         end
@@ -112,12 +112,12 @@ module RSpec
       end
 
       def __build_mock_proxy(order_group)
-        TestDoubleProxy.new(self, order_group, @name)
+        TestDoubleProxy.new(self, order_group)
       end
 
       def __raise_expired_error
         return false unless @__expired
-        ErrorGenerator.new(self, @name).raise_expired_test_double_error
+        ErrorGenerator.new(self).raise_expired_test_double_error
       end
 
       def initialize_copy(other)

--- a/lib/rspec/mocks/verifying_double.rb
+++ b/lib/rspec/mocks/verifying_double.rb
@@ -62,8 +62,6 @@ module RSpec
         possible_name = args.first
         name = if String === possible_name || Symbol === possible_name
                  args.shift
-               else
-                 @description
                end
 
         super(name, *args)
@@ -79,11 +77,6 @@ module RSpec
     class InstanceVerifyingDouble
       include TestDouble
       include VerifyingDouble
-
-      def initialize(doubled_module, *args)
-        @description = "#{doubled_module.description} (instance)"
-        super
-      end
 
       def __build_mock_proxy(order_group)
         VerifyingProxy.new(self, order_group, @name,
@@ -107,11 +100,6 @@ module RSpec
       end
 
     private
-
-      def initialize(doubled_module, *args)
-        @description = doubled_module.description
-        super
-      end
 
       def __build_mock_proxy(order_group)
         VerifyingProxy.new(self, order_group, @name,

--- a/lib/rspec/mocks/verifying_double.rb
+++ b/lib/rspec/mocks/verifying_double.rb
@@ -79,7 +79,7 @@ module RSpec
       include VerifyingDouble
 
       def __build_mock_proxy(order_group)
-        VerifyingProxy.new(self, order_group, @name,
+        VerifyingProxy.new(self, order_group,
                            @doubled_module,
                            InstanceMethodReference
         )
@@ -102,7 +102,7 @@ module RSpec
     private
 
       def __build_mock_proxy(order_group)
-        VerifyingProxy.new(self, order_group, @name,
+        VerifyingProxy.new(self, order_group,
                            @doubled_module,
                            ObjectMethodReference
         )

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -56,8 +56,8 @@ module RSpec
     class VerifyingProxy < TestDoubleProxy
       include VerifyingProxyMethods
 
-      def initialize(object, order_group, name, doubled_module, method_reference_class)
-        super(object, order_group, name)
+      def initialize(object, order_group, doubled_module, method_reference_class)
+        super(object, order_group)
         @object                 = object
         @doubled_module         = doubled_module
         @method_reference_class = method_reference_class

--- a/spec/rspec/mocks/diffing_spec.rb
+++ b/spec/rspec/mocks/diffing_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
         expect(d).to receive(:foo).with("some string\nline2")
         expect {
           d.foo("this other string")
-        }.to fail_with("Double \"double\" received :foo with unexpected arguments\n  expected: (\"some string\\nline2\")\n       got: (\"this other string\")\nDiff:\n@@ -1,3 +1,2 @@\n-some string\n-line2\n+this other string\n")
+        }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: (\"some string\\nline2\")\n       got: (\"this other string\")\nDiff:\n@@ -1,3 +1,2 @@\n-some string\n-line2\n+this other string\n")
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
         expect(d).to receive(:foo).with("some string\nline2", "some other string")
         expect {
           d.foo("this other string")
-        }.to fail_with("Double \"double\" received :foo with unexpected arguments\n  expected: (\"some string\\nline2\", \"some other string\")\n       got: (\"this other string\")\nDiff:\n@@ -1,3 +1,2 @@\n-some string\\nline2\n-some other string\n+this other string\n")
+        }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: (\"some string\\nline2\", \"some other string\")\n       got: (\"this other string\")\nDiff:\n@@ -1,3 +1,2 @@\n-some string\\nline2\n-some other string\n+this other string\n")
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
         expect(d).to receive(:foo).with(expected_hash)
         expect {
           d.foo(:bad => :hash)
-        }.to fail_with("Double \"double\" received :foo with unexpected arguments\n  expected: (#{expected_hash.inspect})\n       got: (#{actual_hash.inspect})\nDiff:\n@@ -1,2 +1,2 @@\n-[#{expected_hash.inspect}]\n+[#{actual_hash.inspect}]\n")
+        }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: (#{expected_hash.inspect})\n       got: (#{actual_hash.inspect})\nDiff:\n@@ -1,2 +1,2 @@\n-[#{expected_hash.inspect}]\n+[#{actual_hash.inspect}]\n")
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
         expect(d).to receive(:foo).with([:a, :b, :c])
         expect {
           d.foo([])
-        }.to fail_with("Double \"double\" received :foo with unexpected arguments\n  expected: ([:a, :b, :c])\n       got: ([])\nDiff:\n@@ -1,2 +1,2 @@\n-[[:a, :b, :c]]\n+[[]]\n")
+        }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: ([:a, :b, :c])\n       got: ([])\nDiff:\n@@ -1,2 +1,2 @@\n-[[:a, :b, :c]]\n+[[]]\n")
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
           expect(d).to receive(:foo).with(collab)
           expect {
             d.foo([])
-          }.to fail_with("Double \"double\" received :foo with unexpected arguments\n  expected: (#{collab_inspect})\n       got: ([])\nDiff:\n@@ -1,2 +1,2 @@\n-[#{collab_inspect}]\n+[[]]\n")
+          }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: (#{collab_inspect})\n       got: ([])\nDiff:\n@@ -1,2 +1,2 @@\n-[#{collab_inspect}]\n+[[]]\n")
         end
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
           expect(d).to receive(:foo).with(collab)
           expect {
             d.foo([:a, :b])
-          }.to fail_with("Double \"double\" received :foo with unexpected arguments\n  expected: (#{collab_description})\n       got: ([:a, :b])\nDiff:\n@@ -1,2 +1,2 @@\n-[\"#{collab_description}\"]\n+[[:a, :b]]\n")
+          }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: (#{collab_description})\n       got: ([:a, :b])\nDiff:\n@@ -1,2 +1,2 @@\n-[\"#{collab_description}\"]\n+[[:a, :b]]\n")
         end
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
           expect(d).to receive(:foo).with(collab)
           expect {
             d.foo([:a, :b])
-          }.to fail_with("Double \"double\" received :foo with unexpected arguments\n  expected: (#{collab_inspect})\n       got: ([:a, :b])\nDiff:\n@@ -1,2 +1,2 @@\n-[#{collab_pp}]\n+[[:a, :b]]\n")
+          }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: (#{collab_inspect})\n       got: ([:a, :b])\nDiff:\n@@ -1,2 +1,2 @@\n-[#{collab_pp}]\n+[[:a, :b]]\n")
         end
       end
     end

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -19,7 +19,7 @@ module RSpec
 
       it "hides internals in its inspect representation" do
         m = double('cup')
-        expect(m.inspect).to match(/#<RSpec::Mocks::Double:0x[a-f0-9.]+ @name="cup">/)
+        expect(m.inspect).to eq('#<Double "cup">')
       end
 
       it 'does not blow up when resetting standard object methods' do

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -14,7 +14,7 @@ module RSpec
 
       it "uses 'Double' in failure messages" do
         dbl = double('name')
-        expect { dbl.foo }.to raise_error(/Double "name" received/)
+        expect { dbl.foo }.to raise_error(/#<Double "name"> received/)
       end
 
       it "hides internals in its inspect representation" do
@@ -217,7 +217,7 @@ module RSpec
         expect(@double).to receive(:something).with("a","b","c").and_return("booh")
         expect {
           @double.something("a","d","c")
-        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")"
+        }.to fail_with "#<Double \"test double\"> received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")"
       end
 
       describe "even when a similar expectation with different arguments exist" do
@@ -227,7 +227,7 @@ module RSpec
           expect {
             @double.something("a","b","c")
             @double.something("z","x","g")
-          }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (\"z\", \"x\", \"c\")\n       got: (\"z\", \"x\", \"g\")"
+          }.to fail_with "#<Double \"test double\"> received :something with unexpected arguments\n  expected: (\"z\", \"x\", \"c\")\n       got: (\"z\", \"x\", \"g\")"
         end
       end
 
@@ -237,7 +237,7 @@ module RSpec
         expect {
           @double.something("a","d","c")
           verify @double
-        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")"
+        }.to fail_with "#<Double \"test double\"> received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")"
       end
 
       it "raises exception if args don't match when method called even when using null_object" do
@@ -246,7 +246,7 @@ module RSpec
         expect {
           @double.something("a","d","c")
           verify @double
-        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")"
+        }.to fail_with "#<Double \"test double\"> received :something with unexpected arguments\n  expected: (\"a\", \"b\", \"c\")\n       got: (\"a\", \"d\", \"c\")"
       end
 
       describe 'with a method that has a default argument' do
@@ -257,14 +257,14 @@ module RSpec
           expect {
             @double.method_with_default_argument(nil)
             verify @double
-          }.to fail_with a_string_starting_with("Double \"test double\" received :method_with_default_argument with unexpected arguments\n  expected: ({})\n       got: (nil)")
+          }.to fail_with a_string_starting_with("#<Double \"test double\"> received :method_with_default_argument with unexpected arguments\n  expected: ({})\n       got: (nil)")
         end
       end
 
       it "fails if unexpected method called" do
         expect {
           @double.something("a","b","c")
-        }.to fail_with "Double \"test double\" received unexpected message :something with (\"a\", \"b\", \"c\")"
+        }.to fail_with "#<Double \"test double\"> received unexpected message :something with (\"a\", \"b\", \"c\")"
       end
 
       it "uses block for expectation if provided" do
@@ -410,14 +410,14 @@ module RSpec
         expect(@double).to receive(:something).with(no_args())
         expect {
           @double.something 1
-        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (no args)\n       got: (1)"
+        }.to fail_with "#<Double \"test double\"> received :something with unexpected arguments\n  expected: (no args)\n       got: (1)"
       end
 
       it "fails when args are expected but none are received" do
         expect(@double).to receive(:something).with(1)
         expect {
           @double.something
-        }.to fail_with "Double \"test double\" received :something with unexpected arguments\n  expected: (1)\n       got: (no args)"
+        }.to fail_with "#<Double \"test double\"> received :something with unexpected arguments\n  expected: (1)\n       got: (no args)"
       end
 
       it "returns value from block by default" do
@@ -521,7 +521,7 @@ module RSpec
         expect(@double).to receive(:yield_back).with(no_args()).once.and_yield('wha', 'zup')
         expect {
           @double.yield_back {|a|}
-        }.to fail_with "Double \"test double\" yielded |\"wha\", \"zup\"| to block with arity of 1"
+        }.to fail_with "#<Double \"test double\"> yielded |\"wha\", \"zup\"| to block with arity of 1"
       end
 
       if kw_args_supported?
@@ -529,7 +529,7 @@ module RSpec
           expect(@double).to receive(:yield_back).and_yield(:x => 1, :y => 2)
           expect {
             eval("@double.yield_back { |x: 1| }")
-          }.to fail_with 'Double "test double" yielded |{:x=>1, :y=>2}| to block with optional keyword args (:x)'
+          }.to fail_with '#<Double "test double"> yielded |{:x=>1, :y=>2}| to block with optional keyword args (:x)'
         end
       end
 
@@ -540,14 +540,14 @@ module RSpec
         expect {
           c = []
           @double.yield_back {|a,b| c << [a, b]}
-        }.to fail_with "Double \"test double\" yielded |\"down\"| to block with arity of 2"
+        }.to fail_with "#<Double \"test double\"> yielded |\"down\"| to block with arity of 2"
       end
 
       it "fails when calling yielding method without block" do
         expect(@double).to receive(:yield_back).with(no_args()).once.and_yield('wha', 'zup')
         expect {
           @double.yield_back
-        }.to fail_with "Double \"test double\" asked to yield |[\"wha\", \"zup\"]| but no block was passed"
+        }.to fail_with "#<Double \"test double\"> asked to yield |[\"wha\", \"zup\"]| but no block was passed"
       end
 
       it "is able to double send" do
@@ -574,7 +574,7 @@ module RSpec
         verify @double
         expect {
           @double.foobar
-        }.to fail_with %q|Double "test double" received unexpected message :foobar with (no args)|
+        }.to fail_with %q|#<Double "test double"> received unexpected message :foobar with (no args)|
       end
 
       it "restores objects to their original state on rspec_reset" do
@@ -731,14 +731,14 @@ module RSpec
           double = double("Foo")
           expect { double.to_str }.to raise_error(
             RSpec::Mocks::MockExpectationError,
-            'Double "Foo" received unexpected message :to_str with (no args)')
+            '#<Double "Foo"> received unexpected message :to_str with (no args)')
         end
       end
 
       describe "double created with no name" do
         it "does not use a name in a failure message" do
           double = double()
-          expect {double.foo}.to raise_error.with_message(a_string_including("Double (anonymous) received"))
+          expect {double.foo}.to raise_error.with_message(a_string_including("#<Double (anonymous)> received"))
         end
 
         it "does respond to initially stubbed methods" do

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -738,7 +738,7 @@ module RSpec
       describe "double created with no name" do
         it "does not use a name in a failure message" do
           double = double()
-          expect {double.foo}.to raise_error(/Double received/)
+          expect {double.foo}.to raise_error.with_message(a_string_including("Double (anonymous) received"))
         end
 
         it "does respond to initially stubbed methods" do

--- a/spec/rspec/mocks/formatting_spec.rb
+++ b/spec/rspec/mocks/formatting_spec.rb
@@ -76,16 +76,16 @@ RSpec.describe "Test doubles format well in failure messages" do
     end
   end
 
-  describe "`object_double(:foo)`" do
+  describe "`object_double([])`" do
     context "with a name" do
-      specify '#<ObjectDouble(:foo) "Name">' do
-        expect(object_double(:foo, "Name")).to format_in_failures_as('#<ObjectDouble(:foo) "Name">')
+      specify '#<ObjectDouble([]) "Name">' do
+        expect(object_double([], "Name")).to format_in_failures_as('#<ObjectDouble([]) "Name">')
       end
     end
 
     context "without a name" do
-      specify '#<ObjectDouble(:foo) (anonymous)>' do
-        expect(object_double(:foo)).to format_in_failures_as('#<ObjectDouble(:foo) (anonymous)>')
+      specify '#<ObjectDouble([]) (anonymous)>' do
+        expect(object_double([])).to format_in_failures_as('#<ObjectDouble([]) (anonymous)>')
       end
     end
   end

--- a/spec/rspec/mocks/formatting_spec.rb
+++ b/spec/rspec/mocks/formatting_spec.rb
@@ -2,6 +2,8 @@ require 'rspec/matchers/fail_matchers'
 require 'support/doubled_classes'
 
 RSpec.describe "Test doubles format well in failure messages" do
+  include RSpec::Matchers::FailMatchers
+
   RSpec::Matchers.define :format_in_failures_as do |expected|
     match do |dbl|
       values_match?(expected, actual_formatting(dbl))
@@ -86,5 +88,22 @@ RSpec.describe "Test doubles format well in failure messages" do
         expect(object_double(:foo)).to format_in_failures_as('#<ObjectDouble(:foo) (anonymous)>')
       end
     end
+  end
+
+  it 'formats the doubles when they appear in data structures and diffs' do
+    allow(RSpec::Expectations.configuration).to receive(:color?).and_return(false)
+
+    foo = double("Foo")
+    bar = double("Bar")
+
+    expect {
+      expect([foo]).to include(bar)
+    }.to fail_with(<<-EOS.gsub(/^\s+\|/, ''))
+      |expected [#<Double "Foo">] to include #<Double "Bar">
+      |Diff:
+      |@@ -1,2 +1,2 @@
+      |-[#<Double "Bar">]
+      |+[#<Double "Foo">]
+    EOS
   end
 end

--- a/spec/rspec/mocks/formatting_spec.rb
+++ b/spec/rspec/mocks/formatting_spec.rb
@@ -1,0 +1,90 @@
+require 'rspec/matchers/fail_matchers'
+require 'support/doubled_classes'
+
+RSpec.describe "Test doubles format well in failure messages" do
+  RSpec::Matchers.define :format_in_failures_as do |expected|
+    match do |dbl|
+      values_match?(expected, actual_formatting(dbl))
+    end
+
+    def actual_formatting(double)
+      expect(1).to eq(double)
+    rescue RSpec::Expectations::ExpectationNotMetError => e
+      e.message[/expected: (.*)$/, 1]
+    else
+      raise "Did not fail as expected"
+    end
+  end
+
+  describe "`double`" do
+    context "with a name" do
+      specify '#<Double "Name">' do
+        expect(double "Book").to format_in_failures_as('#<Double "Book">')
+      end
+
+      it 'formats the name as a symbol if that was how it was provided' do
+        expect(double :book).to format_in_failures_as('#<Double :book>')
+      end
+    end
+
+    context "without a name" do
+      specify '#<Double (anonymous)>' do
+        expect(double).to format_in_failures_as('#<Double (anonymous)>')
+      end
+    end
+
+    it 'avoids sending `instance_variable_get` to the double as it may be stubbed' do
+      dbl = double("Book")
+      expect(dbl).not_to receive(:instance_variable_get)
+      expect(dbl).to format_in_failures_as('#<Double "Book">')
+    end
+  end
+
+  describe "`instance_double(SomeClass)`" do
+    context "with a name" do
+      specify '#<InstanceDouble(SomeClass) "Name">' do
+        expect(instance_double(LoadedClass, "Book")).to format_in_failures_as('#<InstanceDouble(LoadedClass) "Book">')
+      end
+    end
+
+    context "without a name" do
+      specify '#<InstanceDouble(SomeClass) (anonymous)>' do
+        expect(instance_double(LoadedClass)).to format_in_failures_as('#<InstanceDouble(LoadedClass) (anonymous)>')
+      end
+    end
+
+    it 'avoids sending `instance_variable_get` to the double as it may be stubbed' do
+      dbl = instance_double(LoadedClass, "Book")
+      expect(dbl).not_to receive(:instance_variable_get)
+      expect(dbl).to format_in_failures_as('#<InstanceDouble(LoadedClass) "Book">')
+    end
+  end
+
+  describe "`class_double(SomeClass)`" do
+    context "with a name" do
+      specify '#<ClassDouble(SomeClass) "Name">' do
+        expect(class_double(LoadedClass, "Book")).to format_in_failures_as('#<ClassDouble(LoadedClass) "Book">')
+      end
+    end
+
+    context "without a name" do
+      specify '#<ClassDouble(SomeClass) (anonymous)>' do
+        expect(class_double(LoadedClass)).to format_in_failures_as('#<ClassDouble(LoadedClass) (anonymous)>')
+      end
+    end
+  end
+
+  describe "`object_double(:foo)`" do
+    context "with a name" do
+      specify '#<ObjectDouble(:foo) "Name">' do
+        expect(object_double(:foo, "Name")).to format_in_failures_as('#<ObjectDouble(:foo) "Name">')
+      end
+    end
+
+    context "without a name" do
+      specify '#<ObjectDouble(:foo) (anonymous)>' do
+        expect(object_double(:foo)).to format_in_failures_as('#<ObjectDouble(:foo) (anonymous)>')
+      end
+    end
+  end
+end

--- a/spec/rspec/mocks/mock_ordering_spec.rb
+++ b/spec/rspec/mocks/mock_ordering_spec.rb
@@ -41,7 +41,7 @@ module RSpec
         expect(@double).to receive(:two).ordered
         expect {
           @double.two
-        }.to fail_with "Double \"test double\" received :two out of order"
+        }.to fail_with "#<Double \"test double\"> received :two out of order"
       end
 
       it "fails when messages are received out of order (3rd message 1st)" do
@@ -51,7 +51,7 @@ module RSpec
         @double.one
         expect {
           @double.three
-        }.to fail_with "Double \"test double\" received :three out of order"
+        }.to fail_with "#<Double \"test double\"> received :three out of order"
       end
 
       it "fails when messages are received out of order (3rd message 2nd)" do
@@ -61,7 +61,7 @@ module RSpec
         @double.one
         expect {
           @double.three
-        }.to fail_with "Double \"test double\" received :three out of order"
+        }.to fail_with "#<Double \"test double\"> received :three out of order"
       end
 
       it "fails when messages are out of order across objects" do
@@ -73,7 +73,7 @@ module RSpec
         a.one
         expect {
           a.three
-        }.to fail_with "Double \"test double\" received :three out of order"
+        }.to fail_with "#<Double \"test double\"> received :three out of order"
         reset a
         reset b
       end

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -20,7 +20,7 @@ module RSpec
         expect(Object).to receive(:foo)
         expect {
           verify Object
-        }.to fail_with(/<Object \(class\)>/)
+        }.to fail_with(/Object \(class\)/)
       end
 
       it "does not conflict with @options in the object" do

--- a/spec/rspec/mocks/stubbed_message_expectations_spec.rb
+++ b/spec/rspec/mocks/stubbed_message_expectations_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "expection set on previously stubbed method" do
     }.to raise_error(
       RSpec::Mocks::MockExpectationError,
       a_string_including(
-        %Q|Double "double" received :foo with unexpected arguments|,
+        %Q|#<Double "double"> received :foo with unexpected arguments|,
         "expected: (\"first\")",
         "got:","(\"second\")",
                "(\"third\")"))

--- a/spec/rspec/mocks/test_double_spec.rb
+++ b/spec/rspec/mocks/test_double_spec.rb
@@ -48,11 +48,6 @@ module RSpec
           end
         end
       end
-
-      it "register itself with ObjectInspector" do
-        foobar = double('FooBar')
-        expect(RSpec::Support::ObjectInspector.inspect(foobar)).to eq("Double (FooBar)")
-      end
     end
   end
 end

--- a/spec/rspec/mocks/test_double_spec.rb
+++ b/spec/rspec/mocks/test_double_spec.rb
@@ -48,6 +48,11 @@ module RSpec
           end
         end
       end
+
+      it "register itself with ObjectInspector" do
+        foobar = double('FooBar')
+        expect(RSpec::Support::ObjectInspector.inspect(foobar)).to eq("Double (FooBar)")
+      end
     end
   end
 end

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -44,7 +44,7 @@ module RSpec
         o = class_double("LoadedClass")
         expect {
           o.defined_private_class_method
-        }.to raise_error(NoMethodError, /Double "LoadedClass"/)
+        }.to raise_error(NoMethodError, a_string_including("ClassDouble(LoadedClass)"))
       end
 
       it 'checks that stubbed methods are invoked with the correct arity' do

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_not_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_not_loaded_spec.rb
@@ -13,7 +13,7 @@ module RSpec
         o = class_double("NonLoadedClass")
         expect {
           o.foo
-        }.to fail_including('Double "NonLoadedClass"')
+        }.to fail_including('ClassDouble(NonLoadedClass)')
       end
 
       it 'allows any method to be stubbed' do

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -51,7 +51,7 @@ module RSpec
         expect {
           o.defined_private_method
         }.to raise_error(NoMethodError,
-                           /Double "LoadedClass \(instance\)"/)
+                         a_string_including("InstanceDouble(LoadedClass)"))
       end
 
       it 'does not allow dynamic methods to be expected' do
@@ -195,7 +195,7 @@ module RSpec
         it "includes the double's name in a private method error" do
           expect {
             obj.rand
-          }.to raise_error(NoMethodError, %r{private.*Double "LoadedClass \(instance\)"})
+          }.to raise_error(NoMethodError, a_string_including("private", "InstanceDouble(LoadedClass)"))
         end
 
         it 'reports what public messages it responds to accurately' do

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_not_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_not_loaded_spec.rb
@@ -9,11 +9,11 @@ module RSpec
         RSpec::Mocks.configuration.verify_doubled_constant_names = false
       end
 
-      it 'includes the double name in errors for unexpected messages' do
+      it 'includes the doubled module in errors for unexpected messages' do
         o = instance_double("NonLoadedClass")
         expect {
           o.foo
-        }.to fail_including('Double "NonLoadedClass (instance)"')
+        }.to fail_including('InstanceDouble(NonLoadedClass)')
       end
 
       it 'allows any instance method to be stubbed' do

--- a/spec/rspec/mocks/verifying_doubles/naming_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/naming_spec.rb
@@ -26,55 +26,55 @@ module RSpec
     end
 
     RSpec.describe 'Verified double naming' do
-      shared_examples "a named verifying double" do |default_name|
+      shared_examples "a named verifying double" do |type_desc|
         context "when a name is given as a string" do
           subject { create_double("LoadedClass", "foo") }
-          it { is_expected.to fail_expectations_as('Double "foo"') }
+          it { is_expected.to fail_expectations_as(%Q{#{type_desc}(LoadedClass) "foo"}) }
         end
 
         context "when a name is given as a symbol" do
           subject { create_double("LoadedClass", :foo) }
-          it { is_expected.to fail_expectations_as('Double :foo') }
+          it { is_expected.to fail_expectations_as(%Q{#{type_desc}(LoadedClass) :foo}) }
         end
 
         context "when no name is given" do
           subject { create_double("LoadedClass") }
-          it { is_expected.to fail_expectations_as("Double \"#{default_name}\"") }
+          it { is_expected.to fail_expectations_as(%Q{#{type_desc}(LoadedClass) (anonymous)}) }
         end
       end
 
       describe "instance_double" do
-        it_behaves_like "a named verifying double", "LoadedClass (instance)" do
+        it_behaves_like "a named verifying double", "InstanceDouble" do
           alias :create_double :instance_double
         end
       end
 
       describe "instance_spy" do
-        it_behaves_like "a named verifying double", "LoadedClass (instance)" do
+        it_behaves_like "a named verifying double", "InstanceDouble" do
           alias :create_double :instance_spy
         end
       end
 
       describe "class_double" do
-        it_behaves_like "a named verifying double", "LoadedClass" do
+        it_behaves_like "a named verifying double", "ClassDouble" do
           alias :create_double :class_double
         end
       end
 
       describe "class_spy" do
-        it_behaves_like "a named verifying double", "LoadedClass" do
+        it_behaves_like "a named verifying double", "ClassDouble" do
           alias :create_double :class_spy
         end
       end
 
       describe "object_double" do
-        it_behaves_like "a named verifying double", "LoadedClass" do
+        it_behaves_like "a named verifying double", "ObjectDouble" do
           alias :create_double :object_double
         end
       end
 
       describe "object_spy" do
-        it_behaves_like "a named verifying double", "LoadedClass" do
+        it_behaves_like "a named verifying double", "ObjectDouble" do
           alias :create_double :object_spy
         end
       end


### PR DESCRIPTION
Supersedes #920 and fixes rspec/rspec-expectations#688.