### PR TITLE
Follow up to #1231

### DIFF
--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -638,7 +638,7 @@ module RSpec
       describe "expect_any_instance_of(...).not_to have_received" do
         it "fails because we dont want to support it" do
           _expect {
-            expect_any_instance_of(double).to have_received(:some_method)
+            expect_any_instance_of(double).not_to have_received(:some_method)
           }.to fail_with("Using expect_any_instance_of(...) with the `have_received` matcher is not supported.")
         end
       end


### PR DESCRIPTION
My apologies after merging #1231 (whilst writing the changelog!) I noticed the spec is actually wrong, the implementation is correct but the spec was calling `to` and not `to_not`. This fixes that.