### PR TITLE
use the RSpec::Support.method_handle_for instead of Class#method

### DIFF
--- a/lib/rspec/mocks/method_reference.rb
+++ b/lib/rspec/mocks/method_reference.rb
@@ -189,7 +189,7 @@ module RSpec
 
         # We only want to apply our special logic to normal `new` methods.
         # Methods that the user has monkeyed with should be left as-is.
-        klass.method(:new).owner == ::Class
+        ::RSpec::Support.method_handle_for(klass, :new).owner == ::Class
       end
 
       def with_signature

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -566,6 +566,16 @@ module RSpec
             allow(subclass).to receive(:new).with(1, 2)
           end
         end
+
+        context 'on a class that has redefined `self.method`' do
+          it 'allows the stubbing of :new' do
+            subclass = Class.new(klass) do
+              def self.method(*); end
+            end
+
+            allow(subclass).to receive(:new)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
addresses #1118