### PR TITLE
Remove duplicated examples from specs

### DIFF
--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -296,14 +296,6 @@ module RSpec
             expect(klass.new('org').a_method).to eq 'org'
             expect(klass.new.a_method(:arg)).to  eq 'value'
           end
-
-          it 'can combine and_call_original, with, and_return (old syntax)' do
-            allow_any_instance_of(klass).to receive(:a_method).and_call_original
-            allow_any_instance_of(klass).to receive(:a_method).with(:arg).and_return('value')
-
-            expect(klass.new('org').a_method).to eq 'org'
-            expect(klass.new.a_method(:arg)).to  eq 'value'
-          end
         end
 
         context "with #and_raise" do

--- a/spec/rspec/mocks/array_including_matcher_spec.rb
+++ b/spec/rspec/mocks/array_including_matcher_spec.rb
@@ -14,6 +14,10 @@ module RSpec
 
         context "passing" do
           it "matches the same array" do
+            expect(array_including([1, 2, 3])).to be === [1, 2, 3]
+          end
+
+          it "matches the same array, specified without square brackets" do
             expect(array_including(1, 2, 3)).to be === [1, 2, 3]
           end
 

--- a/spec/rspec/mocks/null_object_double_spec.rb
+++ b/spec/rspec/mocks/null_object_double_spec.rb
@@ -76,7 +76,7 @@ module RSpec
         expect(val).to equal(@double)
       end
 
-      it 'allows unexpected message sends using `send`' do
+      it 'allows unexpected message sends using `__send__`' do
         val = @double.__send__(:foo).__send__(:bar)
         expect(val).to equal(@double)
       end

--- a/spec/rspec/mocks/verifying_doubles/object_double_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/object_double_spec.rb
@@ -126,7 +126,7 @@ module RSpec
           allow(o).to receive(:undefined_method)
         end
 
-        it "treats it as being unloaded for `object_double('ConstName')`" do
+        it "treats it as being unloaded for `object_double(ConstName)`" do
           o = object_double(LoadedClass::NOINSTANCE)
           allow(o).to receive(:undefined_method)
         end


### PR DESCRIPTION
* Removed duplicated specs
  - One(old syntax for any_instance) became obsolete since 411743175724d04885367f821e515824b747e781
  - The other (matches the same array,  specified without square brackets) is duplicated since it's very existance
* Updated couple of test descrirption to reflect the actual test