### PR TITLE
Add integration with expect methods defined in minitest 5.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,19 @@ general we discourage its use for a number of reasons:
   which doesn't help.)
 
 
+## Using rspec-mocks with minitest 5.6+
+
+The latest versions of minitest also define an `expect` method. To use the
+`expect` method defined by rspec-mocks with minitest, load the following file
+**after** minitest is loaded:
+
+```ruby
+require "rspec/mocks/minitest_integration"
+```
+
+minitest style `expect` usage should continue to work as normal. 
+
+
 ## Further Reading
 
 There are many different viewpoints about the meaning of mocks and stubs. If

--- a/lib/rspec/mocks/minitest_integration.rb
+++ b/lib/rspec/mocks/minitest_integration.rb
@@ -1,0 +1,15 @@
+require 'rspec/mocks'
+
+Minitest::Expectation.class_eval do
+  def to(*args, &block)
+    ::RSpec::Mocks::ExpectationTarget.new(target).to(*args, &block)
+  end
+
+  def not_to(*args, &block)
+    ::RSpec::Mocks::ExpectationTarget.new(target).not_to(*args, &block)
+  end
+
+  def to_not(*args, &block)
+    ::RSpec::Mocks::ExpectationTarget.new(target).to_not(*args, &block)
+  end
+end


### PR DESCRIPTION
Fixes issue #931.

Integration defines `#to`, `#not_to` and `#to_not` methods on `Minitest::Expectation`, which creates a new `RSpec::Mocks::ExpectationTarget` instance and calls the relevant method on it.