### PR TITLE
Add means to fail test for expectations set on nil

### DIFF
--- a/lib/rspec/mocks/configuration.rb
+++ b/lib/rspec/mocks/configuration.rb
@@ -3,11 +3,28 @@ module RSpec
     # Provides configuration options for rspec-mocks.
     class Configuration
       def initialize
+        @allow_message_expectations_on_nil = nil
         @yield_receiver_to_any_instance_implementation_blocks = true
         @verify_doubled_constant_names = false
         @transfer_nested_constants = false
         @verify_partial_doubles = false
       end
+
+      # Sets whether RSpec will warn, ignore, or fail a test when
+      # expectations are set on nil.
+      # By default, when this flag is not set, warning messages are issued when
+      # expectations are set on nil. This is to prevent false-positives and to
+      # catch potential bugs early on.
+      # When set to `true`, warning messages are suppressed.
+      # When set to `false`, it will raise an error.
+      #
+      # @example
+      #   RSpec.configure do |config|
+      #     config.mock_with :rspec do |mocks|
+      #       mocks.allow_message_expectations_on_nil = false
+      #     end
+      #   end
+      attr_accessor :allow_message_expectations_on_nil
 
       def yield_receiver_to_any_instance_implementation_blocks?
         @yield_receiver_to_any_instance_implementation_blocks

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -213,6 +213,16 @@ module RSpec
         notify MockExpectationAlreadyInvokedError.new(error_message)
       end
 
+      def raise_expectation_on_nil_error(method_name)
+        __raise expectation_on_nil_message(method_name)
+      end
+
+      def expectation_on_nil_message(method_name)
+        "An expectation of :#{method_name} was set on nil. " \
+          "To allow expectations on nil & suppress this message, set allow_expectations_on_nil to true. " \
+          "To disallow expectations on nil, set allow_expectations_on_nil to false"
+      end
+
     private
 
       def received_part_of_expectation_error(actual_received_count, args)

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -197,16 +197,9 @@ module RSpec
       # By default warning messages are issued when expectations are set on
       # nil.  This is to prevent false-positives and to catch potential bugs
       # early on.
+      # @deprecated Use {RSpec::Mocks::Configuration#allow_message_expectations_on_nil} instead.
       def allow_message_expectations_on_nil
         RSpec::Mocks.space.proxy_for(nil).warn_about_expectations = false
-      end
-
-      # Raise an error when setting expectations on nil.
-      #
-      # By default warning messages are issued when expectations are set on
-      # nil.  This is to force test failures when an expectation is set on nil.
-      def disallow_message_expectations_on_nil
-        RSpec::Mocks.space.proxy_for(nil).disallow_expectations = true
       end
 
       # Stubs the named constant with the given value.

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -201,6 +201,14 @@ module RSpec
         RSpec::Mocks.space.proxy_for(nil).warn_about_expectations = false
       end
 
+      # Raise an error when setting expectations on nil.
+      #
+      # By default warning messages are issued when expectations are set on
+      # nil.  This is to force test failures when an expectation is set on nil.
+      def disallow_message_expectations_on_nil
+        RSpec::Mocks.space.proxy_for(nil).disallow_expectations = true
+      end
+
       # Stubs the named constant with the given value.
       # Like method stubs, the constant will be restored
       # to its original value (or lack of one, if it was

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -407,23 +407,29 @@ module RSpec
     class ProxyForNil < PartialDoubleProxy
       def initialize(order_group)
         @warn_about_expectations = true
+        @disallow_expectations = false
         super(nil, order_group)
       end
 
       attr_accessor :warn_about_expectations
+      attr_accessor :disallow_expectations
       alias warn_about_expectations? warn_about_expectations
+      alias disallow_expectations? disallow_expectations
 
       def add_message_expectation(method_name, opts={}, &block)
+        raise_error(method_name) if disallow_expectations?
         warn(method_name) if warn_about_expectations?
         super
       end
 
       def add_negative_message_expectation(location, method_name, &implementation)
+        raise_error(method_name) if disallow_expectations?
         warn(method_name) if warn_about_expectations?
         super
       end
 
       def add_stub(method_name, opts={}, &implementation)
+        raise_error(method_name) if disallow_expectations?
         warn(method_name) if warn_about_expectations?
         super
       end
@@ -433,6 +439,11 @@ module RSpec
       def warn(method_name)
         source = CallerFilter.first_non_rspec_line
         Kernel.warn("An expectation of :#{method_name} was set on nil. Called from #{source}. Use allow_message_expectations_on_nil to disable warnings.")
+      end
+
+      def raise_error(method_name)
+        source = CallerFilter.first_non_rspec_line
+        raise("An expectation of :#{method_name} was set on nil. Called from #{source}. To allow expectations on nil, set disallow_expectations_on_nil to false.")
       end
     end
   end

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -406,44 +406,62 @@ module RSpec
     # @private
     class ProxyForNil < PartialDoubleProxy
       def initialize(order_group)
-        @warn_about_expectations = true
-        @disallow_expectations = false
+        set_expectation_behavior
         super(nil, order_group)
       end
 
-      attr_accessor :warn_about_expectations
       attr_accessor :disallow_expectations
-      alias warn_about_expectations? warn_about_expectations
-      alias disallow_expectations? disallow_expectations
+      attr_accessor :warn_about_expectations
 
       def add_message_expectation(method_name, opts={}, &block)
-        raise_error(method_name) if disallow_expectations?
-        warn(method_name) if warn_about_expectations?
+        warn_or_raise!(method_name)
         super
       end
 
       def add_negative_message_expectation(location, method_name, &implementation)
-        raise_error(method_name) if disallow_expectations?
-        warn(method_name) if warn_about_expectations?
+        warn_or_raise!(method_name)
         super
       end
 
       def add_stub(method_name, opts={}, &implementation)
