### PR TITLE
Forward block received with message on to `have_received` block.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,11 @@ Enhancements:
 * Add option for failing tests when expectations are set on `nil`.
   (Liz Rush, #983)
 
+Bug Fixes:
+
+* Fix `have_received { ... }` so that any block passed when the message
+  was received is forwarded to the `have_received` block. (Myron Marston, #1006)
+
 ### 3.3.2 / 2015-07-15
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.3.1...v3.3.2)
 

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -89,11 +89,11 @@ module RSpec
           @error_generator.raise_expectation_on_unstubbed_method(expected_method_name)
         end
 
-        @messages_received.each do |(actual_method_name, args, _)|
+        @messages_received.each do |(actual_method_name, args, received_block)|
           next unless expectation.matches?(actual_method_name, *args)
 
           expectation.safe_invoke(nil)
-          block.call(*args) if block
+          block.call(*args, &received_block) if block
         end
       end
 

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -129,6 +129,16 @@ module RSpec
           _expect(called).not_to include(:do_end)
         end
 
+        it 'forwards any block passed during method invocation to the `have_received` block' do
+          dbl = spy
+          block = lambda { }
+          dbl.foo(&block)
+
+          expect(dbl).to have_received(:foo) do |&passed_block|
+            _expect(passed_block).to be block
+          end
+        end
+
         it 'resets expectations on class methods when mocks are reset' do
           dbl = Object
           allow(dbl).to receive(:expected_method)


### PR DESCRIPTION
Fixes #1003.