### PR TITLE
Prevent mutated args from failing have_received expectations

### DIFF
--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -161,7 +161,19 @@ module RSpec
       # @private
       def record_message_received(message, *args, &block)
         @order_group.invoked SpecificMessage.new(object, message, args)
-        @messages_received << [message, args.map(&:dup), block]
+        @messages_received << [message, args.map { |arg| dup_if_mutable(arg) }, block]
+      end
+
+      # @private
+      def dup_if_mutable(arg)
+        case arg
+        when IO, StringIO # enumerable, but we don't want to dup it.
+          arg
+        when Enumerable, String
+          arg.dup
+        else
+          arg
+        end
       end
 
       # @private

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -161,7 +161,7 @@ module RSpec
       # @private
       def record_message_received(message, *args, &block)
         @order_group.invoked SpecificMessage.new(object, message, args)
-        @messages_received << [message, args, block]
+        @messages_received << [message, args.map(&:dup), block]
       end
 
       # @private

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -157,6 +157,13 @@ module RSpec
             expect(dbl).to have_received(:expected_method).with(:expected, :args)
           end
 
+          it 'passes when the given args match the args used with the message but later mutated' do
+            args = [:expected, :args]
+            dbl = double_with_met_expectation(:expected_method, args)
+            args.clear
+            expect(dbl).to have_received(:expected_method).with([:expected, :args])
+          end
+
           it 'fails when the given args do not match the args used with the message' do
             dbl = double_with_met_expectation(:expected_method, :expected, :args)
 

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -157,6 +157,11 @@ module RSpec
             expect(dbl).to have_received(:expected_method).with(:expected, :args)
           end
 
+          it 'passes when the given args match the args used with the message but are not dupable' do
+            dbl = double_with_met_expectation(:expected_method, 1, 2, 3)
+            expect(dbl).to have_received(:expected_method).with(1, 2, 3)
+          end
+
           it 'passes when the given args match the args used with the message but later mutated' do
             args = [:expected, :args]
             dbl = double_with_met_expectation(:expected_method, args)

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -110,7 +110,7 @@ module RSpec
             end
 
             def method_missing(name, *)
-              called_methods << name.to_s
+              called_methods << name
               self
             end
           end.new
@@ -119,8 +119,7 @@ module RSpec
           allow(@stub).to receive(:foo)
           expect {
             @stub.foo(recorder)
-            # dup is allowed as it prevents later mutation leaking
-          }.to change(recorder, :called_methods).to(["dup"])
+          }.to_not change(recorder, :called_methods)
         end
       end
 

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -110,15 +110,17 @@ module RSpec
             end
 
             def method_missing(name, *)
-              called_methods << name
+              called_methods << name.to_s
               self
             end
           end.new
 
+
           allow(@stub).to receive(:foo)
           expect {
             @stub.foo(recorder)
-          }.not_to change(recorder, :called_methods)
+            # dup is allowed as it prevents later mutation leaking
+          }.to change(recorder, :called_methods).to(["dup"])
         end
       end
 


### PR DESCRIPTION
This came up in rspec/rspec-expectations#1017 we need to duplicate args we capture for later replay onto expectations, in case they are mutated downstream. This seems like an "ok" way to fix the problem, but maybe someone can suggest a better one?