### PR TITLE
Aggregate failures

### DIFF
--- a/lib/rspec/mocks/any_instance.rb
+++ b/lib/rspec/mocks/any_instance.rb
@@ -1,5 +1,6 @@
 %w[
   any_instance/chain
+  any_instance/error_generator
   any_instance/stub_chain
   any_instance/stub_chain_chain
   any_instance/expect_chain_chain

--- a/lib/rspec/mocks/any_instance/chain.rb
+++ b/lib/rspec/mocks/any_instance/chain.rb
@@ -76,7 +76,7 @@ module RSpec
         end
 
         def never
-          ErrorGenerator.raise_double_negation_error("expect_any_instance_of(MyClass)") if negated?
+          AnyInstance.error_generator.raise_double_negation_error("expect_any_instance_of(MyClass)") if negated?
           super
         end
 

--- a/lib/rspec/mocks/any_instance/error_generator.rb
+++ b/lib/rspec/mocks/any_instance/error_generator.rb
@@ -1,0 +1,35 @@
+module RSpec
+  module Mocks
+    module AnyInstance
+      # @private
+      class ErrorGenerator < ::RSpec::Mocks::ErrorGenerator
+        def raise_second_instance_received_message_error(unfulfilled_expectations)
+          __raise "Exactly one instance should have received the following " \
+                  "message(s) but didn't: #{unfulfilled_expectations.sort.join(', ')}"
+        end
+
+        def raise_method_cant_be_unstubbed_error(method_name)
+          __raise "The method `#{method_name}` was not stubbed or was already unstubbed"
+        end
+
+        def raise_does_not_implement_error(klass, method_name)
+          __raise "#{klass} does not implement ##{method_name}"
+        end
+
+        def raise_message_already_received_by_other_instance_error(method_name, object_inspect, invoked_instance)
+          __raise "The message '#{method_name}' was received by #{object_inspect} " \
+                  "but has already been received by #{invoked_instance}"
+        end
+
+        def raise_not_supported_with_prepend_error(method_name, problem_mod)
+          __raise "Using `any_instance` to stub a method (#{method_name}) that has been " \
+                  "defined on a prepended module (#{problem_mod}) is not supported."
+        end
+      end
+
+      def self.error_generator
+        @error_generator ||= ErrorGenerator.new
+      end
+    end
+  end
+end

--- a/lib/rspec/mocks/any_instance/error_generator.rb
+++ b/lib/rspec/mocks/any_instance/error_generator.rb
@@ -8,10 +8,6 @@ module RSpec
                   "message(s) but didn't: #{unfulfilled_expectations.sort.join(', ')}"
         end
 
-        def raise_method_cant_be_unstubbed_error(method_name)
-          __raise "The method `#{method_name}` was not stubbed or was already unstubbed"
-        end
-
         def raise_does_not_implement_error(klass, method_name)
           __raise "#{klass} does not implement ##{method_name}"
         end

--- a/lib/rspec/mocks/any_instance/message_chains.rb
+++ b/lib/rspec/mocks/any_instance/message_chains.rb
@@ -75,9 +75,7 @@ module RSpec
           return unless ExpectationChain === instance
           return if @instance_with_expectation.equal?(instance)
 
-          raise RSpec::Mocks::MockExpectationError,
-                "Exactly one instance should have received the following " \
-                "message(s) but didn't: #{unfulfilled_expectations.sort.join(', ')}"
+          AnyInstance.error_generator.raise_second_instance_received_message_error(unfulfilled_expectations)
         end
       end
     end

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -76,7 +76,7 @@ module RSpec
         # @see Methods#unstub
         def unstub(method_name)
           unless @observed_methods.include?(method_name.to_sym)
-            AnyInstance.error_generator.raise_method_cant_be_unstubbed_error(method_name)
+            AnyInstance.error_generator.raise_method_not_stubbed_error(method_name)
           end
           message_chains.remove_stub_chains_for!(method_name)
           stubs[method_name].clear

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -76,7 +76,7 @@ module RSpec
         # @see Methods#unstub
         def unstub(method_name)
           unless @observed_methods.include?(method_name.to_sym)
-            raise RSpec::Mocks::MockExpectationError, "The method `#{method_name}` was not stubbed or was already unstubbed"
+            AnyInstance.error_generator.raise_method_cant_be_unstubbed_error(method_name)
           end
           message_chains.remove_stub_chains_for!(method_name)
           stubs[method_name].clear
@@ -91,9 +91,7 @@ module RSpec
           return unless @expectation_set
           return if message_chains.all_expectations_fulfilled?
 
-          raise RSpec::Mocks::MockExpectationError,
-                "Exactly one instance should have received the following " \
-                "message(s) but didn't: #{message_chains.unfulfilled_expectations.sort.join(', ')}"
+          AnyInstance.error_generator.raise_second_instance_received_message_error(message_chains.unfulfilled_expectations)
         end
 
         # @private
@@ -221,8 +219,7 @@ module RSpec
 
           if RSpec::Mocks.configuration.verify_partial_doubles?
             unless public_protected_or_private_method_defined?(method_name)
-              raise MockExpectationError,
-                    "#{@klass} does not implement ##{method_name}"
+              AnyInstance.error_generator.raise_does_not_implement_error(@klass, method_name)
             end
           end
 
@@ -242,7 +239,9 @@ module RSpec
           @klass.__send__(:define_method, method_name) do |*_args, &_blk|
             invoked_instance = recorder.instance_that_received(method_name)
             inspect = "#<#{self.class}:#{object_id} #{instance_variables.map { |name| "#{name}=#{instance_variable_get name}" }.join(', ')}>"
-            raise RSpec::Mocks::MockExpectationError, "The message '#{method_name}' was received by #{inspect} but has already been received by #{invoked_instance}"
+            AnyInstance.error_generator.raise_message_already_received_by_other_instance_error(
+              method_name, inspect, invoked_instance
+            )
           end
         end
 
@@ -252,9 +251,7 @@ module RSpec
             problem_mod = prepended_modules.find { |mod| mod.method_defined?(method_name) }
             return unless problem_mod
 
-            raise RSpec::Mocks::MockExpectationError,
-                  "Using `any_instance` to stub a method (#{method_name}) that has been " \
-                  "defined on a prepended module (#{problem_mod}) is not supported."
+            AnyInstance.error_generator.raise_not_supported_with_prepend_error(method_name, problem_mod)
           end
         else
           def allow_no_prepended_module_definition_of(_method_name)

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -175,6 +175,40 @@ module RSpec
                 "`#{wrapped_expression}.not_to receive(:msg).never` even mean?"
       end
 
+      # @private
+      def raise_verifying_double_not_defined_error(ref)
+        notify(VerifyingDoubleNotDefinedError.new(
+          "#{ref.description.inspect} is not a defined constant. " \
+          "Perhaps you misspelt it? " \
+          "Disable check with `verify_doubled_constant_names` configuration option."
+        ))
+      end
+
+      # @private
+      def raise_have_received_disallowed(type, reason)
+        __raise "Using #{type}(...) with the `have_received` " \
+                "matcher is not supported#{reason}."
+      end
+
+      # @private
+      def raise_cant_constrain_count_for_negated_have_received_error(count_constraint)
+        __raise "can't use #{count_constraint} when negative"
+      end
+
+      # @private
+      def raise_method_not_stubbed_error(method_name)
+        __raise "The method `#{method_name}` was not stubbed or was already unstubbed"
+      end
+
+      # @private
+      def raise_already_invoked_error(message, calling_customization)
+        error_message = "The message expectation for #{intro}.#{message} has already been invoked " \
+          "and cannot be modified further (e.g. using `#{calling_customization}`). All message expectation " \
+          "customizations must be applied before it is used for the first time."
+
+        notify MockExpectationAlreadyInvokedError.new(error_message)
+      end
+
     private
 
       def received_part_of_expectation_error(actual_received_count, args)
@@ -261,7 +295,11 @@ module RSpec
 
       def __raise(message)
         message = opts[:message] unless opts[:message].nil?
-        Kernel.raise(RSpec::Mocks::MockExpectationError, message)
+        notify RSpec::Mocks::MockExpectationError.new(message)
+      end
+
+      def notify(exception)
+        Kernel.raise(exception)
       end
 
       def format_args(args)
@@ -300,6 +338,11 @@ module RSpec
       def group_count(index, args)
         " (#{times(index)})" if args.size > 1 || index > 1
       end
+    end
+
+    # @private
+    def self.error_generator
+      @error_generator ||= ErrorGenerator.new
     end
   end
 end

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -34,7 +34,7 @@ module RSpec
     class ErrorGenerator
       attr_writer :opts
 
-      def initialize(target)
+      def initialize(target=nil)
         @target = target
       end
 
@@ -167,11 +167,12 @@ module RSpec
                 "method has been mocked instead of stubbed or spied."
       end
 
-      def self.raise_double_negation_error(wrapped_expression)
-        raise "Isn't life confusing enough? You've already set a " \
-              "negative message expectation and now you are trying to " \
-              "negate it again with `never`. What does an expression like " \
-              "`#{wrapped_expression}.not_to receive(:msg).never` even mean?"
+      # @private
+      def raise_double_negation_error(wrapped_expression)
+        __raise "Isn't life confusing enough? You've already set a " \
+                "negative message expectation and now you are trying to " \
+                "negate it again with `never`. What does an expression like " \
+                "`#{wrapped_expression}.not_to receive(:msg).never` even mean?"
       end
 
     private

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -299,7 +299,7 @@ module RSpec
       end
 
       def notify(exception)
-        Kernel.raise(exception)
+        RSpec::Support.notify_failure(exception)
       end
 
       def format_args(args)

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -396,10 +396,7 @@ module RSpec
         if RSpec::Mocks.configuration.verify_doubled_constant_names? &&
           !ref.defined?
 
-          raise VerifyingDoubleNotDefinedError,
-                "#{ref.description.inspect} is not a defined constant. " \
-                "Perhaps you misspelt it? " \
-                "Disable check with `verify_doubled_constant_names` configuration option."
+          RSpec::Mocks.error_generator.raise_verifying_double_not_defined_error(ref)
         end
 
         RSpec::Mocks.configuration.verifying_double_callbacks.each do |block|

--- a/lib/rspec/mocks/matchers/have_received.rb
+++ b/lib/rspec/mocks/matchers/have_received.rb
@@ -69,9 +69,7 @@ module RSpec
       private
 
         def disallow(type, reason="")
-          raise RSpec::Mocks::MockExpectationError,
-                "Using #{type}(...) with the `have_received` " \
-                "matcher is not supported#{reason}."
+          RSpec::Mocks.error_generator.raise_have_received_disallowed(type, reason)
         end
 
         def expect
@@ -88,8 +86,7 @@ module RSpec
 
         def ensure_count_unconstrained
           return unless count_constraint
-          raise RSpec::Mocks::MockExpectationError,
-                "can't use #{count_constraint} when negative"
+          RSpec::Mocks.error_generator.raise_cant_constrain_count_for_negated_have_received_error(count_constraint)
         end
 
         def count_constraint

--- a/lib/rspec/mocks/message_chain.rb
+++ b/lib/rspec/mocks/message_chain.rb
@@ -30,10 +30,6 @@ module RSpec
 
     private
 
-      def expectation(_object, _message, &_return_block)
-        raise NotImplementedError
-      end
-
       def chain_on(object, *chain, &block)
         initialize(object, *chain, &block)
         setup_chain

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -553,11 +553,7 @@ module RSpec
         def raise_already_invoked_error_if_necessary(calling_customization)
           return unless has_been_invoked?
 
-          error_message = "The message expectation for #{orig_object.inspect}.#{message} has already been invoked " \
-            "and cannot be modified further (e.g. using `#{calling_customization}`). All message expectation " \
-            "customizations must be applied before it is used for the first time."
-
-          raise MockExpectationAlreadyInvokedError, error_message
+          error_generator.raise_already_invoked_error(message, calling_customization)
         end
 
         def failed_fast?

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -709,11 +709,13 @@ module RSpec
     #
     # @private
     class InsertOntoBacktrace
-      def self.line(location)
-        yield
+      RAISE_METHOD = method(:raise)
+
+      def self.line(location, &block)
+        RSpec::Support.with_failure_notifier(RAISE_METHOD, &block)
       rescue RSpec::Mocks::MockExpectationError => error
         error.backtrace.insert(0, location)
-        Kernel.raise error
+        RSpec::Support.notify_failure(error)
       end
     end
   end

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -252,7 +252,7 @@ module RSpec
       # @example
       #   expect(car).to receive(:stop).never
       def never
-        ErrorGenerator.raise_double_negation_error("expect(obj)") if negative?
+        error_generator.raise_double_negation_error("expect(obj)") if negative?
         @expected_received_count = 0
         self
       end

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -198,7 +198,7 @@ module RSpec
 
       # @private
       def raise_method_not_stubbed_error
-        raise MockExpectationError, "The method `#{method_name}` was not stubbed or was already unstubbed"
+        RSpec::Mocks.error_generator.raise_method_not_stubbed_error(method_name)
       end
 
       # In Ruby 2.0.0 and above prepend will alter the method lookup chain.

--- a/spec/rspec/mocks/failure_notification_spec.rb
+++ b/spec/rspec/mocks/failure_notification_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "Failure notification" do
+  def capture_errors(&block)
+    errors = []
+    RSpec::Support.with_failure_notifier(lambda { |e| errors << e }, &block)
+    errors
+  end
+
+  it "uses the rspec-support notifier to support `aggregate_failures`" do
+    dbl = double("Foo")
+
+    expect(capture_errors { dbl.some_unallowed_method }).to match [an_object_having_attributes(
+      :message => a_string_including(dbl.inspect, "some_unallowed_method")
+    )]
+  end
+
+  it "includes the line of future expectation in the notification for an unreceived message" do
+    dbl = double("Foo")
+    expect(dbl).to receive(:wont_happen); expected_from_line = __LINE__
+
+    error = capture_errors { verify dbl }.first
+    expect(error.backtrace.first).to match(/#{File.basename(__FILE__)}:#{expected_from_line}/)
+  end
+end


### PR DESCRIPTION
This is the necessary changes for rspec/rspec-expectations#776 so that mock expectation failures are aggregated, too.

* Error raising was scattered around rspec-mocks so I spent some effort centralizing it in the error generator, which solved #646.
* With the error raising centralized it was pretty easy to use the RSpec::Support failure notifier.