### PR TITLE
Remove legacy add_negative_message_expectation method

### DIFF
--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -439,11 +439,6 @@ module RSpec
         super
       end
 
-      def add_negative_message_expectation(location, method_name, &implementation)
-        warn_or_raise!(method_name)
-        super
-      end
-
       def add_stub(method_name, opts={}, &implementation)
         warn_or_raise!(method_name)
         super


### PR DESCRIPTION
In the past this method was used to negate expectations, but since [1] it's not
been used. Therefore this commit removes it.

1.) https://github.com/rspec/rspec-mocks/commit/9357e4de76838157c8ea7d4a4ad6d0ae11882b22