### PR TITLE
Allow hash matchers to work with Hash descendants

### DIFF
--- a/lib/rspec/mocks/argument_matchers.rb
+++ b/lib/rspec/mocks/argument_matchers.rb
@@ -116,7 +116,7 @@ module RSpec
 
       # @private
       def self.anythingize_lonely_keys(*args)
-        hash = args.last.class == Hash ? args.delete_at(-1) : {}
+        hash = Hash === args.last ? args.delete_at(-1) : {}
         args.each { | arg | hash[arg] = AnyArgMatcher::INSTANCE }
         hash
       end

--- a/spec/rspec/mocks/hash_excluding_matcher_spec.rb
+++ b/spec/rspec/mocks/hash_excluding_matcher_spec.rb
@@ -28,6 +28,9 @@ module RSpec
             expect(hash_not_including(:a, :b, :c)).to be === { :d => 7 }
           end
 
+          it "matches against classes inheriting from Hash" do
+            expect(hash_not_including(Class.new(Hash)[:c, 1])).not_to be === {:c => 1}
+          end
         end
 
         describe "failing" do

--- a/spec/rspec/mocks/hash_including_matcher_spec.rb
+++ b/spec/rspec/mocks/hash_including_matcher_spec.rb
@@ -22,6 +22,10 @@ module RSpec
             expect(hash_including(:a => 1)).to be === {:a => 1, :b => 2}
           end
 
+          it "matches against classes inheriting from Hash" do
+            expect(hash_including(Class.new(Hash)[:a, 1])).to be === {:a => 1}
+          end
+
           describe "when matching against other matchers" do
             it "matches an int against anything()" do
               expect(hash_including(:a => anything, :b => 2)).to be === {:a => 1, :b => 2}


### PR DESCRIPTION
Instead of checking if the object passed to ArgumentMatchers#anythingize_lonely_key _is_ strictly a Hash, check if it inherits from Hash using Case Equality inherited from `Module.===`

[fixes #1166]