### PR TITLE
Add proper minitest integration.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ Enhancements:
   doubles. (betesh, #1063)
 * Issue warning when attempting to use unsupported
   `allow(...).to receive(...).ordered`. (Jon Rowe, #1000)
+* Add `rspec/mocks/minitest_integration`, to properly integration rspec-mocks
+  with minitest. (Myron Marston, #1065)
 
 Bug Fixes:
 

--- a/features/.nav
+++ b/features/.nav
@@ -40,5 +40,6 @@
   - unstub.feature
 - outside_rspec:
   - minitest.feature
+  - any_test_framework.feature
   - standalone.feature
 - Changelog

--- a/features/outside_rspec/any_test_framework.feature
+++ b/features/outside_rspec/any_test_framework.feature
@@ -1,0 +1,116 @@
+Feature: Integrate with any test framework
+
+  rspec-mocks is a stand-alone gem that can be integrated with any test framework. The
+  example below demonstrates using rspec-mocks with [minitest](http://docs.seattlerb.org/minitest/), but these steps
+  would apply when integrating rspec-mocks with any library or framework:
+
+    * Include `RSpec::Mocks::ExampleMethods` in your test context. This provides rspec-mocks' API.
+    * Call `RSpec::Mocks.setup` before a test begins.
+    * Call `RSpec::Mocks.verify` after a test completes to verify message expectations. Note
+      that this step is optional; rspec-core, for example, skips this when an example has already failed.
+    * Call `RSpec::Mocks.teardown` after a test completes (and after `verify`) to cleanup. This
+      _must_ be called, even if an error has occurred, so it generally goes in an `ensure` clause.
+
+  Note: if you are using minitest, you'll probably want to use the built-in [minitest integration](./integrate-with-minitest).
+
+  Scenario: Use rspec-mocks with Minitest
+    Given a file named "test/test_helper.rb" with:
+      """ruby
+      require 'minitest/autorun'
+      require 'rspec/mocks'
+
+      module MinitestRSpecMocksIntegration
+        include ::RSpec::Mocks::ExampleMethods
+
+        def before_setup
+          ::RSpec::Mocks.setup
+          super
+        end
+
+        def after_teardown
+          super
+          ::RSpec::Mocks.verify
+        ensure
+          ::RSpec::Mocks.teardown
+        end
+      end
+
+      Minitest::Test.send(:include, MinitestRSpecMocksIntegration)
+      """
+    And a file named "test/rspec_mocks_test.rb" with:
+      """ruby
+      require 'test_helper'
+
+      class RSpecMocksTest < Minitest::Test
+        def test_passing_positive_expectation
+          dbl = double
+          expect(dbl).to receive(:message)
+          dbl.message
+        end
+
+        def test_failing_positive_expectation
+          dbl = double
+          expect(dbl).to receive(:message)
+        end
+
+        def test_passing_negative_expectation
+          dbl = double
+          expect(dbl).to_not receive(:message)
+        end
+
+        def test_failing_negative_expectation
+          dbl = double
+          expect(dbl).to_not receive(:message)
+          dbl.message
+        end
+
+        def test_passing_positive_spy_expectation
+          bond = spy
+          bond.james
+          expect(bond).to have_received(:james)
+        end
+
+        def test_failing_positive_spy_expectation
+          bond = spy
+          expect(bond).to have_received(:james)
+        end
+
+        def test_passing_negative_spy_expectation
+          bond = spy
+          expect(bond).not_to have_received(:james)
+        end
+
+        def test_failing_negative_spy_expectation
+          bond = spy
+          bond.james
+          expect(bond).not_to have_received(:james)
+        end
+      end
+      """
+     When I run `ruby -Itest test/rspec_mocks_test.rb`
+     Then it should fail with the following output:
+       |   1) Error:                                                                   |
+       | RSpecMocksTest#test_failing_negative_expectation:                             |
+       | RSpec::Mocks::MockExpectationError: (Double (anonymous)).message(no args)     |
+       |     expected: 0 times with any arguments                                      |
+       |     received: 1 time                                                          |
+       |                                                                               |
+       |   2) Error:                                                                   |
+       | RSpecMocksTest#test_failing_positive_expectation:                             |
+       | RSpec::Mocks::MockExpectationError: (Double (anonymous)).message(*(any args)) |
+       |     expected: 1 time with any arguments                                       |
+       |     received: 0 times with any arguments                                      |
+       |                                                                               |
+       |   3) Error:                                                                   |
+       | RSpecMocksTest#test_failing_positive_spy_expectation:                         |
+       | RSpec::Mocks::MockExpectationError: (Double (anonymous)).james(*(any args))   |
+       |     expected: 1 time with any arguments                                       |
+       |     received: 0 times with any arguments                                      |
+       |                                                                               |
+       |   4) Error:                                                                   |
+       | RSpecMocksTest#test_failing_negative_spy_expectation:                         |
+       | RSpec::Mocks::MockExpectationError: (Double (anonymous)).james(no args)       |
+       |     expected: 0 times with any arguments                                      |
+       |     received: 1 time                                                          |
+       |                                                                               |
+       |  8 runs, 0 assertions, 0 failures, 4 errors, 0 skips                          |

