### PR TITLE
Fix grammar errors

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -89,7 +89,7 @@ PercentLiteralDelimiters:
     '%x': ()      # a shell command as a string
 
 # We have too many special cases where we allow generator methods or prefer a
-# prefixed predicate due to it's improved readability.
+# prefixed predicate due to its improved readability.
 PredicateName:
   Enabled: false
 

--- a/features/configuring_responses/wrapping_the_original_implementation.feature
+++ b/features/configuring_responses/wrapping_the_original_implementation.feature
@@ -1,7 +1,7 @@
 Feature: Wrapping the original implementation
 
   Use `and_wrap_original` to modify a partial double's original response. This can be useful
-  when you want to utilise an external object but mutate it's response. For example if an
+  when you want to utilise an external object but mutate its response. For example if an
   API returns a large amount of data and for test purposes you'd like to trim it down. You can
   also use it to configure the default response for most arguments, and then override that for
   specific arguments using `with`.

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -392,7 +392,7 @@ module RSpec
       def self.included(klass)
         klass.class_exec do
           # This gets mixed in so that if `RSpec::Matchers` is included in
-          # `klass` later, it's definition of `expect` will take precedence.
+          # `klass` later, its definition of `expect` will take precedence.
           include ExpectHost unless method_defined?(:expect)
         end
       end
@@ -400,7 +400,7 @@ module RSpec
       # @private
       def self.extended(object)
         # This gets extended in so that if `RSpec::Matchers` is included in
-        # `klass` later, it's definition of `expect` will take precedence.
+        # `klass` later, its definition of `expect` will take precedence.
         object.extend ExpectHost unless object.respond_to?(:expect)
       end
 

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -207,8 +207,8 @@ module RSpec
 
       # In Ruby 2.0.0 and above prepend will alter the method lookup chain.
       # We use an object's singleton class to define method doubles upon,
-      # however if the object has had it's singleton class (as opposed to
-      # it's actual class) prepended too then the the method lookup chain
+      # however if the object has had its singleton class (as opposed to
+      # its actual class) prepended too then the the method lookup chain
       # will look in the prepended module first, **before** the singleton
       # class.
       #

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -612,7 +612,7 @@ module RSpec
       end
 
       describe "allow(...).to have_received" do
-        it "fails because its nonsensical" do
+        it "fails because it's nonsensical" do
           _expect {
             allow(double).to have_received(:some_method)
           }.to fail_with("Using allow(...) with the `have_received` matcher is not supported as it would have no effect.")
@@ -620,7 +620,7 @@ module RSpec
       end
 
       describe "allow_any_instance_of(...).to have_received" do
-        it "fails because its nonsensical" do
+        it "fails because it's nonsensical" do
           _expect {
             allow_any_instance_of(double).to have_received(:some_method)
           }.to fail_with("Using allow_any_instance_of(...) with the `have_received` matcher is not supported.")

--- a/spec/rspec/mocks/should_syntax_spec.rb
+++ b/spec/rspec/mocks/should_syntax_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe "Using the legacy should syntax" do
       end
     end
 
-    it "adds an class to the current space" do
+    it "adds a class to the current space" do
       expect {
         klass.any_instance
       }.to change { RSpec::Mocks.space.any_instance_recorders.size }.by(1)

--- a/spec/rspec/mocks_spec.rb
+++ b/spec/rspec/mocks_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe RSpec::Mocks do
       end
     end
 
-    context "in a before(:all) with a unmet mock expectation" do
+    context "in a before(:all) with an unmet mock expectation" do
       before(:all) do
         capture_error do
           RSpec::Mocks.with_temporary_scope do


### PR DESCRIPTION
Corrects both "a" vs "an" and "its" vs "it's" grammar errors.