### PR TITLE
Only restore an instance method on the owning class

### DIFF
--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -1,5 +1,22 @@
 require 'delegate'
 
+module AnyInstanceSpec
+  class GrandparentClass
+    def foo(_a)
+      'bar'
+    end
+  end
+
+  class ParentClass < GrandparentClass
+    def foo
+      super(:a)
+    end
+  end
+
+  class ChildClass < ParentClass
+  end
+end
+
 module RSpec
   module Mocks
     RSpec.describe "#any_instance" do
@@ -1223,6 +1240,14 @@ module RSpec
           verify_all
 
           expect(instance.existing_method).to eq :existing_method_return_value
+        end
+
+       it "does not restore a stubbed method not originally implemented in the class" do
+          allow_any_instance_of(::AnyInstanceSpec::ChildClass).to receive(:foo).and_return :result
+          expect(::AnyInstanceSpec::ChildClass.new.foo).to eq :result
+
+          reset_all
+          expect(::AnyInstanceSpec::ChildClass.new.foo).to eq 'bar'
         end
 
         it "restores the original behaviour, even if the expectation fails" do


### PR DESCRIPTION
Fixes #1042

```ruby
class Shape
  def area(value)
    value
  end
end

class Circle < Shape
  def area
    super(2)
  end
end

class SmallCircle < Circle
end
```

When using: allow_any_instance_of(SmallCircle).to receive(:area)

Previously, we'd copy the area method from the first superclass
that implements it.  In this case, we'd copy Circle#area into
SmallCircle with a backup name.

At the end of the example, we'd remove the stubbing and rename the
copied method back, causing SmallCircle to implement area when it never
did previously.

Any calls to SmallCircle#area would end up calling the contents of
Circle#area and the call to super(2) would be sent to the wrong class:
Circle, not Shape.  In this case, Circle#area doesn't take any
arguments so you get an ArgumentError.

Previously, ruby 2.2 and below allowed this strange behavior to work.

This appears to have been "fixed" in ruby in this commit:
https://github.com/ruby/ruby/commit/c8854d2ca4be9ee6946e6d17b0e17d9ef130ee81