### PR TITLE
Use https:// instead of git:// URLs in READMEs

### DIFF
--- a/DEV-README.md
+++ b/DEV-README.md
@@ -1,6 +1,6 @@
 ## Set up the dev environment
 
-    git clone git://github.com/rspec/rspec-mocks.git
+    git clone https://github.com/rspec/rspec-mocks.git
     cd rspec-mocks
     gem install bundler
     bundle install

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ RSpec repos as well. Add the following to your `Gemfile`:
 
 ```ruby
 %w[rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
-  gem lib, :git => "git://github.com/rspec/#{lib}.git", :branch => 'master'
+  gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => 'master'
 end
 ```
 ## Contributing


### PR DESCRIPTION
See https://github.com/rspec/rspec-core/pull/2518.