### PR TITLE
Distinguish between the original method and a method missing proc.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,8 @@ Bug Fixes:
 * Fix `any_args`/`anything` support so that we avoid calling `obj == anything`
   on user objects that may have improperly implemented `==` in a way that
   raises errors. (Myron Marston, #924)
+* Fix edge case involving stubbing the same method on a class and a subclass
+  which previously hit a `NoMethodError` internally in RSpec. (Myron Marston #954)
 
 ### 3.2.1 / 2015-02-23
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.2.0...v3.2.1)

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -118,7 +118,7 @@ module RSpec
           @error_generator.raise_only_valid_on_a_partial_double(:and_call_original)
         else
           warn_about_stub_override if implementation.inner_action
-          @implementation = AndWrapOriginalImplementation.new(@method_double.original_method, block)
+          @implementation = AndWrapOriginalImplementation.new(@method_double.original_implementation_callable, block)
           @yield_receiver_to_implementation_block = false
         end
 

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -163,11 +163,11 @@ module RSpec
 
         # Trigger an eager find of the original method since if we find it any
         # later we end up getting a stubbed method with incorrect arity.
-        save_original_method!
+        save_original_implementation_callable!
       end
 
       def with_signature
-        yield Support::MethodSignature.new(original_method)
+        yield Support::MethodSignature.new(original_implementation_callable)
       end
 
       def unimplemented?

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -74,6 +74,18 @@ module RSpec
         object.foobar
       end
 
+      it 'allows a class and a subclass to both be stubbed' do
+        pending "Does not work on 1.8.7 due to singleton method restrictions" if RUBY_VERSION == "1.8.7" && RSpec::Support::Ruby.mri?
+        the_klass = Class.new
+        the_subklass = Class.new(the_klass)
+
+        allow(the_klass).to receive(:foo).and_return(1)
+        allow(the_subklass).to receive(:foo).and_return(2)
+
+        expect(the_klass.foo).to eq(1)
+        expect(the_subklass.foo).to eq(2)
+      end
+
       it "verifies the method was called when expecting a message" do
         expect(object).to receive(:foobar).with(:test_param).and_return(1)
         expect {


### PR DESCRIPTION
Before, we would return a proc that invokes `method_missing`
from `original_method`, but it wasn’t a `Method` object
and couldn’t be bound, leading to `NoMethodError` in an
edge case.

Fixes #951.