### PR TITLE
Undefine original method in InstanceMethodStasher#stash

### DIFF
--- a/lib/rspec/mocks/instance_method_stasher.rb
+++ b/lib/rspec/mocks/instance_method_stasher.rb
@@ -54,6 +54,7 @@ module RSpec
         def stash
           return unless method_defined_directly_on_klass?
           @original_method ||= ::RSpec::Support.method_handle_for(@object, @method)
+          @klass.__send__(:undef_method, @method)
         end
 
         # @private

--- a/spec/rspec/mocks/instance_method_stasher_spec.rb
+++ b/spec/rspec/mocks/instance_method_stasher_spec.rb
@@ -60,12 +60,19 @@ module RSpec
         def obj.hello; :hello_defined_on_singleton_class; end;
 
         stashed_method = stasher_for(obj, :hello)
-
-        expect {
-          stashed_method.stash
-        }.not_to change { obj.methods.count }
-
+        stashed_method.stash
         expect(obj.methods.grep(/rspec/)).to eq([])
+      end
+
+      it "undefines the original method", :if => (RUBY_VERSION.to_f > 1.8) do
+        obj = Object.new
+        def obj.hello; :hello_defined_on_singleton_class; end;
+
+        stashed_method = stasher_for(obj, :hello)
+        stashed_method.stash
+
+        expect(obj.methods).not_to include(:hello)
+        expect(obj).not_to respond_to(:hello)
       end
     end
   end


### PR DESCRIPTION
... to handle the method redefinition warning on MRI 2.3:

```
/Users/me/Projects/rspec-dev/repos/rspec-mocks/lib/rspec/mocks/method_double.rb:63: warning: method redefined; discarding old running_in_drb?
/Users/me/Projects/rspec-dev/repos/rspec-core/lib/rspec/core/runner.rb:150: warning: previous definition of running_in_drb? was here
```

For some reason MRI 2.2 does not warn of method redefinition when the original method handle has been taken with `Object#method` before the redefinition. On the other hand, MRI 2.3 warns of it regardless of whether the original method handle has been taken or not.

```ruby
obj = Object.new

def obj.foo
  :original_foo
end

obj.method(:foo) if ARGV.first == 'take_method_handle'

singleton_klass = class << obj; self; end
singleton_klass.class_exec do
  define_method(:foo) { }
end
```

```bash
$ ruby -v -w test.rb
ruby 2.2.4p230 (2015-12-16 revision 53155) [x86_64-darwin14]
test.rb:11: warning: method redefined; discarding old foo
test.rb:3: warning: previous definition of foo was here

$ ruby -v -w test.rb take_method_handle
ruby 2.2.4p230 (2015-12-16 revision 53155) [x86_64-darwin14]

$ ruby -v -w test.rb
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin14]
test.rb:11: warning: method redefined; discarding old foo
test.rb:3: warning: previous definition of foo was here

$ ruby -v -w test.rb take_method_handle
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin14]
test.rb:11: warning: method redefined; discarding old foo
test.rb:3: warning: previous definition of foo was here
```

Previously we have left the original method as is in `InstanceMethodStasher#stash`, because it would soon be overwritten in `MethodDouble#define_proxy_method`. However now MRI 2.3 warns of it, so we
should properly undefine the original method before redefining it.

@rspec/rspec Thoughts?

This fixes #1041.
