### PR TITLE
Allow stubbing respond_to? on partial doubles

### DIFF
--- a/lib/rspec/mocks/method_reference.rb
+++ b/lib/rspec/mocks/method_reference.rb
@@ -94,7 +94,24 @@ module RSpec
           # write `method_missing` in such a way that it handles a dynamic message
           # with private or protected visibility. Ruby doesn't provide you with
           # the caller info.
-          return :public if vis.nil? && object.respond_to?(method_name, false)
+          return :public if vis.nil? && object_responds_to?(object, method_name, false)
+        end
+      end
+
+      # @api private
+      KERNEL_RESPOND_TO_METHOD = ::Kernel.instance_method(:respond_to?)
+
+      if Support::RubyFeatures.supports_rebinding_module_methods?
+        def self.object_responds_to?(object, method_name, visibility)
+          KERNEL_RESPOND_TO_METHOD.bind(object).call(method_name, visibility)
+        end
+      else
+        def self.object_responds_to?(object, method_name, visibility)
+          if ::Kernel === object
+            KERNEL_RESPOND_TO_METHOD.bind(object).call(method_name, visibility)
+          else
+            object.respond_to?(method_name, visibility)
+          end
         end
       end
     end

--- a/lib/rspec/mocks/method_reference.rb
+++ b/lib/rspec/mocks/method_reference.rb
@@ -85,26 +85,25 @@ module RSpec
       end
 
       def self.method_visibility_for(object, method_name)
-        instance_method_visibility_for(class << object; self; end, method_name).tap do |vis|
-          # If the method is not defined on the class, `instance_method_visibility_for`
-          # returns `nil`. However, it may be handled dynamically by `method_missing`,
-          # so here we check `respond_to` (passing false to not check private methods).
-          #
-          # This only considers the public case, but I don't think it's possible to
-          # write `method_missing` in such a way that it handles a dynamic message
-          # with private or protected visibility. Ruby doesn't provide you with
-          # the caller info.
-          proxy = RSpec::Mocks.space.proxy_for(object)
-          respond_to = proxy.method_double_if_exists_for_message(:respond_to?)
+        vis = instance_method_visibility_for(class << object; self; end, method_name)
 
-          if proxy && respond_to
-            object_responds_to_method_name = respond_to.original_method.call(method_name)
-          else
-            object_responds_to_method_name = object.respond_to?(method_name)
-          end
+        # If the method is not defined on the class, `instance_method_visibility_for`
+        # returns `nil`. However, it may be handled dynamically by `method_missing`,
+        # so here we check `respond_to` (passing false to not check private methods).
+        #
+        # This only considers the public case, but I don't think it's possible to
+        # write `method_missing` in such a way that it handles a dynamic message
+        # with private or protected visibility. Ruby doesn't provide you with
+        # the caller info.
+        return vis unless vis.nil?
 
-          return :public if vis.nil? && object_responds_to_method_name
-        end
+        proxy = RSpec::Mocks.space.proxy_for(object)
+        respond_to = proxy.method_double_if_exists_for_message(:respond_to?)
+
+        visible = respond_to && respond_to.original_method.call(method_name) ||
+          object.respond_to?(method_name)
+
+        return :public if visible
       end
     end
 

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -228,6 +228,11 @@ module RSpec
         end
       end
 
+      # @private
+      def method_double_if_exists_for_message(message)
+        method_double_for(message) if @method_doubles.key?(message.to_sym)
+      end
+
     private
 
       def method_double_for(message)

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -54,7 +54,8 @@ module RSpec
 
         an_object = the_klass.new
 
-        expect(an_object).to receive(:respond_to?).with(:my_method) { true }
+        expect(an_object).to receive(:respond_to?)
+                               .with(:my_method).at_least(:once) { true }
         expect(an_object).to receive(:my_method)
 
         an_object.call :my_method

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -43,6 +43,23 @@ module RSpec
         expect(object.bar).to eq(2)
       end
 
+      it 'allows `respond_to?` to be stubbed' do
+        the_klass = Class.new do
+          def call(name)
+            if respond_to?(name)
+              send(name)
+            end
+          end
+        end
+
+        an_object = the_klass.new
+
+        expect(an_object).to receive(:respond_to?).with(:my_method) { true }
+        expect(an_object).to receive(:my_method)
+
+        an_object.call :my_method
+      end
+
       it "can disallow messages from being received" do
         expect(object).not_to receive(:fuhbar)
         expect_fast_failure_from(


### PR DESCRIPTION
Previously stubbing `respond_to?` would causing an infinite loop when hit, this prevents that.

//cc @samphippen 