### PR TITLE
Supress warnings from not specifying error

### DIFF
--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -366,7 +366,7 @@ module RSpec
 
               dbl.one
               dbl.two
-            }.to raise_error
+            }.to fail
 
             reset_all
           end
@@ -388,7 +388,7 @@ module RSpec
               dbl.one
               dbl.one
               dbl.two
-            }.to raise_error
+            }.to fail
 
             reset_all
           end


### PR DESCRIPTION
Pulled this out to it's own PR because it's simple, and used your suggestion @myronmarston 