### PR TITLE
Warn when `ordered` is used with `allow`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Enhancements:
 
 * Improve error message displayed when using `and_wrap_original` on pure test
   doubles. (betesh, #1063)
+* Issue warning when attempting to use unsupported
+  `allow(...).to receive(...).ordered`. (Jon Rowe, #1000)
 
 Bug Fixes:
 

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -328,6 +328,13 @@ module RSpec
       #   expect(api).to receive(:run).ordered
       #   expect(api).to receive(:finish).ordered
       def ordered(&block)
+        if type == :stub
+          RSpec.warning(
+            "`allow(...).to receive(..).ordered` is not supported and will" \
+            "have no effect, use `and_return(*ordered_values)` instead."
+          )
+        end
+
         self.inner_implementation_action = block
         additional_expected_calls.times do
           @order_group.register(self)
@@ -349,9 +356,13 @@ module RSpec
         attr_writer :expected_received_count, :expected_from, :argument_list_matcher
         protected :expected_received_count=, :expected_from=, :error_generator, :error_generator=, :implementation=
 
+        # @private
+        attr_reader :type
+
         # rubocop:disable Style/ParameterLists
         def initialize(error_generator, expectation_ordering, expected_from, method_double,
                        type=:expectation, opts={}, &implementation_block)
+          @type = type
           @error_generator = error_generator
           @error_generator.opts = opts
           @expected_from = expected_from

--- a/spec/rspec/mocks/block_return_value_spec.rb
+++ b/spec/rspec/mocks/block_return_value_spec.rb
@@ -48,13 +48,22 @@ RSpec.describe "a double declaration with a block handed to:" do
     end
   end
 
-  %w[once twice ordered].each do |method|
+  %w[once twice].each do |method|
     describe method do
       it "returns the value of executing the block" do
         obj = Object.new
         allow(obj).to receive(:foo).send(method) { 'bar' }
         expect(obj.foo).to eq('bar')
       end
+    end
+  end
+
+  describe 'ordered' do
+    it "returns the value of executing the block" do
+      obj = Object.new
+      expect_warning_with_call_site(__FILE__, __LINE__ + 1)
+      allow(obj).to receive(:foo).ordered { 'bar' }
+      expect(obj.foo).to eq('bar')
     end
   end
 

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -274,6 +274,14 @@ module RSpec
           let(:target) { allow(object) }
         end
 
+        context 'ordered with receive counts' do
+          specify 'is not supported' do
+            a_dbl = double
+            expect_warning_with_call_site(__FILE__, __LINE__ + 1)
+            allow(a_dbl).to receive(:one).ordered
+          end
+        end
+
         context 'on a class method, from a class with subclasses' do
           let(:superclass)     { Class.new { def self.foo; "foo"; end }}
           let(:subclass_redef) { Class.new(superclass) { def self.foo; ".foo."; end }}


### PR DESCRIPTION
An attempt at resolving #997, are there other scenarios we should explicitly warn about for `ordered`?