### PR TITLE
Concurrent execution vs mocks without falsely creating Mutex

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -1,3 +1,5 @@
+RSpec::Support.require_rspec_support 'mutex'
+
 module RSpec
   module Mocks
     # A message expectation that only allows concrete return values to be set
@@ -368,11 +370,6 @@ module RSpec
         # @private
         attr_reader :type
 
-        unless defined?(Mutex)
-          Support.require_rspec_support 'mutex'
-          Mutex = Support::Mutex
-        end
-
         # rubocop:disable Metrics/ParameterLists
         def initialize(error_generator, expectation_ordering, expected_from, method_double,
                        type=:expectation, opts={}, &implementation_block)
@@ -384,7 +381,7 @@ module RSpec
           @orig_object = @method_double.object
           @message = @method_double.method_name
           @actual_received_count = 0
-          @actual_received_count_write_mutex = Mutex.new
+          @actual_received_count_write_mutex = Support::Mutex.new
           @expected_received_count = type == :expectation ? 1 : :any
           @argument_list_matcher = ArgumentListMatcher::MATCH_ALL
           @order_group = expectation_ordering

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -9,6 +9,11 @@ module RSpec
         end
       end
 
+      unless defined?(Mutex)
+        Support.require_rspec_support 'mutex'
+        Mutex = Support::Mutex
+      end
+
       # @private
       def ensure_implemented(*_args)
         # noop for basic proxies, see VerifyingProxy for behaviour.
@@ -20,6 +25,7 @@ module RSpec
         @order_group = order_group
         @error_generator = ErrorGenerator.new(object)
         @messages_received = []
+        @messages_received_mutex = Mutex.new
         @options = options
         @null_object = false
         @method_doubles = Hash.new { |h, k| h[k] = MethodDouble.new(@object, k, self) }
@@ -90,27 +96,31 @@ module RSpec
           @error_generator.raise_expectation_on_unstubbed_method(expected_method_name)
         end
 
-        @messages_received.each do |(actual_method_name, args, received_block)|
-          next unless expectation.matches?(actual_method_name, *args)
+        @messages_received_mutex.synchronize do
+          @messages_received.each do |(actual_method_name, args, received_block)|
+            next unless expectation.matches?(actual_method_name, *args)
 
-          expectation.safe_invoke(nil)
-          block.call(*args, &received_block) if block
+            expectation.safe_invoke(nil)
+            block.call(*args, &received_block) if block
+          end
         end
       end
 
       # @private
       def check_for_unexpected_arguments(expectation)
-        return if @messages_received.empty?
+        @messages_received_mutex.synchronize do
+          return if @messages_received.empty?
 
-        return if @messages_received.any? { |method_name, args, _| expectation.matches?(method_name, *args) }
+          return if @messages_received.any? { |method_name, args, _| expectation.matches?(method_name, *args) }
 
-        name_but_not_args, others = @messages_received.partition do |(method_name, args, _)|
-          expectation.matches_name_but_not_args(method_name, *args)
+          name_but_not_args, others = @messages_received.partition do |(method_name, args, _)|
+            expectation.matches_name_but_not_args(method_name, *args)
+          end
+
+          return if name_but_not_args.empty? && !others.empty?
+
+          expectation.raise_unexpected_message_args_error(name_but_not_args.map { |args| args[1] })
         end
-
-        return if name_but_not_args.empty? && !others.empty?
-
-        expectation.raise_unexpected_message_args_error(name_but_not_args.map { |args| args[1] })
       end
 
       # @private
@@ -141,17 +151,23 @@ module RSpec
 
       # @private
       def reset
-        @messages_received.clear
+        @messages_received_mutex.synchronize do
+          @messages_received.clear
+        end
       end
 
       # @private
       def received_message?(method_name, *args, &block)
-        @messages_received.any? { |array| array == [method_name, args, block] }
+        @messages_received_mutex.synchronize do
+          @messages_received.any? { |array| array == [method_name, args, block] }
+        end
       end
 
       # @private
       def messages_arg_list
-        @messages_received.map { |_, args, _| args }
+        @messages_received_mutex.synchronize do
+          @messages_received.map { |_, args, _| args }
+        end
       end
 
       # @private
@@ -162,7 +178,9 @@ module RSpec
       # @private
       def record_message_received(message, *args, &block)
         @order_group.invoked SpecificMessage.new(object, message, args)
-        @messages_received << [message, args, block]
+        @messages_received_mutex.synchronize do
+          @messages_received << [message, args, block]
+        end
       end
 
       # @private

--- a/spec/rspec/mocks/stubbed_message_expectations_spec.rb
+++ b/spec/rspec/mocks/stubbed_message_expectations_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe "expection set on previously stubbed method" do
   end
 
   it 'handles concurrent validation of expectations' do
-    pending('support for concurrent validation of message expectations')
-
     dbl = double('double', :foo => true)
     concurrency = 4
     repetition = 10

--- a/spec/rspec/mocks/stubbed_message_expectations_spec.rb
+++ b/spec/rspec/mocks/stubbed_message_expectations_spec.rb
@@ -23,6 +23,25 @@ RSpec.describe "expection set on previously stubbed method" do
     reset dbl
   end
 
+  it 'handles concurrent validation of expectations' do
+    pending('support for concurrent validation of message expectations')
+
+    dbl = double('double', :foo => true)
+    concurrency = 4
+    repetition = 10
+    expect(dbl).to receive(:foo).with(anything).exactly(concurrency * repetition).times
+
+    concurrency.times.map do |thread|
+      Thread.new do
+        repetition.times do |index|
+          dbl.foo("#{thread}-#{index}")
+        end
+      end
+    end.map(&:join)
+
+    verify dbl
+  end
+
   it 'indicates the site of expectation in the stacktrace when outputing arguments of similar calls' do
     dbl = double('double', :foo => true)
     expect(dbl).to receive(:foo).with('first'); line = __LINE__


### PR DESCRIPTION
Finish up #1236 by handling the `Mutex` edge case.