### PR TITLE
Rename verifying double callback and expand to partial doubles.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,9 @@ Enhancements:
   number of times and the received arguments in the output. (John Ceh, #918)
 * Improve how test doubles are represented in failure messages.
   (@sivagollapalli, Myron Marston, #932)
+* Rename `RSpec::Mocks::Configuration#when_declaring_verifying_double` to
+  `RSpec::Mocks::Configuration#before_verifying_doubles` and utilise when
+  verifying partial doubles. (Jon Rowe, #940)
 
 Bug Fixes:
 

--- a/features/verifying_doubles/dynamic_classes.feature
+++ b/features/verifying_doubles/dynamic_classes.feature
@@ -94,14 +94,14 @@ Feature: Dynamic classes
     And a file named "spec/fake_record_helper.rb" with:
       """ruby
       RSpec.configuration.mock_with(:rspec) do |config|
-        config.when_declaring_verifying_double do |reference|
+        config.before_verifying_doubles do |reference|
           reference.target.define_attribute_methods
         end
       end
       #
       # or you can use:
       #
-      # RSpec::Mocks.configuration.when_declaring_verifying_double do |reference|
+      # RSpec::Mocks.configuration.before_verifying_doubles do |reference|
       #   reference.target.define_attribute_methods
       # end
       """

--- a/lib/rspec/mocks/configuration.rb
+++ b/lib/rspec/mocks/configuration.rb
@@ -103,17 +103,18 @@ module RSpec
       # Provides a way to perform customisations when verifying doubles.
       #
       # @example
-      #  RSpec::Mocks.configuration.when_declaring_verifying_double do |ref|
+      #  RSpec::Mocks.configuration.before_verifying_doubles do |ref|
       #    ref.some_method!
       #  end
-      def when_declaring_verifying_double(&block)
-        verifying_double_declaration_callbacks << block
+      def before_verifying_doubles(&block)
+        verifying_double_callbacks << block
       end
+      alias :when_declaring_verifying_double :before_verifying_doubles
 
       # @api private
       # Returns an array of blocks to call when verifying doubles
-      def verifying_double_declaration_callbacks
-        @verifying_double_declaration_callbacks ||= []
+      def verifying_double_callbacks
+        @verifying_double_callbacks ||= []
       end
 
       def transfer_nested_constants?

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -402,7 +402,7 @@ module RSpec
                 "Disable check with `verify_doubled_constant_names` configuration option."
         end
 
-        RSpec::Mocks.configuration.verifying_double_declaration_callbacks.each do |block|
+        RSpec::Mocks.configuration.verifying_double_callbacks.each do |block|
           block.call(ref)
         end
 

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -98,6 +98,10 @@ module RSpec
         @method_doubles = Hash.new do |h, k|
           h[k] = VerifyingExistingMethodDouble.for(object, k, self)
         end
+
+        RSpec::Mocks.configuration.verifying_double_callbacks.each do |block|
+          block.call @doubled_module
+        end
       end
 
       def method_reference

--- a/spec/rspec/mocks/configuration_spec.rb
+++ b/spec/rspec/mocks/configuration_spec.rb
@@ -178,9 +178,9 @@ module RSpec
           block = proc { |ref| ref }
           block2 = proc { |ref| ref }
           RSpec.configuration.mock_with :rspec do |config|
-            config.when_declaring_verifying_double(&block)
+            config.before_verifying_doubles(&block)
             config.when_declaring_verifying_double(&block2)
-            expect(config.verifying_double_declaration_callbacks).to eq [block, block2]
+            expect(config.verifying_double_callbacks).to eq [block, block2]
           end
         end
       end


### PR DESCRIPTION
This is prep for fixing rspec/rspec-rails#1357 (well actually I think it fixes it but I haven't check from the other side yet so... starting here)