### PR TITLE
Benchmark and optimise allocations

### DIFF
--- a/benchmarks/allocations/1_object_1000_mocks.rb
+++ b/benchmarks/allocations/1_object_1000_mocks.rb
@@ -1,0 +1,76 @@
+require_relative "helper"
+symbols = (1..1000).map {|x| :"#{x}"}
+
+benchmark_allocations do
+  o = Object.new
+  symbols.each do |sym|
+    expect(o).to receive(sym)
+  end
+
+  symbols.each do |sym|
+    o.send(sym)
+  end
+
+  RSpec::Mocks.space.verify_all
+  RSpec::Mocks.space.reset_all
+end
+
+__END__
+As of commit 9ee3e3adb529113bf1cc75cc4424d014f880dc47:
+
+                     class_plus                       count
+----------------------------------------------------  -----
+Array                                                 22003
+Proc                                                   3001
+RubyVM::Env                                            3001
+Array<Symbol>                                          2000
+String                                                 2000
+Hash                                                   1002
+RSpec::Mocks::ExpectationTarget                        1000
+Enumerator                                             1000
+RSpec::Mocks::Matchers::Receive                        1000
+Array<Fixnum>                                          1000
+RSpec::Mocks::InstanceMethodStasher                    1000
+RSpec::Mocks::MethodDouble                             1000
+Array<NilClass>                                        1000
+RSpec::Mocks::MessageExpectation                       1000
+Array<RSpec::Mocks::MethodDouble,Symbol>               1000
+Array<Array>                                           1000
+Array<RSpec::Mocks::ArgumentMatchers::NoArgsMatcher>   1000
+Array<Symbol,Array,NilClass>                           1000
+RSpec::Mocks::Proxy::SpecificMessage                   1000
+RSpec::Mocks::Implementation                           1000
+Array<Class,Module>                                       1
+RSpec::Mocks::PartialDoubleProxy                          1
+RSpec::Mocks::ErrorGenerator                              1
+Array<RSpec::Mocks::PartialDoubleProxy>                   1
+
+
+After PR #936:
+
+                     class_plus                       count
+----------------------------------------------------  -----
+Array                                                 21003
+RubyVM::Env                                            3001
+Proc                                                   3001
+String                                                 2000
+RSpec::Mocks::InstanceMethodStasher                    1000
+RSpec::Mocks::Matchers::Receive                        1000
+RSpec::Mocks::ExpectationTarget                        1000
+RSpec::Mocks::Implementation                           1000
+RSpec::Mocks::MessageExpectation                       1000
+RSpec::Mocks::MethodDouble                             1000
+Array<Symbol>                                          1000
+Array<RSpec::Mocks::MethodDouble,Symbol>               1000
+Array<Array>                                           1000
+Enumerator                                             1000
+Array<RSpec::Mocks::ArgumentMatchers::NoArgsMatcher>   1000
+Array<Symbol,Array,NilClass>                           1000
+RSpec::Mocks::Proxy::SpecificMessage                   1000
+Array<NilClass>                                        1000
+Array<Fixnum>                                          1000
+Hash                                                      2
+RSpec::Mocks::PartialDoubleProxy                          1
+Array<RSpec::Mocks::PartialDoubleProxy>                   1
+RSpec::Mocks::ErrorGenerator                              1
+Array<Class,Module>                                       1

--- a/benchmarks/allocations/helper.rb
+++ b/benchmarks/allocations/helper.rb
@@ -1,0 +1,17 @@
+$LOAD_PATH.unshift File.expand_path("../../../lib", __FILE__)
+require "allocation_stats"
+require 'rspec/mocks/standalone'
+
+def benchmark_allocations(burn: 1)
+  stats = AllocationStats.new(burn: burn).trace do
+    yield
+  end
+
+  columns = if ENV['DETAIL']
+              [:sourcefile, :sourceline, :class_plus]
+            else
+              [:class_plus]
+            end
+
+  puts stats.allocations(alias_paths: true).group_by(*columns).from_pwd.sort_by_size.to_text
+end

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -176,6 +176,11 @@ module RSpec
       def and_yield(*args, &block)
         raise_already_invoked_error_if_necessary(__method__)
         yield @eval_context = Object.new if block
+
+        # Initialize args to yield now that it's being used, see also: comment
+        # in constructor.
+        @args_to_yield ||= []
+
         @args_to_yield << args
         self.initial_implementation_action = AndYieldImplementation.new(@args_to_yield, @eval_context, @error_generator)
         self
@@ -370,7 +375,10 @@ module RSpec
           @expectation_type = type
           @ordered = false
           @at_least = @at_most = @exactly = nil
-          @args_to_yield = []
+
+          # Initialized to nil so that we don't allocate an array for every
+          # mock or stub. See also comment in `and_yield`.
+          @args_to_yield = nil
           @failed_fast = nil
           @eval_context = nil
           @yield_receiver_to_implementation_block = false

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -45,7 +45,7 @@ module RSpec
 
       # @private
       def configure_method
-        @original_visibility = [visibility, method_name]
+        @original_visibility = visibility
         @method_stasher.stash unless @method_is_proxied
         define_proxy_method
       end
@@ -101,7 +101,7 @@ module RSpec
         return unless @original_visibility &&
           MethodReference.method_defined_at_any_visibility?(object_singleton_class, @method_name)
 
-        object_singleton_class.__send__(*@original_visibility)
+        object_singleton_class.__send__(@original_visibility, method_name)
       end
 
       # @private

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -45,8 +45,10 @@ module RSpec
         nil
       end
 
+      DEFAULT_MESSAGE_EXPECTATION_OPTS = {}.freeze
+
       # @private
-      def add_message_expectation(method_name, opts={}, &block)
+      def add_message_expectation(method_name, opts=DEFAULT_MESSAGE_EXPECTATION_OPTS, &block)
         location = opts.fetch(:expected_from) { CallerFilter.first_non_rspec_line }
         meth_double = method_double_for(method_name)
 


### PR DESCRIPTION
This was allocating linear hashes per mock. Now it allocates at most
one in the execution of the whole test suite, the default hash is a
constant.

WIP, but here's an initial optimisation. I'll do as many as I can and get this cleaned up by the end of next weekend.