### PR TITLE
Add explicit link to Configuring Responses section for `*_any_instance_of`

### DIFF
--- a/features/working_with_legacy_code/any_instance.feature
+++ b/features/working_with_legacy_code/any_instance.feature
@@ -11,6 +11,8 @@ Feature: Any Instance
 
   These methods add the appropriate stub or expectation to all instances of `Widget`.
 
+  You can also [configure the responses](../configuring-responses) in the same manner.
+
   This feature is sometimes useful when working with legacy code, though in general we
   discourage its use for a number of reasons:
 


### PR DESCRIPTION
To suggest that it can also be used without having to add an extraneous example in the feature specs.

As suggested in #1082 