### PR TITLE
Upgrade rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,17 +1,28 @@
-inherit_from: .rubocop_rspec_base.yml
+inherit_from:
+  - .rubocop_rspec_base.yml
 
-# This should go down over time.
-Style/ClassLength:
+# All these metrics should go down over time.
+
+Metrics/ClassLength:
   Max: 279
 
-# This should go down over time.
-Style/CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   Max: 18
 
-# This should go down over time.
-Style/LineLength:
+Metrics/LineLength:
   Max: 193
 
-# This should go down over time.
-Style/MethodLength:
+Metrics/MethodLength:
   Max: 49
+
+Metrics/AbcSize:
+  Max: 45
+
+Metrics/BlockLength:
+  Max: 45
+
+Metrics/ModuleLength:
+  Max: 209
+
+Metrics/PerceivedComplexity:
+  Max: 19

--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -227,3 +227,8 @@ Layout/SpaceAroundOperators:
 
 Layout/SpaceBeforeComma:
   Enabled: false
+
+# This could likely be enabled, but it had a false positive on rspec-mocks
+# (suggested change was not behaviour preserving) so I don't trust it.
+Performance/HashEachMethods:
+  Enabled: false

--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -50,9 +50,6 @@ DoubleNegation:
 EachWithObject:
   Enabled: false
 
-Encoding:
-  EnforcedStyle: when_needed
-
 FormatString:
   EnforcedStyle: percent
 
@@ -73,7 +70,7 @@ MethodLength:
   Max: 15
 
 # Who cares what we call the argument for binary operator methods?
-OpMethod:
+BinaryOperatorParameterName:
   Enabled: false
 
 PercentLiteralDelimiters:
@@ -121,10 +118,112 @@ StringLiterals:
 Style/SpecialGlobalVars:
   Enabled: false
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
   Enabled: false
 
 TrivialAccessors:
   AllowDSLWriters: true
   AllowPredicates: true
   ExactNameMatch: true
+
+Style/ParallelAssignment:
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Enabled: false
+
+Naming/ConstantName:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+
+Style/MethodMissing:
+  Enabled: false
+
+Style/MixinUsage:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NestedModifier:
+  Enabled: false
+
+Style/NestedParenthesizedCalls:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/RedundantParentheses:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/SymbolProc:
+  Enabled: false
+
+Style/YodaCondition:
+  Enabled: false
+
+Style/ZeroLengthPredicate:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Layout/SpaceAroundBlockParameters:
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+Layout/SpaceBeforeComma:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,9 @@ end
 
 gem 'yard', '~> 0.9.12', :require => false
 
-if RUBY_VERSION >= '2' && RUBY_VERSION <= '2.1'
-  # todo upgrade rubocop and run on a recent version e.g. 2.3 or 2.4
-  gem 'rubocop', "~> 0.23.0"
+# No need to run rubocop on earlier versions
+if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
+  gem 'rubocop', "~> 0.52.1"
 end
 
 if RUBY_VERSION < '2.0.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -72,7 +72,7 @@ module RSpec
         "#{intro} received #{expectation.message.inspect} #{unexpected_arguments_message(expected_args, actual_args)}".dup
       end
 
-      # rubocop:disable Style/ParameterLists
+      # rubocop:disable Metrics/ParameterLists
       # @private
       def raise_expectation_error(message, expected_received_count, argument_list_matcher,
                                   actual_received_count, expectation_count_type, args,
@@ -81,7 +81,7 @@ module RSpec
         received_part = received_part_of_expectation_error(actual_received_count, args)
         __raise "(#{intro(:unwrapped)}).#{message}#{format_args(args)}\n    #{expected_part}\n    #{received_part}", backtrace_line, source_id
       end
-      # rubocop:enable Style/ParameterLists
+      # rubocop:enable Metrics/ParameterLists
 
       # @private
       def raise_unimplemented_error(doubled_module, method_name, object)

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -650,7 +650,7 @@ module RSpec
             @error_generator.raise_wrong_arity_error(args, block_signature)
           end
 
-          value = @eval_context ? @eval_context.instance_exec(*args, &block) : block.call(*args)
+          value = @eval_context ? @eval_context.instance_exec(*args, &block) : yield(*args)
         end
         value
       end

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -367,7 +367,7 @@ module RSpec
         # @private
         attr_reader :type
 
-        # rubocop:disable Style/ParameterLists
+        # rubocop:disable Metrics/ParameterLists
         def initialize(error_generator, expectation_ordering, expected_from, method_double,
                        type=:expectation, opts={}, &implementation_block)
           @type = type
@@ -395,7 +395,7 @@ module RSpec
           @implementation = Implementation.new
           self.inner_implementation_action = implementation_block
         end
-        # rubocop:enable Style/ParameterLists
+        # rubocop:enable Metrics/ParameterLists
 
         def expected_args
           @argument_list_matcher.expected_args

--- a/lib/rspec/mocks/method_reference.rb
+++ b/lib/rspec/mocks/method_reference.rb
@@ -64,14 +64,6 @@ module RSpec
         :public
       end
 
-    private
-
-      def original_method
-        @object_reference.when_loaded do |m|
-          self.defined? && find_method(m)
-        end
-      end
-
       def self.instance_method_visibility_for(klass, method_name)
         if klass.public_method_defined?(method_name)
           :public
@@ -106,6 +98,14 @@ module RSpec
           object.respond_to?(method_name)
 
         return :public if visible
+      end
+
+    private
+
+      def original_method
+        @object_reference.when_loaded do |m|
+          self.defined? && find_method(m)
+        end
       end
     end
 

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -44,7 +44,7 @@ module RSpec
 
       # @private
       def to_s
-        inspect.gsub('<', '[').gsub('>', ']')
+        inspect.tr('<', '[').tr('>', ']')
       end
 
       # @private

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -180,7 +180,7 @@ function check_documentation_coverage {
 
 function check_style_and_lint {
   echo "bin/rubocop lib"
-  bin/rubocop lib
+  eval "(unset RUBYOPT; exec bin/rubocop lib)"
 }
 
 function run_all_spec_suites {


### PR DESCRIPTION
Defaulted most new things to off, though tried to keep performance and linters.

Note that `.rubocop_rspec_base` doesn't 100% match up with `rspec-dev` because I was adding to it as we went along. Once these are all merged I'm planning to ensure they're all consistent.