--- a/lib/rspec/mocks/minitest_integration.rb
+++ b/lib/rspec/mocks/minitest_integration.rb
@@ -1,0 +1,68 @@
+require 'rspec/mocks'
+
+module RSpec
+  module Mocks
+    # @private
+    module MinitestIntegration
+      include ::RSpec::Mocks::ExampleMethods
+
+      def before_setup
+        ::RSpec::Mocks.setup
+        super
+      end
+
+      def after_teardown
+        super
+
+        # Only verify if there's not already an error. Otherwise
+        # we risk getting the same failure twice, since negative
+        # expectation violations raise both when the message is
+        # unexpectedly received, and also during `verify` (in case
+        # the first failure was caught by user code via a
+        # `rescue Exception`).
+        ::RSpec::Mocks.verify unless failures.any?
+      ensure
+        ::RSpec::Mocks.teardown
+      end
+    end
+  end
+end
+
+Minitest::Test.send(:include, RSpec::Mocks::MinitestIntegration)
+
+if defined?(::Minitest::Expectation)
+  if defined?(::RSpec::Expectations) && ::Minitest::Expectation.method_defined?(:to)
+    # rspec/expectations/minitest_integration has already been loaded and
+    # has defined `to`/`not_to`/`to_not` on `Minitest::Expectation` so we do
+    # not want to here (or else we would interfere with rspec-expectations' definition).
+  else
+    # ...otherwise, define those methods now. If `rspec/expectations/minitest_integration`
+    # is loaded after this file, it'll overide the defintion here.
+    Minitest::Expectation.class_eval do
+      include RSpec::Mocks::ExpectationTargetMethods
+
+      def to(*args)
+        ctx.assertions += 1
+        super
+      end
+
+      def not_to(*args)
+        ctx.assertions += 1
+        super
+      end
+
+      def to_not(*args)
+        ctx.assertions += 1
+        super
+      end
+    end
+  end
+end
+
+module RSpec
+  module Mocks
+    remove_const :MockExpectationError
+    # Raised when a message expectation is not satisfied.
+    MockExpectationError = ::Minitest::Assertion
+  end
+end

--- a/lib/rspec/mocks/targets.rb
+++ b/lib/rspec/mocks/targets.rb
@@ -1,12 +1,8 @@
 module RSpec
   module Mocks
     # @private
-    class TargetBase
-      def initialize(target)
-        @target = target
-      end
-
-      def self.delegate_to(matcher_method)
+    module TargetDelegationClassMethods
+      def delegate_to(matcher_method)
         define_method(:to) do |matcher, &block|
           unless matcher_allowed?(matcher)
             raise_unsupported_matcher(:to, matcher)
@@ -15,7 +11,7 @@ module RSpec
         end
       end
 
