### PR TITLE
Add a nice error message when calling stub_const with something other than a string

### DIFF
--- a/lib/rspec/mocks/mutate_const.rb
+++ b/lib/rspec/mocks/mutate_const.rb
@@ -105,9 +105,9 @@ module RSpec
       #  so you can stub constants in other contexts (e.g. helper
       #  classes).
       def self.stub(constant_name, value, options={})
-        raise ArgumentError,
-              "Please provide a string as constant name" \
-              " You provided a #{constant_name.class.name}" unless constant_name.is_a?(String)
+        unless String === constant_name
+          raise ArgumentError, "`stub_const` requires a String, but you provided a #{constant_name.class.name}"
+        end
 
         mutator = if recursive_const_defined?(constant_name, &raise_on_invalid_const)
                     DefinedConstantReplacer

--- a/lib/rspec/mocks/mutate_const.rb
+++ b/lib/rspec/mocks/mutate_const.rb
@@ -105,6 +105,10 @@ module RSpec
       #  so you can stub constants in other contexts (e.g. helper
       #  classes).
       def self.stub(constant_name, value, options={})
+        raise ArgumentError,
+              "Please provide a string as constant name" \
+              " You provided a #{constant_name.class.name}" unless constant_name.is_a?(String)
+
         mutator = if recursive_const_defined?(constant_name, &raise_on_invalid_const)
                     DefinedConstantReplacer
                   else

--- a/spec/rspec/mocks/mutate_const_spec.rb
+++ b/spec/rspec/mocks/mutate_const_spec.rb
@@ -218,6 +218,12 @@ module RSpec
           it_behaves_like "loaded constant stubbing", "TestClassThatDefinesSend::C"
         end
 
+        context "for a non string argument" do
+          it { expect { stub_const(10, 1) }.to raise_error(ArgumentError, /Please provide a string/i) }
+          it { expect { stub_const(nil, 1) }.to raise_error(ArgumentError, /Please provide a string/i) }
+          it { expect { stub_const(10.1, 1) }.to raise_error(ArgumentError, /Please provide a string/i) }
+        end
+
         context 'for a loaded unnested constant' do
           it_behaves_like "loaded constant stubbing", "TestClass"
 

--- a/spec/rspec/mocks/mutate_const_spec.rb
+++ b/spec/rspec/mocks/mutate_const_spec.rb
@@ -218,10 +218,8 @@ module RSpec
           it_behaves_like "loaded constant stubbing", "TestClassThatDefinesSend::C"
         end
 
-        context "for a non string argument" do
-          it { expect { stub_const(10, 1) }.to raise_error(ArgumentError, /Please provide a string/i) }
-          it { expect { stub_const(nil, 1) }.to raise_error(ArgumentError, /Please provide a string/i) }
-          it { expect { stub_const(10.1, 1) }.to raise_error(ArgumentError, /Please provide a string/i) }
+        it "requires a string argument" do
+          expect { stub_const(10, 1) }.to raise_error(ArgumentError, /requires a String/i)
         end
 
         context 'for a loaded unnested constant' do


### PR DESCRIPTION
Sometimes, I'm calling `.stub_const` so frequently that I don't even understand why it doesn't work only to later figuring out that I was calling it with the _actual_ constant to stub instead of a string with the namespace of the constant.

For example:

```ruby
module A
    CONST = 10
end

# Instead of calling
stub_const("A::CONST", 1)

# I sometimes do
stub_const(A::CONST, 1)

# Giving me the error message:
NoMethodError:
       undefined method `sub' for 10:Fixnum
```

Thank you for this awesome project btw!