### PR TITLE
Chain and_yields for any_instance

### DIFF
--- a/lib/rspec/mocks/any_instance/stub_chain.rb
+++ b/lib/rspec/mocks/any_instance/stub_chain.rb
@@ -30,7 +30,7 @@ module RSpec
             :with => [nil],
             :and_return => [:with, nil],
             :and_raise => [:with, nil],
-            :and_yield => [:with, nil],
+            :and_yield => [:with, :and_yield, nil],
             :and_call_original => [:with, nil],
             :and_wrap_original => [:with, nil]
           }

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -33,6 +33,13 @@ module RSpec
       end
       let(:existing_method_return_value) { :existing_method_return_value }
 
+      context "chain" do
+        it "yields the value specified" do
+          allow_any_instance_of(klass).to receive(:foo).and_yield(1).and_yield(2)
+          expect { |b| klass.new.foo(&b) }.to yield_successive_args(1, 2)
+        end
+      end
+
       context "invocation order" do
         context "when stubbing" do
           it "raises an error if 'with' follows 'and_return'" do
@@ -45,6 +52,11 @@ module RSpec
 
           it "raises an error if 'with' follows 'and_yield'" do
             expect { allow_any_instance_of(klass).to receive(:foo).and_yield(1).with("1") }.to raise_error(NoMethodError)
+          end
+
+          it "allows chaining 'and_yield'" do
+            allow_any_instance_of(klass).to receive(:foo).and_yield(1).and_yield(2)
+            expect { |b| klass.new.foo(&b) }.to yield_successive_args(1, 2)
           end
         end
 


### PR DESCRIPTION
This fixes #1025.
```
allow_any_instance_of(Klass).to receive(:method).and_yield(1).and_yield(2)
```
now behaves as expected, instead of raising `NoMethodError: Undefined method and_yield`.