### PR TITLE
Make `have_received` work without relying upon rspec-expectations.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### 3.4.0 Development
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.3.1...master)
 
+Enhancements:
+
+* Make `expect(...).to have_received` work without relying upon
+  rspec-expectations. (Myron Marston, #978)
+
 ### 3.3.1 / 2015-06-19
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.3.0...v3.3.1)
 

--- a/features/outside_rspec/minitest.feature
+++ b/features/outside_rspec/minitest.feature
@@ -61,6 +61,28 @@ Feature: Integrate with Minitest
           expect(dbl).to_not receive(:message)
           dbl.message
         end
+
+        def test_passing_positive_spy_expectation
+          bond = spy
+          bond.james
+          expect(bond).to have_received(:james)
+        end
+
+        def test_failing_positive_spy_expectation
+          bond = spy
+          expect(bond).to have_received(:james)
+        end
+
+        def test_passing_negative_spy_expectation
+          bond = spy
+          expect(bond).not_to have_received(:james)
+        end
+
+        def test_failing_negative_spy_expectation
+          bond = spy
+          bond.james
+          expect(bond).not_to have_received(:james)
+        end
       end
       """
      When I run `ruby -Itest test/rspec_mocks_test.rb`
@@ -77,4 +99,16 @@ Feature: Integrate with Minitest
        |     expected: 1 time with any arguments                                       |
        |     received: 0 times with any arguments                                      |
        |                                                                               |
-       |  4 runs, 0 assertions, 0 failures, 2 errors, 0 skips                          |
+       |   3) Error:                                                                   |
+       | RSpecMocksTest#test_failing_positive_spy_expectation:                         |
+       | RSpec::Mocks::MockExpectationError: (Double (anonymous)).james(*(any args))   |
+       |     expected: 1 time with any arguments                                       |
+       |     received: 0 times with any arguments                                      |
+       |                                                                               |
+       |   4) Error:                                                                   |
+       | RSpecMocksTest#test_failing_negative_spy_expectation:                         |
+       | RSpec::Mocks::MockExpectationError: (Double (anonymous)).james(no args)       |
+       |     expected: 0 times with any arguments                                      |
+       |     received: 1 time                                                          |
+       |                                                                               |
+       |  8 runs, 0 assertions, 0 failures, 4 errors, 0 skips                          |

--- a/lib/rspec/mocks/matchers/have_received.rb
+++ b/lib/rspec/mocks/matchers/have_received.rb
@@ -36,11 +36,11 @@ module RSpec
         end
 
         def failure_message
-          generate_failure_message
+          capture_failure_message
         end
 
         def failure_message_when_negated
-          generate_failure_message
+          capture_failure_message
         end
 
         def description
@@ -52,6 +52,14 @@ module RSpec
             @constraints << [expectation, *args]
             self
           end
+        end
+
+        def setup_expectation(subject, &block)
+          notify_failure_message unless matches?(subject, &block)
+        end
+
+        def setup_negative_expectation(subject, &block)
+          notify_failure_message unless does_not_match?(subject, &block)
         end
 
         def setup_allowance(_subject, &_block)
@@ -95,11 +103,15 @@ module RSpec
           end
         end
 
-        def generate_failure_message
+        def capture_failure_message
           RSpec::Support.with_failure_notifier(Proc.new { |err, _opt| return err.message }) do
-            mock_proxy.check_for_unexpected_arguments(@expectation)
-            @expectation.generate_error
+            notify_failure_message
           end
+        end
+
+        def notify_failure_message
+          mock_proxy.check_for_unexpected_arguments(@expectation)
+          @expectation.generate_error
         end
 
         def expected_messages_received_in_order?

--- a/lib/rspec/mocks/targets.rb
+++ b/lib/rspec/mocks/targets.rb
@@ -19,7 +19,7 @@ module RSpec
         method_name = options.fetch(:from)
         define_method(method_name) do |matcher, &block|
           case matcher
-          when Matchers::Receive
+          when Matchers::Receive, Matchers::HaveReceived
             define_matcher(matcher, matcher_method, &block)
           when Matchers::ReceiveMessages, Matchers::ReceiveMessageChain
             raise_negation_unsupported(method_name, matcher)
@@ -47,7 +47,7 @@ module RSpec
 
       def raise_unsupported_matcher(method_name, matcher)
         raise UnsupportedMatcherError,
-              "only the `receive` or `receive_messages` matchers are supported " \
+              "only the `receive`, `have_received` and `receive_messages` matchers are supported " \
               "with `#{expression}(...).#{method_name}`, but you have provided: #{matcher}"
       end
 

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -491,7 +491,7 @@ module RSpec
             framework.new.instance_exec do
               expect(3).to eq(3)
             end
-          }.to raise_error(/only the `receive` or `receive_messages` matchers are supported with `expect\(...\).to`/)
+          }.to raise_error(/only the `receive`, `have_received` and `receive_messages` matchers are supported with `expect\(...\).to`/)
         end
 
         it 'can toggle the available syntax' do


### PR DESCRIPTION
Fixes #967 and #968.

@randycoulman -- want to try this out?