### PR TITLE
Avoid stack overflow when #respond_to? expectation fails

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -69,12 +69,7 @@ module RSpec
       end
 
       def default_error_message(expectation, expected_args, actual_args)
-        [
-          intro,
-          "received",
-          expectation.message.inspect,
-          unexpected_arguments_message(expected_args, actual_args),
-        ].join(" ")
+        "#{intro} received #{expectation.message.inspect} #{unexpected_arguments_message(expected_args, actual_args)}"
       end
 
       # rubocop:disable Style/ParameterLists

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -448,7 +448,7 @@ module RSpec
             expect(the_dbl).to have_received(:three).once.ordered
           end
 
-          it 'passes with at most receive counts when received in order', :ordered_and_vauge_counts_unsupported do
+          it 'passes with at most receive counts when received in order', :ordered_and_vague_counts_unsupported do
             the_dbl.one
             the_dbl.one
             the_dbl.two
@@ -458,7 +458,7 @@ module RSpec
             expect(the_dbl).to have_received(:two).once.ordered
           end
 
-          it 'passes with at least receive counts when received in order', :ordered_and_vauge_counts_unsupported do
+          it 'passes with at least receive counts when received in order', :ordered_and_vague_counts_unsupported do
             the_dbl.one
             the_dbl.one
             the_dbl.two
@@ -478,7 +478,7 @@ module RSpec
             }.to raise_error(/received :two out of order/m)
           end
 
-          it "fails with at most receive counts when recieved out of order", :ordered_and_vauge_counts_unsupported do
+          it "fails with at most receive counts when recieved out of order", :ordered_and_vague_counts_unsupported do
             the_dbl.one
             the_dbl.two
             the_dbl.one
@@ -489,7 +489,7 @@ module RSpec
             }.to raise_error(/received :two out of order/m)
           end
 
-          it "fails with at least receive counts when recieved out of order", :ordered_and_vauge_counts_unsupported do
+          it "fails with at least receive counts when recieved out of order", :ordered_and_vague_counts_unsupported do
             the_dbl.one
             the_dbl.two
             the_dbl.one

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -393,6 +393,27 @@ module RSpec
             reset_all
           end
         end
+
+        context "when expected message is respond_to?" do
+          context "and conditions are placed on expected call" do
+            context "and the conditions fail... :(" do
+              it "does not result in infinite recursion and stack overflow" do
+                # Setting a method expectation causes the method to be proxied
+                # RSpec may call #respond_to? when processing a failed expectation
+                # If those internal calls go to the proxied method, that could
+                #   result in another failed expectation error, causing infinite loop
+
+                expect {
+                  obj = Object.new
+                  expect(obj).to receive(:respond_to?).with('something highly unlikely')
+                  obj.respond_to?(:not_what_we_wanted)
+                }.to raise_error(/received :respond_to\? with unexpected arguments/)
+
+                reset_all
+              end
+            end
+          end
+        end
       end
 
       describe "expect_any_instance_of(...).to receive" do

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -359,7 +359,7 @@ module RSpec
             dbl.two
           end
 
-          it "fails with at least when the ordering is incorrect", :ordered_and_vauge_counts_unsupported do
+          it "fails with at least when the ordering is incorrect", :ordered_and_vague_counts_unsupported do
             expect {
               expect(dbl).to receive(:one).at_least(2).times.ordered
               expect(dbl).to receive(:two).once.ordered
@@ -379,7 +379,7 @@ module RSpec
             dbl.two
           end
 
-          it "fails with at most when the ordering is incorrect", :ordered_and_vauge_counts_unsupported do
+          it "fails with at most when the ordering is incorrect", :ordered_and_vague_counts_unsupported do
             expect {
               expect(dbl).to receive(:one).at_most(2).times.ordered
               expect(dbl).to receive(:two).once.ordered

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -109,14 +109,14 @@ RSpec.configure do |config|
   config.extend RSpec::Support::RubyFeatures
   config.include RSpec::Support::RubyFeatures
 
-  config.define_derived_metadata :ordered_and_vauge_counts_unsupported do |meta|
-    meta[:pending] = "`.ordered` combined with a vauge count (e.g. `at_least` or `at_most`) is not yet supported (see #713)"
+  config.define_derived_metadata :ordered_and_vague_counts_unsupported do |meta|
+    meta[:pending] = "`.ordered` combined with a vague count (e.g. `at_least` or `at_most`) is not yet supported (see #713)"
   end
 
   # We have yet to try to address this issue, and it's just noise in our output,
   # so skip it locally. However, on CI we want it to still run them so that if
   # we do something that makes these specs pass, we are notified.
-  config.filter_run_excluding :ordered_and_vauge_counts_unsupported unless ENV['CI']
+  config.filter_run_excluding :ordered_and_vague_counts_unsupported unless ENV['CI']
 
   RSpec::Matchers.define_negated_matcher :a_string_excluding, :include
 end


### PR DESCRIPTION
As per discussion in issue #1020.

(I slipped a spelling fix in as an extra commit...)