### PR TITLE
Provide a nice string representation of a message expectation.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### 3.5 Development
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.5.0.beta4...master)
 
+Enhancements:
+
+* Provides a nice string representation of
+  `RSpec::Mocks::MessageExpectation` (Myron Marston, #1095)
+
 ### 3.5.0.beta4 / 2016-06-05
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.5.0.beta3...v3.5.0.beta4)
 

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -218,6 +218,33 @@ module RSpec
         "To disallow expectations on `nil`, set `config.allow_message_expectations_on_nil` to `false`"
       end
 
+      # @private
+      def intro(unwrapped=false)
+        case @target
+        when TestDouble then TestDoubleFormatter.format(@target, unwrapped)
+        when Class then
+          formatted = "#{@target.inspect} (class)"
+          return formatted if unwrapped
+          "#<#{formatted}>"
+        when NilClass then "nil"
+        else @target.inspect
+        end
+      end
+
+      # @private
+      def method_call_args_description(args, generic_prefix=" with arguments: ", matcher_prefix=" with ")
+        case args.first
+        when ArgumentMatchers::AnyArgsMatcher then "#{matcher_prefix}any arguments"
+        when ArgumentMatchers::NoArgsMatcher  then "#{matcher_prefix}no arguments"
+        else
+          if yield
+            "#{generic_prefix}#{format_args(args)}"
+          else
+            ""
+          end
+        end
+      end
+
     private
 
       def received_part_of_expectation_error(actual_received_count, args)
@@ -232,19 +259,6 @@ module RSpec
           method_call_args_description(argument_list_matcher.expected_args) do
             argument_list_matcher.expected_args.length > 0
           end
-      end
-
-      def method_call_args_description(args)
-        case args.first
-        when ArgumentMatchers::AnyArgsMatcher then " with any arguments"
-        when ArgumentMatchers::NoArgsMatcher  then " with no arguments"
-        else
-          if yield
-            " with arguments: #{format_args(args)}"
-          else
-            ""
-          end
-        end
       end
 
       def unexpected_arguments_message(expected_args_string, actual_args_string)
@@ -288,18 +302,6 @@ module RSpec
 
       def differ
         RSpec::Support::Differ.new(:color => RSpec::Mocks.configuration.color?)
-      end
-
-      def intro(unwrapped=false)
-        case @target
-        when TestDouble then TestDoubleFormatter.format(@target, unwrapped)
-        when Class then
-          formatted = "#{@target.inspect} (class)"
-          return formatted if unwrapped
-          "#<#{formatted}>"
-        when NilClass then "nil"
-        else @target
-        end
       end
 
       def __raise(message, backtrace_line=nil, source_id=nil)

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -343,6 +343,14 @@ module RSpec
         self
       end
 
+      # @return [String] a nice representation of the message expectation
+      def to_s
+        args_description = error_generator.method_call_args_description(@argument_list_matcher.expected_args, "", "") { true }
+        args_description = "(#{args_description})" unless args_description.start_with?("(")
+        "#<#{self.class} #{error_generator.intro}.#{message}#{args_description}>"
+      end
+      alias inspect to_s
+
       # @private
       # Contains the parts of `MessageExpectation` that aren't part of
       # rspec-mocks' public API. The class is very big and could really use

--- a/spec/rspec/mocks/message_expectation_string_representation_spec.rb
+++ b/spec/rspec/mocks/message_expectation_string_representation_spec.rb
@@ -1,3 +1,21 @@
+# Add temporary monkey patch to see if this fixes the 1.8.7 travis build
+# before we merge the rspec-expectations PR with this fix.
+RSpec::Matchers::EnglishPhrasing.class_eval do
+  if RUBY_VERSION == '1.8.7'
+    # Not sure why, but on travis on 1.8.7 we have gotten these warnings:
+    # lib/rspec/matchers/english_phrasing.rb:28: warning: default `to_a' will be obsolete
+    # So it appears that `Array` can trigger that (e.g. by calling `to_a` on the passed object?)
+    # So here we replace `Kernel#Array` with our own warning-free implementation for 1.8.7.
+    # @private
+    def self.Array(obj)
+      case obj
+      when Array then obj
+      else [obj]
+      end
+    end
+  end
+end
+
 module RSpec
   module Mocks
     RSpec.describe MessageExpectation, "has a nice string representation" do

--- a/spec/rspec/mocks/message_expectation_string_representation_spec.rb
+++ b/spec/rspec/mocks/message_expectation_string_representation_spec.rb
@@ -1,0 +1,36 @@
+module RSpec
+  module Mocks
+    RSpec.describe MessageExpectation, "has a nice string representation" do
+      let(:test_double) { double }
+
+      example "for a raw message expectation on a test double" do
+        expect(allow(test_double).to receive(:foo)).to have_string_representation(
+          "#<RSpec::Mocks::MessageExpectation #<Double (anonymous)>.foo(any arguments)>"
+        )
+      end
+
+      example "for a raw message expectation on a partial double" do
+        expect(allow("partial double").to receive(:foo)).to have_string_representation(
+          '#<RSpec::Mocks::MessageExpectation "partial double".foo(any arguments)>'
+        )
+      end
+
+      example "for a message expectation constrained by `with`" do
+        expect(allow(test_double).to receive(:foo).with(1, a_kind_of(String), any_args)).to have_string_representation(
+          "#<RSpec::Mocks::MessageExpectation #<Double (anonymous)>.foo(1, a kind of String, *(any args))>"
+        )
+      end
+
+      RSpec::Matchers.define :have_string_representation do |expected_representation|
+        match do |object|
+          values_match?(expected_representation, object.to_s) && object.to_s == object.inspect
+        end
+
+        failure_message do |object|
+          "expected string representation: #{expected_representation}\n" \
+          " but got string representation: #{object.to_s}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For the new book, we're using `rspec/mocks/standalone` in an `irb` session to demonstrate some concepts.  Unfortunately, the existing `to_s` output of a message expectation is super long and really scary looking.  This makes it much nicer.