### PR TITLE
Added `duck_type_including` ArgumentMatcher

### DIFF
--- a/lib/rspec/mocks/argument_matchers.rb
+++ b/lib/rspec/mocks/argument_matchers.rb
@@ -52,6 +52,15 @@ module RSpec
         DuckTypeMatcher.new(*args)
       end
 
+      # Matches if the actual argument responds to the specified messages, and the values match.
+      #
+      # @example
+      #   expect(object).to receive(:message).with(duck_type_including(name: 'Fred'))
+      #   expect(object).to receive(:message).with(duck_type_including(name: 'Fred', last_name: 'Flintstone'))
+      def duck_type_including(**args)
+        DuckTypeIncludingMatcher.new(**args)
+      end
+
       # Matches a boolean value.
       #
       # @example
@@ -268,6 +277,24 @@ module RSpec
 
         def description
           "duck_type(#{@methods_to_respond_to.map(&:inspect).join(', ')})"
+        end
+      end
+
+      # @private
+      class DuckTypeIncludingMatcher
+        def initialize(**methods_to_respond_to_with_values)
+          @methods_to_respond_to_with_values = methods_to_respond_to_with_values
+        end
+
+        def ===(value)
+          @methods_to_respond_to_with_values.all? do |message, expected_value|
+            value.respond_to?(message) && value.send(message.to_sym) == expected_value
+          end
+        end
+
+        def description
+          hash_as_string = @methods_to_respond_to_with_values.collect { |k, v| "#{k}: '#{v}'" }.join(', ')
+          "duck_type_including(#{hash_as_string})"
         end
       end
 

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -128,6 +128,44 @@ module RSpec
         end
       end
 
+      describe "duck_type_including" do
+        it "matches duck type with one method and matching value" do
+          expect(a_double).to receive(:random_call).with(duck_type_including(name: 'Fred'))
+
+          a_double.random_call(OpenStruct.new(name: 'Fred'))
+        end
+
+        it "matches duck type with two methods and two matching values" do
+          expect(a_double).to receive(:random_call).with(duck_type_including(name: 'Fred', last_name: 'Flintstone'))
+
+          a_double.random_call(OpenStruct.new(name: 'Fred', last_name: 'Flintstone'))
+        end
+
+        it "fails when the method exists, but the value doesn't match", reset: true do
+          expect(a_double).to receive(:random_call).with(duck_type_including(name: 'Fred'))
+
+          expect {
+            a_double.random_call(OpenStruct.new(name: 'Bob'))
+          }.to fail_including "expected: (duck_type_including(name: 'Fred'))"
+        end
+        
+        it "fails when both methods exist, but only 1 value matches", reset: true do
+          expect(a_double).to receive(:random_call).with(duck_type_including(name: 'Fred', last_name: 'Jones'))
+
+          expect {
+            a_double.random_call(OpenStruct.new(name: 'Fred', last_name: 'Flintstone'))
+          }.to fail_including "expected: (duck_type_including(name: 'Fred', last_name: 'Jones'))"
+        end
+
+        it "fails when the method doesn't exist", reset: true do
+          expect(a_double).to receive(:random_call).with(duck_type_including(name: 'Fred'))
+
+          expect {
+            a_double.random_call(OpenStruct.new(age: 18))
+          }.to fail_including "expected: (duck_type_including(name: 'Fred'))"
+        end
+      end
+
       describe "any_args" do
         context "as the only arg passed to `with`" do
           before { expect(a_double).to receive(:random_call).with(any_args) }


### PR DESCRIPTION
# Background
If you are working with a hash, you can use:
```
allow(obj).to receive(:message).with(hash_including(name: 'Fred', last_name: 'Flintstone'))
```
If you are working with objects, you can use:
```
allow(obj).to receive(:message).with(duck_type(:name, :last_name))
```

But what if you want to combine these, and allow any object that **both** responds to `name` and `last_name` **and** returns `Fred` and `Flintstone`, respectively? That's where the `duck_type_including` argument matcher comes in. :)

# Implementation
```
allow(obj).to receive(:message).with(duck_type_including(name: 'Fred', last_name: 'Flintstone'))
```