-        raise_error(method_name) if disallow_expectations?
-        warn(method_name) if warn_about_expectations?
+        warn_or_raise!(method_name)
         super
       end
 
     private
 
+      def set_expectation_behavior
+        case RSpec::Mocks.configuration.allow_message_expectations_on_nil
+        when false
+          @warn_about_expectations = false
+          @disallow_expectations = true
+        when true
+          @warn_about_expectations = false
+          @disallow_expectations = false
+        else
+          @warn_about_expectations = true
+          @disallow_expectations = false
+        end
+      end
+
+      def warn_or_raise!(method_name)
+        # This method intentionally swallows the message when
+        # neither disallow_expectations nor warn_about_expectations
+        # are set to true.
+        if disallow_expectations
+          raise_error(method_name)
+        elsif warn_about_expectations
+          warn(method_name)
+        end
+      end
+
       def warn(method_name)
-        source = CallerFilter.first_non_rspec_line
-        Kernel.warn("An expectation of :#{method_name} was set on nil. Called from #{source}. Use allow_message_expectations_on_nil to disable warnings.")
+        warning_msg = @error_generator.expectation_on_nil_message(method_name)
+        RSpec.warning(warning_msg)
       end
 
       def raise_error(method_name)
-        source = CallerFilter.first_non_rspec_line
-        raise("An expectation of :#{method_name} was set on nil. Called from #{source}. To allow expectations on nil, set disallow_expectations_on_nil to false.")
+        @error_generator.raise_expectation_on_nil_error(method_name)
       end
     end
   end

--- a/spec/rspec/mocks/nil_expectation_warning_spec.rb
+++ b/spec/rspec/mocks/nil_expectation_warning_spec.rb
@@ -24,6 +24,13 @@ module RSpec
         nil.foo
       end
 
+      it "raises an error when expectations on nil are disallowed" do
+        disallow_message_expectations_on_nil
+
+        expect { expect(nil).to receive(:foo)     }.to raise_error(StandardError)
+        expect { expect(nil).not_to receive(:bar) }.to raise_error(StandardError)
+      end
+
       it 'does not call #nil? on a double extra times' do
         dbl = double
         expect(dbl).to receive(:nil?).once.and_return(false)

--- a/spec/rspec/mocks/nil_expectation_warning_spec.rb
+++ b/spec/rspec/mocks/nil_expectation_warning_spec.rb
@@ -2,8 +2,10 @@ module RSpec
   module Mocks
     RSpec.describe "an expectation set on nil" do
       it "issues a warning with file and line number information" do
-        expected_warning = %r%An expectation of :foo was set on nil. Called from #{__FILE__}:#{__LINE__+3}(:in .+)?. Use allow_message_expectations_on_nil to disable warnings.%
-        expect(Kernel).to receive(:warn).with(expected_warning)
+        expected_warning = "WARNING: An expectation of :foo was set on nil. " \
+          "To allow expectations on nil & suppress this message, set allow_expectations_on_nil to true. " \
+          "To disallow expectations on nil, set allow_expectations_on_nil to false. Called from #{__FILE__}:#{__LINE__+3}(:in .+)?."
+        expect(Kernel).to receive(:warn).with(/#{expected_warning}/)
 
         expect(nil).to receive(:foo)
         nil.foo
@@ -15,20 +17,36 @@ module RSpec
         expect(nil).not_to receive(:foo)
       end
 
-      it "does not issue a warning when expectations are set to be allowed" do
+      it 'does not issue a warning when expectations are set to be allowed' do
         allow_message_expectations_on_nil
         expect(Kernel).not_to receive(:warn)
 
         expect(nil).to receive(:foo)
-        expect(nil).not_to receive(:bar)
+        expect(nil).to_not receive(:bar)
         nil.foo
       end
 
-      it "raises an error when expectations on nil are disallowed" do
-        disallow_message_expectations_on_nil
+      context 'configured to allow expectation on nil' do
+        include_context 'with isolated configuration'
 
-        expect { expect(nil).to receive(:foo)     }.to raise_error(StandardError)
-        expect { expect(nil).not_to receive(:bar) }.to raise_error(StandardError)
+        it 'does not issue a warning when expectations are set to be allowed' do
+          RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+          expect(Kernel).not_to receive(:warn)
+
+          expect(nil).to receive(:foo)
+          expect(nil).not_to receive(:bar)
+          nil.foo
+        end
+      end
+
+      context 'configured to disallow expectations on nil' do
+        include_context 'with isolated configuration'
+
+        it "raises an error when expectations on nil are disallowed" do
+          RSpec::Mocks.configuration.allow_message_expectations_on_nil = false
+          expect { expect(nil).to receive(:foo)     }.to raise_error(RSpec::Mocks::MockExpectationError)
+          expect { expect(nil).not_to receive(:bar) }.to raise_error(RSpec::Mocks::MockExpectationError)
+        end
       end
 
       it 'does not call #nil? on a double extra times' do


### PR DESCRIPTION
This PR adds a configuration option for setting expectations on nil. Previously there was an option to `allow_expectations_on_nil` that would either warn by default or suppress the warnings when an expectation was set on nil.

Now, we have the following options that can be set inside an RSpec configuration:
* Do nothing with the config flag and retain the default behavior:
  * RSpec will warn the user when an expectation has been set on nil, but the test will not fail
* Set `allow_expectations_on_nil` to `true`:
  * RSpec will suppress the warning messages
* Set `allow_expectations_on_nil` to `false`:
  * RSpec will fail the test when the expectation has been set on nil.

This will help catch false positives and help prevent users from thinking their tests are fine when green but warnings that were given were not read.