### PR TITLE
Fix problem with 'receive' on MRI 1.8.7 (when used on singleton methods in superclass and subclass)

### DIFF
--- a/lib/rspec/mocks/instance_method_stasher.rb
+++ b/lib/rspec/mocks/instance_method_stasher.rb
@@ -31,7 +31,6 @@ module RSpec
         def stashed_method_name
           "obfuscated_by_rspec_mocks__#{@method}"
         end
-        private :stashed_method_name
 
         # @private
         def restore

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -3,7 +3,7 @@ module RSpec
     # @private
     class MethodDouble
       # @private
-      attr_reader :method_name, :object, :expectations, :stubs
+      attr_reader :method_name, :object, :expectations, :stubs, :method_stasher
 
       # @private
       def initialize(object, method_name, proxy)

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "and_call_original" do
       end
     end
 
-    context "when a non-existant method has been stubbed previously" do
+    context "when a non-existent method has been stubbed previously" do
       it 'restores the original NameError behavior' do
         expect { instance.abcd }.to raise_error(NameError).with_message(/abcd/)
 
@@ -249,7 +249,7 @@ RSpec.describe "and_call_original" do
 
     let(:request) { request_klass.new(:get, "http://foo.com/bar") }
 
-    it 'still works even though #method has been overriden' do
+    it 'still works even though #method has been overridden' do
       expect(request).to receive(:perform).and_call_original
       expect(request.perform).to eq(:the_response)
     end

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -143,6 +143,19 @@ RSpec.describe "and_call_original" do
       expect(subclass.new_instance).to be_a(subclass)
     end
 
+    context 'when a class method is stubbed in the superclass' do
+      it 'still works for class methods defined on a superclass' do
+        superclass = Class.new { def self.foo; "foo"; end }
+        subclass   = Class.new(superclass)
+
+        allow(superclass).to receive(:foo).and_return(:fake)
+        expect(subclass).to receive(:foo).and_call_original
+
+        expect(superclass.foo).to be :fake
+        expect(subclass.foo).to eq "foo"
+      end
+    end
+
     it 'works for class methods defined on a grandparent class' do
       sub_subclass = Class.new(Class.new(klass))
       expect(sub_subclass).to receive(:new_instance).and_call_original


### PR DESCRIPTION
The following code is broken on MRI 1.8.7:

```ruby
class A; def self.foo; "foo"; end end
class B < A; end

allow(A).to receive(:foo) { ... }
allow(B).to receive(:foo) { ... }
```

The problem is that `Proxy#original_method_handle_for` gets the `UnboundMethod` which is stashed in the superclass' proxy, and tries to rebind it to the subclass. This doesn't work in 1.8.7.

Can you suggest a cleaner way to implement the workaround?