### PR TITLE
Deprecate using `with` without arguments.

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -358,6 +358,8 @@ module RSpec
           else
             self.inner_implementation_action = block
           end
+        elsif args.empty?
+          RSpec.deprecate "Using `with` without arguments", :replacement => "`with(no_args)`"
         end
 
         @argument_list_matcher = ArgumentListMatcher.new(*args, &block)

--- a/spec/rspec/mocks/mock_spec.rb
+++ b/spec/rspec/mocks/mock_spec.rb
@@ -776,6 +776,22 @@ module RSpec
             @double.should_receive(:foo).with('bar')
             @double.foo('bar')
           end
+
+          it "warns of deprecation when called without arguments" do
+            expect(RSpec).to receive(:deprecate) do |message, opts|
+              expect(message).to match(/Using `with` without arguments/)
+            end
+            obj = Object.new
+            obj.stub(:foo).with().and_return('bar')
+            expect(obj.foo).to eq('bar')
+          end
+
+          it 'includes callsite in deprecation when called without arguments' do
+            obj = Object.new
+            expect_deprecation_with_call_site __FILE__, __LINE__ + 1
+            obj.stub(:foo).with().and_return('bar')
+            expect(obj.foo).to eq('bar')
+          end
         end
 
         context "with non-matching args" do


### PR DESCRIPTION
RSpec3.0 prohibit using `with` without arguments.
- https://github.com/rspec/rspec-mocks/blob/v3.0.4/lib/rspec/mocks/message_expectation.rb#L336-L339

### example spec
```ruby
class Dummy
end

RSpec.describe Dummy do
  let(:dummy){Dummy.new}
  it "use 'with()'" do
    expect(dummy).to receive(:dummy_method).with().and_return("this is dummy method.")

    expect(dummy.dummy_method).to eq("this is dummy method.")
  end
end
```

### execute by rspec2.99
```
$ bundle exec rspec example_spec.rb 
.

Finished in 0.00211 seconds
1 example, 0 failures
```

### execute by rspec3.0
```
$ bundle exec rspec example_spec.rb 
F

Failures:

  1) Dummy use 'with()'
     Failure/Error: expect(dummy).to receive(:dummy_method).with().and_return("this is dummy method.")
     ArgumentError:
       `with` must have at least one argument. Use `no_args` matcher to set the expectation of receiving no arguments.
     # ./example_spec.rb:7:in `block (2 levels) in <top (required)>'

Finished in 0.02599 seconds (files took 0.21393 seconds to load)
1 example, 1 failure
```
