### PR TITLE
Allow expectations on subclass any instance methods.

### DIFF
--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -115,7 +115,7 @@ module RSpec
 
         # @private
         def build_alias_method_name(method_name)
-          "__#{method_name}_without_any_instance__"
+          "__#{@klass}__#{method_name}_without_any_instance__"
         end
 
         # @private

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -168,6 +168,24 @@ module RSpec
           end
         end
 
+        it "allows an expectation to be set on a subclass when an allowance already exists on a superclass" do
+          a = Class.new do
+            def foo
+              true
+            end
+          end
+
+          b = Class.new(a) do
+            def foo
+              super
+            end
+          end
+
+          allow_any_instance_of(a).to receive(:foo)
+          expect_any_instance_of(b).to receive(:foo).with(:bar)
+          b.new.foo(:bar)
+        end
+
         context "when the class has a prepended module", :if => Support::RubyFeatures.module_prepends_supported? do
           it 'allows stubbing a method that is not defined on the prepended module' do
             klass.class_eval { prepend Module.new { def other; end } }


### PR DESCRIPTION
This allows us to override methods which are present on a parent and subclass with `any_instance_of`.

Closes #1077, /cc @samphippen