### PR TITLE
Allow inheriting mocks matchers

### DIFF
--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -117,6 +117,7 @@ module RSpec
 
     # Namespace for mock-related matchers.
     module Matchers
+      autoload :Matcher,             "rspec/mocks/matchers/matcher"
       autoload :HaveReceived,        "rspec/mocks/matchers/have_received"
       autoload :Receive,             "rspec/mocks/matchers/receive"
       autoload :ReceiveMessageChain, "rspec/mocks/matchers/receive_message_chain"

--- a/lib/rspec/mocks/matchers/have_received.rb
+++ b/lib/rspec/mocks/matchers/have_received.rb
@@ -3,6 +3,8 @@ module RSpec
     module Matchers
       # @private
       class HaveReceived
+        include Matcher
+
         COUNT_CONSTRAINTS = %w[exactly at_least at_most times once twice thrice]
         ARGS_CONSTRAINTS = %w[with]
         CONSTRAINTS = COUNT_CONSTRAINTS + ARGS_CONSTRAINTS + %w[ordered]

--- a/lib/rspec/mocks/matchers/matcher.rb
+++ b/lib/rspec/mocks/matchers/matcher.rb
@@ -1,0 +1,8 @@
+module RSpec
+  module Mocks
+    module Matchers
+      # just a "tag" for rspec-mock matchers detection
+      module Matcher; end
+    end
+  end
+end

--- a/lib/rspec/mocks/matchers/receive.rb
+++ b/lib/rspec/mocks/matchers/receive.rb
@@ -5,6 +5,8 @@ module RSpec
     module Matchers
       # @private
       class Receive
+        include Matcher
+
         def initialize(message, block)
           @message                 = message
           @block                   = block

--- a/lib/rspec/mocks/matchers/receive_message_chain.rb
+++ b/lib/rspec/mocks/matchers/receive_message_chain.rb
@@ -5,6 +5,8 @@ module RSpec
     module Matchers
       # @private
       class ReceiveMessageChain
+        include Matcher
+
         def initialize(chain, &block)
           @chain = chain
           @block = block

--- a/lib/rspec/mocks/matchers/receive_messages.rb
+++ b/lib/rspec/mocks/matchers/receive_messages.rb
@@ -3,6 +3,8 @@ module RSpec
     module Matchers
       # @private
       class ReceiveMessages
+        include Matcher
+
         def initialize(message_return_value_hash)
           @message_return_value_hash = message_return_value_hash
           @backtrace_line = CallerFilter.first_non_rspec_line

--- a/lib/rspec/mocks/targets.rb
+++ b/lib/rspec/mocks/targets.rb
@@ -38,7 +38,7 @@ module RSpec
     private
 
       def matcher_allowed?(matcher)
-        matcher.class.name.start_with?("RSpec::Mocks::Matchers".freeze)
+        Matchers::Matcher === matcher
       end
 
       def define_matcher(matcher, name, &block)

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -90,6 +90,12 @@ module RSpec
           }.to raise_error(UnsupportedMatcherError)
         end
 
+        it 'does support inherited matchers', :unless => options.include?(:allow_other_matchers) do
+          receive_foo = Class.new(RSpec::Mocks::Matchers::Receive).new(:foo, nil)
+          wrapped.to receive_foo
+          receiver.foo
+        end
+
         it 'does not get confused by messages being passed as strings and symbols' do
           wrapped.to receive(:foo).with(1) { :a }
           wrapped.to receive("foo").with(2) { :b }


### PR DESCRIPTION
With reference to #1055

Allows rspec matchers inherited from `RSpec::Mocks::Matchers::*` to be used
both in mocks and expectations:

```ruby
  class ReceiveFoo < RSpec::Mocks::Matchers::Receive
    def initialize
      super :foo, nil
    end
  end

  describe "receiving foo" do
    it "works" do
      object = double

      allow(object).to receive_foo
      expect(object).to receive_foo

      object.foo
    end
  end
```