### PR TITLE
Add spec for delegating to the original instance method w/in the block implementation

### DIFF
--- a/features/old_syntax/any_instance.feature
+++ b/features/old_syntax/any_instance.feature
@@ -82,6 +82,26 @@ Feature: `any_instance`
     When I run `rspec spec/example_spec.rb`
     Then the examples should all pass
 
+  Scenario: Block implementation supports delegating to the original implementation
+    Given a file named "spec/any_instance_delegate_to_original_spec.rb" with:
+      """ruby
+      RSpec.describe "Stubbing any instance of a class" do
+        it 'supports delegating to the original instance method within the block implementation' do
+          original_instance_method = String.instance_method(:slice)
+          String.any_instance.stub(:slice) do |instance, start, length|
+            expect(start).to be_a Fixnum
+            expect(length).to be_a Fixnum
+
+            original_instance_method.bind(instance).call(start, length)
+          end
+
+          expect('string'.slice(2, 3)).to eq('rin')
+        end
+      end
+      """
+    When I run `rspec spec/any_instance_delegate_to_original_spec.rb`
+    Then the examples should all pass
+
   Scenario: Expect a message on any instance of a class
     Given a file named "spec/example_spec.rb" with:
       """ruby


### PR DESCRIPTION
In [this example](https://www.relishapp.com/rspec/rspec-mocks/v/3-3/docs/working-with-legacy-code/any-instance#block-implementation-is-passed-the-receiver-as-first-arg) `String#slice` was replaced within the block with `String#[]`. In some cases, you don't have to luxury of having an equivalent method to rely on. Sometimes, you just want to use the same method within the block and include some assertions before it (or do something else if you wanted to).

This example clears that up. Hopefully it will save someone a few minutes/hours. :) Didn't know [UnboundMethod](docs.ruby-lang.org/en/2.2.0/UnboundMethod.html) in ruby before.