### PR TITLE
Mention `and_return` in "Allowing messages" feature

### DIFF
--- a/features/basics/allowing_messages.feature
+++ b/features/basics/allowing_messages.feature
@@ -19,6 +19,20 @@ Feature: Allowing messages
      When I run `rspec allow_message_spec.rb`
      Then the examples should all pass
 
+  Scenario: Allowed messages can return values using `and_return`
+    Given a file named "allow_message_and_return_value_spec.rb" with:
+      """ruby
+      RSpec.describe "and_return" do
+        it "returns the specified return value" do
+          dbl = double("Some Collaborator")
+          allow(dbl).to receive(:foo).and_return(2)
+          expect(dbl.foo).to eq(2)
+        end
+      end
+      """
+     When I run `rspec allow_message_and_return_value_spec.rb`
+     Then the examples should all pass
+
   Scenario: Messages can be allowed in bulk using `receive_messages`
     Given a file named "receive_messages_spec.rb" with:
       """ruby


### PR DESCRIPTION
Even though `and_return` is covered in detail in following features, it would make sense to mention how to return a value while allowing a single message because it's more likely the use case a reader is looking for when they start reading the Basics topic.