### PR TITLE
Temporarily suppress verifying partial doubles.

### DIFF
--- a/benchmarks/accessing_configuration_via_method_vs_cache.rb
+++ b/benchmarks/accessing_configuration_via_method_vs_cache.rb
@@ -1,0 +1,52 @@
+require 'benchmark'
+
+n = 10_000
+
+require 'rspec/mocks'
+
+# precache config
+RSpec::Mocks.configuration
+
+Benchmark.benchmark do |bm|
+  puts "#{n} times - ruby #{RUBY_VERSION}"
+
+  puts
+  puts "directly"
+
+  3.times do
+    bm.report do
+      n.times do
+        original_state = RSpec::Mocks.configuration.temporarily_suppress_partial_double_verification
+        RSpec::Mocks.configuration.temporarily_suppress_partial_double_verification = true
+        RSpec::Mocks.configuration.temporarily_suppress_partial_double_verification = original_state
+      end
+    end
+  end
+
+  puts
+  puts "with cached value"
+
+  3.times do
+    bm.report do
+      n.times do
+        config = RSpec::Mocks.configuration
+        original_state = config.temporarily_suppress_partial_double_verification
+        config.temporarily_suppress_partial_double_verification = true
+        config.temporarily_suppress_partial_double_verification = original_state
+      end
+    end
+  end
+end
+
+__END__
+10000 times - ruby 2.3.1
+
+directly
+   0.000000   0.000000   0.000000 (  0.002654)
+   0.000000   0.000000   0.000000 (  0.002647)
+   0.010000   0.000000   0.010000 (  0.002645)
+
+with cached value
+   0.000000   0.000000   0.000000 (  0.001386)
+   0.000000   0.000000   0.000000 (  0.001387)
+   0.000000   0.000000   0.000000 (  0.001399)

--- a/lib/rspec/mocks/configuration.rb
+++ b/lib/rspec/mocks/configuration.rb
@@ -8,6 +8,7 @@ module RSpec
         @verify_doubled_constant_names = false
         @transfer_nested_constants = false
         @verify_partial_doubles = false
+        @temporarily_suppressing_verification = false
       end
 
       # Sets whether RSpec will warn, ignore, or fail a test when
@@ -152,6 +153,11 @@ module RSpec
       def verify_partial_doubles?
         @verify_partial_doubles
       end
+
+      # @private
+      # Used to track wether we are temporarily suppressing verifying doubles
+      # with `without_verifying_partial_doubles { ... }`
+      attr_accessor :temporarily_suppressing_verification
 
       if ::RSpec.respond_to?(:configuration)
         def color?

--- a/lib/rspec/mocks/configuration.rb
+++ b/lib/rspec/mocks/configuration.rb
@@ -156,7 +156,7 @@ module RSpec
 
       # @private
       # Used to track wether we are temporarily suppressing verifying partial
-      # doubles with `without_verifying_partial_doubles { ... }`
+      # doubles with `without_partial_double_verification { ... }`
       attr_accessor :temporarily_suppress_partial_double_verification
 
       if ::RSpec.respond_to?(:configuration)

--- a/lib/rspec/mocks/configuration.rb
+++ b/lib/rspec/mocks/configuration.rb
@@ -8,7 +8,7 @@ module RSpec
         @verify_doubled_constant_names = false
         @transfer_nested_constants = false
         @verify_partial_doubles = false
-        @temporarily_suppressing_partial_double_verification = false
+        @temporarily_suppress_partial_double_verification = false
       end
 
       # Sets whether RSpec will warn, ignore, or fail a test when
@@ -157,7 +157,7 @@ module RSpec
       # @private
       # Used to track wether we are temporarily suppressing verifying partial
       # doubles with `without_verifying_partial_doubles { ... }`
-      attr_accessor :temporarily_suppressing_partial_double_verification
+      attr_accessor :temporarily_suppress_partial_double_verification
 
       if ::RSpec.respond_to?(:configuration)
         def color?

--- a/lib/rspec/mocks/configuration.rb
+++ b/lib/rspec/mocks/configuration.rb
@@ -8,7 +8,7 @@ module RSpec
         @verify_doubled_constant_names = false
         @transfer_nested_constants = false
         @verify_partial_doubles = false
