### PR TITLE
Apply some slight improvements to nil expectation warning logic.

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -218,9 +218,9 @@ module RSpec
       end
 
       def expectation_on_nil_message(method_name)
-        "An expectation of :#{method_name} was set on nil. " \
-          "To allow expectations on nil & suppress this message, set allow_expectations_on_nil to true. " \
-          "To disallow expectations on nil, set allow_expectations_on_nil to false"
+        "An expectation of `:#{method_name}` was set on `nil`. " \
+        "To allow expectations on `nil` and suppress this message, set `config.allow_expectations_on_nil` to `true`. " \
+        "To disallow expectations on `nil`, set `config.allow_expectations_on_nil` to `false`"
       end
 
     private

--- a/spec/rspec/mocks/nil_expectation_warning_spec.rb
+++ b/spec/rspec/mocks/nil_expectation_warning_spec.rb
@@ -2,27 +2,33 @@ module RSpec
   module Mocks
     RSpec.describe "an expectation set on nil" do
       it "issues a warning with file and line number information" do
-        expected_warning = "WARNING: An expectation of :foo was set on nil. " \
-          "To allow expectations on nil & suppress this message, set allow_expectations_on_nil to true. " \
-          "To disallow expectations on nil, set allow_expectations_on_nil to false. Called from #{__FILE__}:#{__LINE__+3}(:in .+)?."
-        expect(Kernel).to receive(:warn).with(/#{expected_warning}/)
+        expect {
+          expect(nil).to receive(:foo)
+        }.to output(a_string_including(
+          "An expectation of `:foo` was set on `nil`",
+          "#{__FILE__}:#{__LINE__ - 3}"
+        )).to_stderr
 
-        expect(nil).to receive(:foo)
         nil.foo
       end
 
       it "issues a warning when the expectation is negative" do
-        expect(Kernel).to receive(:warn)
-
-        expect(nil).not_to receive(:foo)
+        expect {
+          expect(nil).not_to receive(:foo)
+        }.to output(a_string_including(
+          "An expectation of `:foo` was set on `nil`",
+          "#{__FILE__}:#{__LINE__ - 3}"
+        )).to_stderr
       end
 
       it 'does not issue a warning when expectations are set to be allowed' do
         allow_message_expectations_on_nil
-        expect(Kernel).not_to receive(:warn)
 
-        expect(nil).to receive(:foo)
-        expect(nil).to_not receive(:bar)
+        expect {
+          expect(nil).to receive(:foo)
+          expect(nil).to_not receive(:bar)
+        }.not_to output.to_stderr
+
         nil.foo
       end
 
@@ -31,10 +37,12 @@ module RSpec
 
         it 'does not issue a warning when expectations are set to be allowed' do
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
-          expect(Kernel).not_to receive(:warn)
 
-          expect(nil).to receive(:foo)
-          expect(nil).not_to receive(:bar)
+          expect {
+            expect(nil).to receive(:foo)
+            expect(nil).not_to receive(:bar)
+          }.not_to output.to_stderr
+
           nil.foo
         end
       end
@@ -63,8 +71,14 @@ module RSpec
         allow_message_expectations_on_nil
         RSpec::Mocks.teardown
         RSpec::Mocks.setup
-        expect(Kernel).to receive(:warn)
-        expect(nil).to receive(:foo)
+
+        expect {
+          expect(nil).to receive(:foo)
+        }.to output(a_string_including(
+          "An expectation of `:foo` was set on `nil`",
+          "#{__FILE__}:#{__LINE__ - 3}"
+        )).to_stderr
+
         nil.foo
       end
 


### PR DESCRIPTION
- Use backticks in the warning to indicate code snippets.
- Make specs slightly less brittle by preferring the `output`
  matcher over mocking `Kernel.warn` (an interface we don’t own),
  and by specifying only a few important bits of the warning.

Followup to #983.