### PR TITLE
Fix typo in receive example description.

### DIFF
--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -175,7 +175,7 @@ module RSpec
       end
 
       shared_examples "an expect syntax negative expectation" do
-        it 'sets up a negaive message expectation that passes if the message is not received' do
+        it 'sets up a negative message expectation that passes if the message is not received' do
           wrapped.not_to receive(:foo)
           verify_all
         end


### PR DESCRIPTION
Just remembered spotting this when researching an issue that I think is closed now.