-        @temporarily_suppressing_verification = false
+        @temporarily_suppressing_partial_double_verification = false
       end
 
       # Sets whether RSpec will warn, ignore, or fail a test when
@@ -155,9 +155,9 @@ module RSpec
       end
 
       # @private
-      # Used to track wether we are temporarily suppressing verifying doubles
-      # with `without_verifying_partial_doubles { ... }`
-      attr_accessor :temporarily_suppressing_verification
+      # Used to track wether we are temporarily suppressing verifying partial
+      # doubles with `without_verifying_partial_doubles { ... }`
+      attr_accessor :temporarily_suppressing_partial_double_verification
 
       if ::RSpec.respond_to?(:configuration)
         def color?

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -286,7 +286,7 @@ module RSpec
       # block, this is useful in situations where methods are defined at run
       # time and you wish to define stubs for them but not turn off partial
       # doubles for the entire run suite. (e.g. view specs in rspec-rails).
-      def without_verifying_partial_doubles
+      def without_partial_double_verification
         Mocks.configuration.temporarily_suppress_partial_double_verification = true
         yield
       ensure

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -287,10 +287,10 @@ module RSpec
       # time and you wish to define stubs for them but not turn off partial
       # doubles for the entire run suite. (e.g. view specs in rspec-rails).
       def without_verifying_partial_doubles
-        Mocks.configuration.temporarily_suppressing_partial_double_verification = true
+        Mocks.configuration.temporarily_suppress_partial_double_verification = true
         yield
       ensure
-        Mocks.configuration.temporarily_suppressing_partial_double_verification = false
+        Mocks.configuration.temporarily_suppress_partial_double_verification = false
       end
 
       # @method expect

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -287,10 +287,10 @@ module RSpec
       # time and you wish to define stubs for them but not turn off partial
       # doubles for the entire run suite. (e.g. view specs in rspec-rails).
       def without_verifying_partial_doubles
-        Mocks.configuration.temporarily_suppressing_verification = true
+        Mocks.configuration.temporarily_suppressing_partial_double_verification = true
         yield
       ensure
-        Mocks.configuration.temporarily_suppressing_verification = false
+        Mocks.configuration.temporarily_suppressing_partial_double_verification = false
       end
 
       # @method expect

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -282,6 +282,17 @@ module RSpec
         Matchers::HaveReceived.new(method_name, &block)
       end
 
+      # Turns off the verifying of partial doubles for the duration of the
+      # block, this is useful in situations where methods are defined at run
+      # time and you wish to define stubs for them but not turn off partial
+      # doubles for the entire run suite. (e.g. view specs in rspec-rails).
+      def without_verifying_partial_doubles
+        Mocks.configuration.temporarily_suppressing_verification = true
+        yield
+      ensure
+        Mocks.configuration.temporarily_suppressing_verification = false
+      end
+
       # @method expect
       # Used to wrap an object in preparation for setting a mock expectation
       # on it.

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -287,10 +287,11 @@ module RSpec
       # time and you wish to define stubs for them but not turn off partial
       # doubles for the entire run suite. (e.g. view specs in rspec-rails).
       def without_partial_double_verification
+        original_state = Mocks.configuration.temporarily_suppress_partial_double_verification
         Mocks.configuration.temporarily_suppress_partial_double_verification = true
         yield
       ensure
-        Mocks.configuration.temporarily_suppress_partial_double_verification = false
+        Mocks.configuration.temporarily_suppress_partial_double_verification = original_state
       end
 
       # @method expect

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -36,7 +36,6 @@ module RSpec
       end
 
       def ensure_implemented(method_name)
