### PR TITLE
Show the right message when using spies and calling many methods

### DIFF
--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -101,12 +101,15 @@ module RSpec
       def check_for_unexpected_arguments(expectation)
         return if @messages_received.empty?
 
-        # Check if any of the arguments were expected.
-        return if @messages_received.any? do |(method_name, args, _)|
-                    !expectation.matches_name_but_not_args(method_name, *args)
-                  end
+        return if @messages_received.any? { |method_name, args, _| expectation.matches?(method_name, *args) }
 
-        raise_unexpected_message_args_error(expectation, messages_arg_list)
+        name_but_not_args, others = @messages_received.partition do |(method_name, args, _)|
+          expectation.matches_name_but_not_args(method_name, *args)
+        end
+
+        return if name_but_not_args.empty? && !others.empty?
+
+        raise_unexpected_message_args_error(expectation, name_but_not_args.map { |args| args[1] })
       end
 
       # @private

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -137,6 +137,16 @@ module RSpec
           expect(matcher.description).to eq 'have received expected_method(:expected_args) 1 time'
         end
 
+        it 'produces an error message that matches the expected method if another method was called' do
+          my_spy = spy
+          my_spy.foo(1)
+          my_spy.bar(3)
+
+          expect {
+            expect(my_spy).to have_received(:foo).with(3)
+          }.to fail_including("received :foo with unexpected arguments", "expected: (3)", "got: (1)")
+        end
+
         context "counts" do
           let(:the_dbl) { double(:expected_method => nil) }
 


### PR DESCRIPTION
This fixes the issue where when you called a method expected using `have_received` with an unexpected argument and called some other bogus method the spec error message wouldn't say the expected method was called with wrong arguments.

Fixes #949.