### PR TITLE
Pass `source_id` when notifying failures

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -51,8 +51,8 @@ module RSpec
       end
 
       # @private
-      def raise_unexpected_message_args_error(expectation, args_for_multiple_calls)
-        __raise error_message(expectation, args_for_multiple_calls)
+      def raise_unexpected_message_args_error(expectation, args_for_multiple_calls, source_id=nil)
+        __raise error_message(expectation, args_for_multiple_calls), nil, source_id
       end
 
       # @private
@@ -81,10 +81,10 @@ module RSpec
       # @private
       def raise_expectation_error(message, expected_received_count, argument_list_matcher,
                                   actual_received_count, expectation_count_type, args,
-                                  backtrace_line=nil)
+                                  backtrace_line=nil, source_id=nil)
         expected_part = expected_part_of_expectation_error(expected_received_count, expectation_count_type, argument_list_matcher)
         received_part = received_part_of_expectation_error(actual_received_count, args)
-        __raise "(#{intro(:unwrapped)}).#{message}#{format_args(args)}\n    #{expected_part}\n    #{received_part}", backtrace_line
+        __raise "(#{intro(:unwrapped)}).#{message}#{format_args(args)}\n    #{expected_part}\n    #{received_part}", backtrace_line, source_id
       end
       # rubocop:enable Style/ParameterLists
 
@@ -297,11 +297,11 @@ module RSpec
         end
       end
 
-      def __raise(message, backtrace_line=nil)
+      def __raise(message, backtrace_line=nil, source_id=nil)
         message = opts[:message] unless opts[:message].nil?
         exception = RSpec::Mocks::MockExpectationError.new(message)
         prepend_to_backtrace(exception, backtrace_line) if backtrace_line
-        notify exception
+        notify exception, :source_id => source_id
       end
 
       if RSpec::Support::Ruby.jruby?
@@ -316,8 +316,8 @@ module RSpec
         end
       end
 
-      def notify(exception)
-        RSpec::Support.notify_failure(exception)
+      def notify(*args)
+        RSpec::Support.notify_failure(*args)
       end
 
       def format_args(args)

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -477,7 +477,7 @@ module RSpec
             @error_generator.raise_expectation_error(
               @message, @expected_received_count, @argument_list_matcher,
               @actual_received_count, expectation_count_type, expected_args,
-              @expected_from
+              @expected_from, exception_source_id
             )
           else
             @error_generator.raise_similar_message_args_error(
@@ -487,7 +487,7 @@ module RSpec
         end
 
         def raise_unexpected_message_args_error(args_for_multiple_calls)
-          @error_generator.raise_unexpected_message_args_error(self, args_for_multiple_calls)
+          @error_generator.raise_unexpected_message_args_error(self, args_for_multiple_calls, exception_source_id)
         end
 
         def expectation_count_type
@@ -530,6 +530,10 @@ module RSpec
 
       private
 
+        def exception_source_id
+          @exception_source_id ||= "#{self.class.name} #{__id__}"
+        end
+
         def invoke_incrementing_actual_calls_by(increment, allowed_to_fail, parent_stub, *args, &block)
           args.unshift(orig_object) if yield_receiver_to_implementation_block?
 
@@ -540,7 +544,7 @@ module RSpec
               @message, @expected_received_count,
               @argument_list_matcher,
               @actual_received_count + increment,
-              expectation_count_type, args
+              expectation_count_type, args, nil, exception_source_id
             )
           end
 

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -486,6 +486,10 @@ module RSpec
           end
         end
 
+        def raise_unexpected_message_args_error(args_for_multiple_calls)
+          @error_generator.raise_unexpected_message_args_error(self, args_for_multiple_calls)
+        end
+
         def expectation_count_type
           return :at_least if @at_least
           return :at_most if @at_most

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -378,7 +378,6 @@ module RSpec
           # Initialized to nil so that we don't allocate an array for every
           # mock or stub. See also comment in `and_yield`.
           @args_to_yield = nil
-          @failed_fast = nil
           @eval_context = nil
           @yield_receiver_to_implementation_block = false
 
@@ -531,7 +530,6 @@ module RSpec
           args.unshift(orig_object) if yield_receiver_to_implementation_block?
 
           if negative? || (allowed_to_fail && (@exactly || @at_most) && (@actual_received_count == @expected_received_count))
