### PR TITLE
Add argument matcher for expecting a block.

### DIFF
--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -122,3 +122,28 @@ Feature: Matching arguments
       """
     When I run `rspec responding_differently_spec.rb`
     Then the examples should all pass
+
+  Scenario: Expecting a method invocatin with a block
+    Given a file named "expect_method_with_block.rb" with:
+    """ruby
+    RSpec.describe "Expecting a message with a block" do
+      let(:dbl) { double }
+      before { expect(dbl).to receive(:foo).with(a_block) }
+
+      it "passes when the method is invoked with a block" do
+        dbl.foo { |a| :block }
+      end
+
+      it "fails when the method is invoked without a block" do
+        dbl.foo
+      end
+    end
+    """
+  When I run `rspec expect_method_with_block.rb`
+  Then it should fail with the following output:
+    | 2 examples, 1 failure                                           |
+    |                                                                 |
+    | Failure/Error: dbl.foo                                          |
+    |   #<Double (anonymous)> received :foo with unexpected arguments |
+    |     expected: (a block)                                         |
+    |          got: (no args)                                         |

--- a/lib/rspec/mocks/argument_list_matcher.rb
+++ b/lib/rspec/mocks/argument_list_matcher.rb
@@ -54,8 +54,13 @@ module RSpec
       # position of the arguments passed to `new`.
       #
       # @see #initialize
-      def args_match?(*args)
-        Support::FuzzyMatcher.values_match?(resolve_expected_args_based_on(args), args)
+      def args_match?(*args, &block)
+        expected_args = resolve_expected_args_based_on(args)
+        if [ArgumentMatchers::BlockMatcher::INSTANCE] == expected_args
+          ArgumentMatchers::BlockMatcher::INSTANCE === block
+        else
+          Support::FuzzyMatcher.values_match?(expected_args, args)
+        end
       end
 
       # @private

--- a/lib/rspec/mocks/argument_list_matcher.rb
+++ b/lib/rspec/mocks/argument_list_matcher.rb
@@ -56,8 +56,8 @@ module RSpec
       # @see #initialize
       def args_match?(*args, &block)
         expected_args = resolve_expected_args_based_on(args)
-        if [ArgumentMatchers::BlockMatcher::INSTANCE] == expected_args
-          ArgumentMatchers::BlockMatcher::INSTANCE === block
+        if ArgumentMatchers::BlockMatcher::INSTANCE == expected_args.last
+          Support::FuzzyMatcher.values_match?(expected_args, args + [block])
         else
           Support::FuzzyMatcher.values_match?(expected_args, args)
         end

--- a/lib/rspec/mocks/argument_matchers.rb
+++ b/lib/rspec/mocks/argument_matchers.rb
@@ -114,6 +114,10 @@ module RSpec
 
       alias_method :a_kind_of, :kind_of
 
+      def a_block
+        BlockMatcher::INSTANCE
+      end
+
       # @private
       def self.anythingize_lonely_keys(*args)
         hash = Hash === args.last ? args.delete_at(-1) : {}
@@ -300,6 +304,17 @@ module RSpec
 
         def description
           "kind of #{@klass.name}"
+        end
+      end
+
+      # @private
+      class BlockMatcher < SingletonMatcher
+        def ===(block)
+          block.kind_of?(Proc)
+        end
+
+        def description
+          "a block"
         end
       end
 

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -415,8 +415,8 @@ module RSpec
           @yield_receiver_to_implementation_block
         end
 
-        def matches?(message, *args)
-          @message == message && @argument_list_matcher.args_match?(*args)
+        def matches?(message, *args, &block)
+          @message == message && @argument_list_matcher.args_match?(*args, &block)
         end
 
         def safe_invoke(parent_stub, *args, &block)

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -187,7 +187,7 @@ module RSpec
       def message_received(message, *args, &block)
         record_message_received message, *args, &block
 
-        expectation = find_matching_expectation(message, *args)
+        expectation = find_matching_expectation(message, *args, &block)
         stub = find_matching_method_stub(message, *args)
 
         if (stub && expectation && expectation.called_max_times?) || (stub && !expectation)
@@ -258,9 +258,9 @@ module RSpec
         @method_doubles[message.to_sym]
       end
 
-      def find_matching_expectation(method_name, *args)
+      def find_matching_expectation(method_name, *args, &block)
         find_best_matching_expectation_for(method_name) do |expectation|
-          expectation.matches?(method_name, *args)
+          expectation.matches?(method_name, *args, &block)
         end
       end
 

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -454,6 +454,18 @@ module RSpec
           expect { a_double.msg 3 }.to fail_including "expected: (my_thing)"
         end
       end
+
+      describe "a_block" do
+        before { expect(a_double).to receive(:random_call).with(a_block) }
+
+        it "matches a method call with a block" do
+          a_double.random_call { :a_dummy_block }
+        end
+
+        pending "fails if the method call has no block" do
+          expect { a_double.random_call }.to fail_including "(a block)"
+        end
+      end
     end
   end
 end

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -456,14 +456,34 @@ module RSpec
       end
 
       describe "a_block" do
-        before { expect(a_double).to receive(:random_call).with(a_block) }
-
         it "matches a method call with a block" do
-          a_double.random_call { :a_dummy_block }
+          expect(a_double).to receive(:msg).with(a_block)
+          a_double.msg { :a_dummy_block }
         end
 
-        pending "fails if the method call has no block" do
-          expect { a_double.random_call }.to fail_including "(a block)"
+        it "matches a method call with arguments and a block" do
+          expect(a_double).to receive(:msg).with(1, 2, anything, a_block)
+          a_double.msg(1,2,3) { :and_a_block }
+        end
+
+        it "matches a method call with a block and still allows and_yield" do
+          expect(a_double).to receive(:msg).with(a_block).and_yield(1)
+          a_double.msg { |a| expect(a).to eq(1) }
+        end
+
+        it "fails if the method call has no block", :reset => true do
+          expect(a_double).to receive(:msg).with(a_block)
+          expect { a_double.msg }.to fail_including "expected: (a block)"
+        end
+
+        it "fails if the method call omits a block when matching arguments", :reset => true do
+          expect(a_double).to receive(:msg).with(1, 2, anything, a_block)
+          expect { a_double.msg(1,2,3) }.to fail_including "expected: (1, 2, anything, a block)"
+        end
+
+        it "fails if supplying an incorrect arity block when using and_yield", :reset => true do
+          expect(a_double).to receive(:msg).with(a_block).and_yield(1)
+          expect { a_double.msg { :a_bad_block } }.to fail_including " yielded |1| to block with"
         end
       end
     end


### PR DESCRIPTION
This is @kaiwren's `a_block` argument matcher with fleshed out sad path specs, and a refactoring of the match logic to allow mixing with other arguments. Review please @kaiwren @ioquatix @benoittgt.