-        return if Mocks.configuration.temporarily_suppress_partial_double_verification
         return unless method_reference[method_name].unimplemented?
 
         @error_generator.raise_unimplemented_error(
@@ -47,7 +46,6 @@ module RSpec
       end
 
       def ensure_publicly_implemented(method_name, _object)
-        return if Mocks.configuration.temporarily_suppress_partial_double_verification
         ensure_implemented(method_name)
         visibility = method_reference[method_name].visibility
 
@@ -120,6 +118,11 @@ module RSpec
         end
 
         optional_callback_invocation_strategy.call(@doubled_module)
+      end
+
+      def ensure_implemented(_method_name)
+        return if Mocks.configuration.temporarily_suppress_partial_double_verification
+        super
       end
 
       def method_reference

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -36,7 +36,7 @@ module RSpec
       end
 
       def ensure_implemented(method_name)
-        return if Mocks.configuration.temporarily_suppressing_partial_double_verification
+        return if Mocks.configuration.temporarily_suppress_partial_double_verification
         return unless method_reference[method_name].unimplemented?
 
         @error_generator.raise_unimplemented_error(
@@ -47,7 +47,7 @@ module RSpec
       end
 
       def ensure_publicly_implemented(method_name, _object)
-        return if Mocks.configuration.temporarily_suppressing_partial_double_verification
+        return if Mocks.configuration.temporarily_suppress_partial_double_verification
         ensure_implemented(method_name)
         visibility = method_reference[method_name].visibility
 
@@ -195,7 +195,7 @@ module RSpec
       def self.for(object, method_name, proxy)
         if ClassNewMethodReference.applies_to?(method_name) { object }
           VerifyingExistingClassNewMethodDouble
-        elsif Mocks.configuration.temporarily_suppressing_partial_double_verification
+        elsif Mocks.configuration.temporarily_suppress_partial_double_verification
           MethodDouble
         else
           self

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -195,6 +195,8 @@ module RSpec
       def self.for(object, method_name, proxy)
         if ClassNewMethodReference.applies_to?(method_name) { object }
           VerifyingExistingClassNewMethodDouble
+        elsif Mocks.configuration.temporarily_suppressing_verification
+          MethodDouble
         else
           self
         end.new(object, method_name, proxy)

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -36,6 +36,7 @@ module RSpec
       end
 
       def ensure_implemented(method_name)
+        return if Mocks.configuration.temporarily_suppressing_verification
         return unless method_reference[method_name].unimplemented?
 
         @error_generator.raise_unimplemented_error(
@@ -46,6 +47,7 @@ module RSpec
       end
 
       def ensure_publicly_implemented(method_name, _object)
+        return if Mocks.configuration.temporarily_suppressing_verification
         ensure_implemented(method_name)
         visibility = method_reference[method_name].visibility
 

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -36,7 +36,7 @@ module RSpec
       end
 
       def ensure_implemented(method_name)
-        return if Mocks.configuration.temporarily_suppressing_verification
+        return if Mocks.configuration.temporarily_suppressing_partial_double_verification
         return unless method_reference[method_name].unimplemented?
 
         @error_generator.raise_unimplemented_error(
@@ -47,7 +47,7 @@ module RSpec
       end
 
       def ensure_publicly_implemented(method_name, _object)
-        return if Mocks.configuration.temporarily_suppressing_verification
+        return if Mocks.configuration.temporarily_suppressing_partial_double_verification
         ensure_implemented(method_name)
         visibility = method_reference[method_name].visibility
 
@@ -195,7 +195,7 @@ module RSpec
       def self.for(object, method_name, proxy)
         if ClassNewMethodReference.applies_to?(method_name) { object }
           VerifyingExistingClassNewMethodDouble
-        elsif Mocks.configuration.temporarily_suppressing_verification
+        elsif Mocks.configuration.temporarily_suppressing_partial_double_verification
           MethodDouble
         else
           self

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -404,11 +404,9 @@ module RSpec
       end
 
       specify 'temporarily supressing partial doubles does not affect normal verifying doubles' do
-        klass = Class.new
-        object = nil
         without_partial_double_verification do
           expect {
-            object = instance_double(klass, :fictitious_method => 'works')
+            instance_double(Class.new, :fictitious_method => 'works')
           }.to raise_error RSpec::Mocks::MockExpectationError
         end
       end

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -388,6 +388,16 @@ module RSpec
         }.to raise_error RSpec::Mocks::MockExpectationError
       end
 
+      specify 'temporarily supressing partial doubles does not affect normal verifying doubles' do
+        klass = Class.new
+        object = nil
+        without_verifying_partial_doubles do
+          expect {
+            object = instance_double(klass, :fictitious_method => 'works')
+          }.to raise_error RSpec::Mocks::MockExpectationError
+        end
+      end
+
       it 'runs the before_verifying_double callbacks before verifying an expectation' do
         expect { |probe|
           RSpec.configuration.mock_with(:rspec) do |config|

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -388,6 +388,21 @@ module RSpec
         }.to raise_error RSpec::Mocks::MockExpectationError
       end
 
+      it 'can be temporarily supressed and nested' do
+        without_partial_double_verification do
+          without_partial_double_verification do
+            expect(object).to receive(:fictitious_method) { 'works' }
+          end
+          expect(object).to receive(:other_fictitious_method) { 'works' }
+        end
+        expect(object.fictitious_method).to eq 'works'
+        expect(object.other_fictitious_method).to eq 'works'
+
+        expect {
+          expect(object).to receive(:another_fictitious_method) { 'works' }
+        }.to raise_error RSpec::Mocks::MockExpectationError
+      end
+
       specify 'temporarily supressing partial doubles does not affect normal verifying doubles' do
         klass = Class.new
         object = nil

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -377,6 +377,17 @@ module RSpec
         expect(object.send(:defined_private_method)).to eq("works")
       end
 
+      it 'can be temporarily supressed' do
+        without_verifying_partial_doubles do
+          expect(object).to receive(:fictitious_method) { 'works' }
+        end
+        expect(object.fictitious_method).to eq 'works'
+
+        expect {
+          expect(object).to receive(:another_fictitious_method) { 'works' }
+        }.to raise_error RSpec::Mocks::MockExpectationError
+      end
+
       it 'runs the before_verifying_double callbacks before verifying an expectation' do
         expect { |probe|
           RSpec.configuration.mock_with(:rspec) do |config|
@@ -416,9 +427,9 @@ module RSpec
       end
 
       context "for a class" do
-        it "only runs the `before_verifying_doubles` callback for the class (not for superclasses)" do
-          subclass = Class.new(klass)
+        let(:subclass) { Class.new(klass) }
 
+        it "only runs the `before_verifying_doubles` callback for the class (not for superclasses)" do
           expect { |probe|
             RSpec.configuration.mock_with(:rspec) do |config|
               config.before_verifying_doubles(&probe)
@@ -429,6 +440,18 @@ module RSpec
             an_object_having_attributes(:target => subclass)
           )
         end
+
+        it 'can be temporarily supressed' do
+          without_verifying_partial_doubles do
+            expect(subclass).to receive(:fictitious_method) { 'works' }
+          end
+          expect(subclass.fictitious_method).to eq 'works'
+
+          expect {
+            expect(subclass).to receive(:another_fictitious_method) { 'works' }
+          }.to raise_error RSpec::Mocks::MockExpectationError
+        end
+
       end
 
       it 'does not allow a non-existing method to be expected' do

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -378,7 +378,7 @@ module RSpec
       end
 
       it 'can be temporarily supressed' do
-        without_verifying_partial_doubles do
+        without_partial_double_verification do
           expect(object).to receive(:fictitious_method) { 'works' }
         end
         expect(object.fictitious_method).to eq 'works'
@@ -391,7 +391,7 @@ module RSpec
       specify 'temporarily supressing partial doubles does not affect normal verifying doubles' do
         klass = Class.new
         object = nil
-        without_verifying_partial_doubles do
+        without_partial_double_verification do
           expect {
             object = instance_double(klass, :fictitious_method => 'works')
           }.to raise_error RSpec::Mocks::MockExpectationError
@@ -452,7 +452,7 @@ module RSpec
         end
 
         it 'can be temporarily supressed' do
-          without_verifying_partial_doubles do
+          without_partial_double_verification do
             expect(subclass).to receive(:fictitious_method) { 'works' }
           end
           expect(subclass.fictitious_method).to eq 'works'


### PR DESCRIPTION
Implements: 

``` Ruby
without_verifying_partial_doubles do
  ...
end
```

Closes #1102 and should be used to suppress partial doubles in view specs, /cc @samphippen 
