### PR TITLE
Misspelling: overridden

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -896,7 +896,8 @@ Bug fixes
 * Fix `should_receive` so that when it is called on an `as_null_object`
   double with no implementation, and there is a previous explicit stub
   for the same method, the explicit stub remains (rather than being
-  overriden with the null object implementation--`return self`). (Myron Marston)
+  overridden with the null object implementation--`return self`). (Myron
+  Marston)
 
 ### 2.11.0 / 2012-07-07
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v2.10.1...v2.11.0)

--- a/features/configuring_responses/calling_the_original_implementation.feature
+++ b/features/configuring_responses/calling_the_original_implementation.feature
@@ -33,13 +33,13 @@ Feature: Calling the original implementation
     When I run `rspec spec/and_call_original_spec.rb`
     Then the examples should all pass
 
-  Scenario: `and_call_original` can configure a default response that can be overriden for specific args
+  Scenario: `and_call_original` can configure a default response that can be overridden for specific args
     Given a file named "spec/and_call_original_spec.rb" with:
       """ruby
       require 'calculator'
 
       RSpec.describe "and_call_original" do
-        it "can be overriden for specific arguments using #with" do
+        it "can be overridden for specific arguments using #with" do
           allow(Calculator).to receive(:add).and_call_original
           allow(Calculator).to receive(:add).with(2, 3).and_return(-5)
 

--- a/features/configuring_responses/wrapping_the_original_implementation.feature
+++ b/features/configuring_responses/wrapping_the_original_implementation.feature
@@ -34,13 +34,13 @@ Feature: Wrapping the original implementation
     When I run `rspec spec/and_wrap_original_spec.rb`
     Then the examples should all pass
 
-  Scenario: `and_wrap_original` can configure a default response that can be overriden for specific args
+  Scenario: `and_wrap_original` can configure a default response that can be overridden for specific args
     Given a file named "spec/and_wrap_original_spec.rb" with:
       """ruby
       require 'api'
 
       RSpec.describe "and_wrap_original" do
-        it "can be overriden for specific arguments using #with" do
+        it "can be overridden for specific arguments using #with" do
           allow(API).to receive(:solve_for).and_wrap_original { |m, *args| m.call(*args).first(5) }
           allow(API).to receive(:solve_for).with(2).and_return([3])
 

--- a/spec/rspec/mocks/combining_implementation_instructions_spec.rb
+++ b/spec/rspec/mocks/combining_implementation_instructions_spec.rb
@@ -129,17 +129,17 @@ module RSpec
         let(:stubbed_double) { allow(the_dbl).to receive(:foo) }
         before { stubbed_double.and_return(1) }
 
-        it 'allows the terminal action to be overriden to `and_return(y)`' do
+        it 'allows the terminal action to be overridden to `and_return(y)`' do
           stubbed_double.and_return(3)
           expect(the_dbl.foo).to eq(3)
         end
 
-        it 'allows the terminal action to be overriden to `and_raise(y)`' do
+        it 'allows the terminal action to be overridden to `and_raise(y)`' do
           stubbed_double.and_raise("boom")
           expect { the_dbl.foo }.to raise_error("boom")
         end
 
-        it 'allows the terminal action to be overriden to `and_throw(y)`' do
+        it 'allows the terminal action to be overridden to `and_throw(y)`' do
           stubbed_double.and_throw(:bar)
           expect { the_dbl.foo }.to throw_symbol(:bar)
         end
@@ -157,7 +157,7 @@ module RSpec
         end
       end
 
-      it 'warns when the inner implementation block is overriden' do
+      it 'warns when the inner implementation block is overridden' do
         expect(RSpec).to receive(:warning).with(/overriding a previous stub implementation of `foo`.*#{__FILE__}:#{__LINE__ + 1}/)
         allow(double).to receive(:foo).with(:arg) { :with_block }.at_least(:once) { :at_least_block }
       end

--- a/spec/rspec/mocks/to_ary_spec.rb
+++ b/spec/rspec/mocks/to_ary_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "a double receiving to_ary" do
       expect(obj.to_ary).to be(:non_nil_value)
     end
 
-    it "responds when overriden" do
+    it "responds when overridden" do
       allow(obj).to receive(:to_ary) { :non_nil_value }
       expect(obj).to respond_to(:to_ary)
     end

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -187,14 +187,14 @@ module RSpec
         end
       end
 
-      context "when given a class that has an overriden `#name` method" do
+      context "when given a class that has an overridden `#name` method" do
         it "properly verifies" do
-          check_verification class_double(LoadedClassWithOverridenName)
+          check_verification class_double(LoadedClassWithOverriddenName)
         end
 
         it "can still stub the const" do
-          class_double(LoadedClassWithOverridenName).as_stubbed_const
-          check_verification LoadedClassWithOverridenName
+          class_double(LoadedClassWithOverriddenName).as_stubbed_const
+          check_verification LoadedClassWithOverriddenName
         end
 
         def check_verification(o)

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -167,9 +167,9 @@ module RSpec
         end
       end
 
-      context "when given a class that has an overriden `#name` method" do
+      context "when given a class that has an overridden `#name` method" do
         it "properly verifies" do
-          o = instance_double(LoadedClassWithOverridenName)
+          o = instance_double(LoadedClassWithOverriddenName)
           allow(o).to receive(:defined_instance_method)
           prevents { allow(o).to receive(:undefined_method) }
         end

--- a/spec/support/doubled_classes.rb
+++ b/spec/support/doubled_classes.rb
@@ -80,7 +80,7 @@ private
   end
 end
 
-class LoadedClassWithOverridenName < LoadedClass
+class LoadedClassWithOverriddenName < LoadedClass
   def self.name
     "Overriding name is not a good idea but we can't count on users not doing this"
   end


### PR DESCRIPTION
This PR fixes the misspelling of `overridden`.