-      def self.delegate_not_to(matcher_method, options={})
+      def delegate_not_to(matcher_method, options={})
         method_name = options.fetch(:from)
         define_method(method_name) do |matcher, &block|
           case matcher
@@ -29,11 +25,16 @@ module RSpec
         end
       end
 
-      def self.disallow_negation(method_name)
+      def disallow_negation(method_name)
         define_method(method_name) do |matcher, *_args|
           raise_negation_unsupported(method_name, matcher)
         end
       end
+    end
+
+    # @private
+    module TargetDelegationInstanceMethods
+      attr_reader :target
 
     private
 
@@ -42,7 +43,7 @@ module RSpec
       end
 
       def define_matcher(matcher, name, &block)
-        matcher.__send__(name, @target, &block)
+        matcher.__send__(name, target, &block)
       end
 
       def raise_unsupported_matcher(method_name, matcher)
@@ -56,31 +57,54 @@ module RSpec
               "`#{expression}(...).#{method_name} #{matcher.name}` is not supported since it " \
               "doesn't really make sense. What would it even mean?"
       end
+    end
+
+    # @private
+    class TargetBase
+      def initialize(target)
+        @target = target
+      end
+
+      extend TargetDelegationClassMethods
+      include TargetDelegationInstanceMethods
+    end
+
+    # @private
+    module ExpectationTargetMethods
+      extend TargetDelegationClassMethods
+      include TargetDelegationInstanceMethods
+
+      delegate_to :setup_expectation
+      delegate_not_to :setup_negative_expectation, :from => :not_to
+      delegate_not_to :setup_negative_expectation, :from => :to_not
 
       def expression
-        self.class::EXPRESSION
+        :expect
       end
     end
 
     # @private
+    class ExpectationTarget < TargetBase
+      include ExpectationTargetMethods
+    end
+
+    # @private
     class AllowanceTarget < TargetBase
-      EXPRESSION = :allow
+      def expression
+        :allow
+      end
+
       delegate_to :setup_allowance
       disallow_negation :not_to
       disallow_negation :to_not
     end
 
     # @private
-    class ExpectationTarget < TargetBase
-      EXPRESSION = :expect
-      delegate_to :setup_expectation
-      delegate_not_to :setup_negative_expectation, :from => :not_to
-      delegate_not_to :setup_negative_expectation, :from => :to_not
-    end
-
-    # @private
     class AnyInstanceAllowanceTarget < TargetBase
-      EXPRESSION = :allow_any_instance_of
+      def expression
+        :allow_any_instance_of
+      end
+
       delegate_to :setup_any_instance_allowance
       disallow_negation :not_to
       disallow_negation :to_not
@@ -88,7 +112,10 @@ module RSpec
 
     # @private
     class AnyInstanceExpectationTarget < TargetBase
-      EXPRESSION = :expect_any_instance_of
+      def expression
+        :expect_any_instance_of
+      end
+
       delegate_to :setup_any_instance_expectation
       delegate_not_to :setup_any_instance_negative_expectation, :from => :not_to
       delegate_not_to :setup_any_instance_negative_expectation, :from => :to_not

--- a/spec/rspec/mocks_spec.rb
+++ b/spec/rspec/mocks_spec.rb
@@ -2,6 +2,9 @@ require 'rspec/support/spec/library_wide_checks'
 
 RSpec.describe RSpec::Mocks do
   lib_preamble = [
+    # We define minitest constants because rspec/mocks/minitest_integration
+    # expects these constants to already be defined.
+    "module Minitest; class Assertion; end; module Test; end; end",
     'require "rspec/mocks"',
     # Must be required before other files due to how our autoloads are setup.
     # (Users won't hit this problem because they won't require all the files


### PR DESCRIPTION
`require 'rspec/mocks/minitest_integration'` will configure minitest
to work properly with rspec-mocks.

This also deals with the addition of `expect` to Minitest::Spec 5.6+.

Fixes #931.