### PR TITLE
A fix for #972

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+### 3.4.0 Development
+
+Bug Fixes:
+
+* Fix bug in before_verifying_double callback logic that caused it to be called
+  once for class in the ancestor list when mocking or stubbing a class. Now it
+  is only called for the mocked or stubbed class, as you would expect. (Sam
+  Phippen, #974)
+
 ### 3.3.0 / 2015-06-12
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.2.1...v3.3.0)
 

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -391,7 +391,7 @@ module RSpec
         return @superclass_proxy if defined?(@superclass_proxy)
 
         if (superclass = object.superclass)
-          @superclass_proxy = @source_space.proxy_for(superclass)
+          @superclass_proxy = @source_space.superclass_proxy_for(superclass)
         else
           @superclass_proxy = nil
         end

--- a/spec/rspec/mocks/diffing_spec.rb
+++ b/spec/rspec/mocks/diffing_spec.rb
@@ -140,6 +140,10 @@ RSpec.describe "Diffs printed when arguments don't match" do
             def self.name
               "RSpec::Mocks::ArgumentMatchers::"
             end
+
+            def inspect
+              "#<MyCollab>"
+            end
           end.new
 
           expect(RSpec::Support.is_a_matcher?(collab)).to be true

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -394,7 +394,7 @@ module RSpec
 
             allow(subclass).to receive(:new)
           }.to yield_successive_args(
-            an_object_having_attributes(:target => subclass),
+            an_object_having_attributes(:target => subclass)
           )
         end
       end

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -383,6 +383,22 @@ module RSpec
         object.implemented
       end
 
+      context "for a class" do
+        it "only runs the `before_verifying_doubles` callback for the class (not for superclasses)" do
+          subclass = Class.new(klass)
+
+          expect { |probe|
+            RSpec.configuration.mock_with(:rspec) do |config|
+              config.before_verifying_doubles(&probe)
+            end
+
+            allow(subclass).to receive(:new)
+          }.to yield_successive_args(
+            an_object_having_attributes(:target => subclass),
+          )
+        end
+      end
+
       it 'does not allow a non-existing method to be expected' do
         prevents { expect(object).to receive(:unimplemented) }
       end


### PR DESCRIPTION
It seemed to me that if the problem is creating superclass proxies, then we could just add a method and put a flag in to the constructors to fix this. The current fix is a bit shonky, but demonstrates the solution.

I have some questions/thoughts:

1. Perhaps, this behaviour change should be extracted out in to an object, as opposed to a conditional. We'd inject a callbacks collaborator into the proxies which they would then invoke
2. Perhaps this should be flag on proxy_for instead of adding a new method?
3. I think the verifying class proxy is the only place we need to put the flag, but is that correct?

This fix is *really simple*, but I'm not sure it's architecturally brilliant. Thoughts?