### PR TITLE
Prevent received count from being double-incremented.

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -526,24 +526,26 @@ module RSpec
           args.unshift(orig_object) if yield_receiver_to_implementation_block?
 
           if negative? || (allowed_to_fail && (@exactly || @at_most) && (@actual_received_count == @expected_received_count))
-            @actual_received_count += increment
             @failed_fast = true
             # args are the args we actually received, @argument_list_matcher is the
             # list of args we were expecting
-            @error_generator.raise_expectation_error(@message, @expected_received_count, @argument_list_matcher, @actual_received_count, expectation_count_type, args)
+            @error_generator.raise_expectation_error(
+              @message, @expected_received_count,
+              @argument_list_matcher,
+              @actual_received_count + increment,
+              expectation_count_type, args
+            )
           end
 
           @order_group.handle_order_constraint self
 
-          begin
-            if implementation.present?
-              implementation.call(*args, &block)
-            elsif parent_stub
-              parent_stub.invoke(nil, *args, &block)
-            end
-          ensure
-            @actual_received_count += increment
+          if implementation.present?
+            implementation.call(*args, &block)
+          elsif parent_stub
+            parent_stub.invoke(nil, *args, &block)
           end
+        ensure
+          @actual_received_count += increment
         end
 
         def has_been_invoked?

--- a/spec/rspec/mocks/failure_notification_spec.rb
+++ b/spec/rspec/mocks/failure_notification_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe "Failure notification" do
     expect(error.backtrace.first).to match(/#{File.basename(__FILE__)}:#{expected_from_line}/)
   end
 
+  it "does not allow a double to miscount the number of times a message was recevied when a failure is notified in an alternate way" do
+    dbl = double("Foo")
+    expect(dbl).not_to receive(:bar)
+
+    capture_errors { dbl.bar }
+
+    expect { verify dbl }.to fail_including("expected: 0 times", "received: 1 time")
+  end
+
   context "when using `aggregate_failures`" do
     specify 'spy failures for unreceived messages are reported correctly' do
       expect {


### PR DESCRIPTION
For #956.

This doesn't completely fix #956 (I'm still mulling over solutions) but addresses the weirdness with the failure saying it received the message 2 times when it only received it once.