### PR TITLE
Fix specs for diffs showing keys in alphabetic order for PR /rspec-support/pull/334

### DIFF
--- a/spec/rspec/mocks/diffing_spec.rb
+++ b/spec/rspec/mocks/diffing_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
       end
     end
 
-    let(:expected_hash) { {:foo => :bar, :baz => :quz} }
+    let(:expected_hash) { {:baz => :quz, :foo => :bar } }
 
     let(:actual_hash) { {:bad => :hash} }
 


### PR DESCRIPTION
Supporting PR https://github.com/rspec/rspec-support/pull/334