-            @failed_fast = true
             # args are the args we actually received, @argument_list_matcher is the
             # list of args we were expecting
             @error_generator.raise_expectation_error(
@@ -561,10 +559,6 @@ module RSpec
           return unless has_been_invoked?
 
           error_generator.raise_already_invoked_error(message, calling_customization)
-        end
-
-        def failed_fast?
-          @failed_fast
         end
 
         def set_expected_received_count(relativity, n)

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -109,7 +109,7 @@ module RSpec
 
         return if name_but_not_args.empty? && !others.empty?
 
-        raise_unexpected_message_args_error(expectation, name_but_not_args.map { |args| args[1] })
+        expectation.raise_unexpected_message_args_error(name_but_not_args.map { |args| args[1] })
       end
 
       # @private
@@ -184,7 +184,7 @@ module RSpec
           expectation.advise(*args) if null_object? unless expectation.expected_messages_received?
 
           if null_object? || !has_negative_expectation?(message)
-            raise_unexpected_message_args_error(expectation, [args])
+            expectation.raise_unexpected_message_args_error([args])
           end
         elsif (stub = find_almost_matching_stub(message, *args))
           stub.advise(*args)
@@ -199,11 +199,6 @@ module RSpec
       # @private
       def raise_unexpected_message_error(method_name, args)
         @error_generator.raise_unexpected_message_error method_name, args
-      end
-
-      # @private
-      def raise_unexpected_message_args_error(expectation, args_for_multiple_calls)
-        @error_generator.raise_unexpected_message_args_error(expectation, args_for_multiple_calls)
       end
 
       # @private

--- a/spec/rspec/mocks/failure_notification_spec.rb
+++ b/spec/rspec/mocks/failure_notification_spec.rb
@@ -54,5 +54,23 @@ RSpec.describe "Failure notification" do
         expect(e.message).to include("expected: (2)", "got: (1)")
       end
     end
+
+    specify "failing negative expectations are only notified once" do
+      expect {
+        aggregate_failures do
+          dbl = double
+
+          expect(dbl).not_to receive(:foo)
+          expect(dbl).not_to receive(:bar)
+
+          dbl.foo
+          dbl.bar
+
+          verify_all
+        end
+      }.to raise_error(RSpec::Expectations::MultipleExpectationsNotMetError) do |e|
+        expect(e.failures.count).to eq(2)
+      end
+    end
   end
 end

--- a/spec/rspec/mocks/failure_notification_spec.rb
+++ b/spec/rspec/mocks/failure_notification_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Failure notification" do
   def capture_errors(&block)
     errors = []
-    RSpec::Support.with_failure_notifier(lambda { |e| errors << e }, &block)
+    RSpec::Support.with_failure_notifier(Proc.new { |e, _opts| errors << e }, &block)
     errors
   end
 

--- a/spec/rspec/mocks/reraising_eager_raises_spec.rb
+++ b/spec/rspec/mocks/reraising_eager_raises_spec.rb
@@ -8,42 +8,151 @@ RSpec.describe "Reraising eager raises during the verify step" do
     end
   end
 
-  it "reraises when a negative expectation receives a call" do
-    with_unfulfilled_double do |dbl|
-      expect(dbl).not_to receive(:foo)
-      expect { dbl.foo }.to fail
-      expect { verify_all }.to fail_with(/expected: 0 times with any arguments/)
+  context "when a negative expectation receives a call" do
+    it "reraises during verification" do
+      with_unfulfilled_double do |dbl|
+        expect(dbl).not_to receive(:foo)
+        expect { dbl.foo }.to fail
+        expect { verify_all }.to fail_with(/expected: 0 times with any arguments/)
+      end
+    end
+
+    it 'notifies both exceptions using the same `:source_id` so `aggregate_failures` can de-dup' do
+      with_unfulfilled_double do |dbl|
+        expect(dbl).not_to receive(:foo)
+        expect { dbl.foo }.to notify_with_same_source_id_as_later_verification
+      end
+    end
+
+    it 'notifies with a different `source_id` than that for the same double and a different message' do
+      with_unfulfilled_double do |dbl|
+        expect(dbl).not_to receive(:foo)
+
+        expect {
+          dbl.foo # should trigger first source_id
+          reset(dbl)
+
+          # Prepare a failing expectation for a different message
+          expect(dbl).not_to receive(:bar)
+          RSpec::Support.with_failure_notifier(Proc.new { }) { dbl.bar }
+        }.not_to notify_with_same_source_id_as_later_verification
+      end
+    end
+
+    it 'notifies with a different `source_id` than a different double expecting that message' do
+      with_unfulfilled_double do |dbl_1|
+        with_unfulfilled_double do |dbl_2|
+          expect(dbl_1).not_to receive(:foo)
+          expect(dbl_2).not_to receive(:foo)
+
+          expect { dbl_2.foo }.to fail
+          expect { dbl_1.foo; reset(dbl_1) }.not_to notify_with_same_source_id_as_later_verification
+        end
+      end
     end
   end
 
-  it "reraises when an expectation with a count is exceeded" do
-    with_unfulfilled_double do |dbl|
+  context "when an expectation with a count is exceeded" do
+    def prepare(dbl)
       expect(dbl).to receive(:foo).exactly(2).times
 
       dbl.foo
       dbl.foo
+    end
 
-      expect { dbl.foo }.to fail
-      expect { verify_all }.to fail_with(/expected: 2 times with any arguments/)
+    it "reraises during verification" do
+      with_unfulfilled_double do |dbl|
+        prepare dbl
+
+        expect { dbl.foo }.to fail
+        expect { verify_all }.to fail_with(/expected: 2 times with any arguments/)
+      end
+    end
+
+    it 'notifies both exceptions using the same `:source_id` so `aggregate_failures` can de-dup' do
+      with_unfulfilled_double do |dbl|
+        prepare dbl
+        expect { dbl.foo }.to notify_with_same_source_id_as_later_verification
+      end
     end
   end
 
-  it "reraises when an expectation is called with the wrong arguments" do
-    with_unfulfilled_double do |dbl|
-      expect(dbl).to receive(:foo).with(1,2,3)
-      expect { dbl.foo(1,2,4) }.to fail
-      expect { verify_all }.to fail_with(/expected: 1 time with arguments: \(1, 2, 3\)/)
+  context "when an expectation is called with the wrong arguments" do
+    it "reraises during verification" do
+      with_unfulfilled_double do |dbl|
+        expect(dbl).to receive(:foo).with(1, 2, 3)
+        expect { dbl.foo(1, 2, 4) }.to fail
+        expect { verify_all }.to fail_with(/expected: 1 time with arguments: \(1, 2, 3\)/)
+      end
+    end
+
+    it 'notifies both exceptions using the same `:source_id` so `aggregate_failures` can de-dup' do
+      with_unfulfilled_double do |dbl|
+        expect(dbl).to receive(:foo).with(1, 2, 3)
+        expect { dbl.foo(1, 2, 4) }.to notify_with_same_source_id_as_later_verification
+      end
     end
   end
 
-  it "reraises when an expectation is called out of order",
+  context "when an expectation is called out of order",
      :pending => "Says bar was called 0 times when it was, see: http://git.io/pjTq" do
-    with_unfulfilled_double do |dbl|
-      expect(dbl).to receive(:foo).ordered
-      expect(dbl).to receive(:bar).ordered
-      expect { dbl.bar }.to fail
-      dbl.foo # satisfy the `foo` expectation so that only the bar one fails below
-      expect { verify_all }.to fail_with(/received :bar out of order/)
+    it "reraises during verification" do
+      with_unfulfilled_double do |dbl|
+        expect(dbl).to receive(:foo).ordered
+        expect(dbl).to receive(:bar).ordered
+        expect { dbl.bar }.to fail
+        dbl.foo # satisfy the `foo` expectation so that only the bar one fails below
+        expect { verify_all }.to fail_with(/received :bar out of order/)
+      end
+    end
+  end
+
+  RSpec::Matchers.define :notify_with_same_source_id_as_later_verification do
+    attr_reader :block
+
+    match do |block|
+      @block = block
+      block_source_id == verify_all_source_id && block_source_id
+    end
+
+    match_when_negated do |block|
+      @block = block
+      block_source_id && verify_all_source_id && (
+        block_source_id != verify_all_source_id
+      )
+    end
+
+    supports_block_expectations
+
+    failure_message do
+      if block_source_id.nil?
+        "expected it to notify with a non-nil source id"
+      else
+        "expected `verify_all` to notify with source_id: #{block_source_id.inspect} but notified with source_id: #{verify_all_source_id.inspect}"
+      end
+    end
+
+    failure_message_when_negated do
+      if block_source_id.nil?
+        "expected it to notify with a non-nil source id"
+      else
+        "expected `verify_all` to notify with a different source_id but got the same one: #{block_source_id.inspect} / #{verify_all_source_id.inspect}"
+      end
+    end
+
+    def block_source_id
+      @block_source_id ||= capture_notified_source_id(&block)
+    end
+
+    def verify_all_source_id
+      @verify_all_source_id ||= capture_notified_source_id { verify_all }
+    end
+
+    def capture_notified_source_id(&block)
+      source_id = nil
+      notifier = Proc.new { |err, opt| source_id = opt.fetch(:source_id) }
+      RSpec::Support.with_failure_notifier(notifier, &block)
+      source_id
     end
   end
 end

--- a/spec/rspec/mocks/reraising_eager_raises_spec.rb
+++ b/spec/rspec/mocks/reraising_eager_raises_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Reraising eager raises during the verify step" do
     with_unfulfilled_double do |dbl|
       expect(dbl).to receive(:foo).with(1,2,3)
       expect { dbl.foo(1,2,4) }.to fail
-      expect { RSpec::Mocks.verify }.to fail_with(/expected: 1 time with arguments: \(1, 2, 3\)/)
+      expect { verify_all }.to fail_with(/expected: 1 time with arguments: \(1, 2, 3\)/)
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe "Reraising eager raises during the verify step" do
       expect(dbl).to receive(:bar).ordered
       expect { dbl.bar }.to fail
       dbl.foo # satisfy the `foo` expectation so that only the bar one fails below
-      expect { RSpec::Mocks.verify }.to fail_with(/received :bar out of order/)
+      expect { verify_all }.to fail_with(/received :bar out of order/)
     end
   end
 end


### PR DESCRIPTION
Fixes #956 (in combination with rspec/rspec-expectations#799, which should be merged first).