### PR TITLE
Allow constraining arguments on any instance using receive_message_chain and `with`

### DIFF
--- a/lib/rspec/mocks/any_instance/stub_chain_chain.rb
+++ b/lib/rspec/mocks/any_instance/stub_chain_chain.rb
@@ -16,6 +16,7 @@ module RSpec
 
         def invocation_order
           @invocation_order ||= {
+            :with => [nil],
             :and_return => [nil],
             :and_raise => [nil],
             :and_yield => [nil]

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -112,6 +112,13 @@ module RSpec
               allow_any_instance_of(klass).to receive_message_chain('one.two.three').and_return(:four)
               expect(klass.new.one.two.three).to eq(:four)
             end
+
+            it "can constrain the return value by the argument to the last call" do
+              allow_any_instance_of(klass).to receive_message_chain(:one, :plus).with(1) { 2 }
+              allow_any_instance_of(klass).to receive_message_chain(:one, :plus).with(2) { 3 }
+              expect(klass.new.one.plus(1)).to eq(2)
+              expect(klass.new.one.plus(2)).to eq(3)
+            end
           end
         end
 


### PR DESCRIPTION
Fixes #1050. We never tested constraining arguments in an `any_instance` scenario so this would blow up on chains. This fixes that.