### PR TITLE
pin diff-lcs to under 1.3 if we're running 1.8.7

### DIFF
--- a/rspec-mocks.gemspec
+++ b/rspec-mocks.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "rspec-support", "~> #{RSpec::Mocks::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 
-  s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
+  s.add_runtime_dependency "diff-lcs", ">= 1.2.0", (RUBY_VERSION < "1.9.0" ? "< 1.3" : "< 2.0")
 
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.3.15'


### PR DESCRIPTION
`diff-lcs` 1.3 drops support for 1.8.7 so once again the builds have broken. I'm not sure if its worthwhile just pinning to `< 1.3` for all so I've attempted to only do it on `1.8.7`. 

We could also consider dropping them a note pointing out that they've just broken semver (we were already checking less than <2)

Counterpart to rspec/rspec-expectations#968