### PR TITLE
Update docs for raising errors with required params

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,10 +327,8 @@ expect(double).to receive(:msg).and_return(value)
 expect(double).to receive(:msg).exactly(3).times.and_return(value1, value2, value3)
   # returns value1 the first time, value2 the second, etc
 expect(double).to receive(:msg).and_raise(error)
-  # error can be an instantiated object or a class
+  # `error` can be an instantiated object (e.g. `StandardError.new(some_arg)`) or a class (e.g. `StandardError`)
   # if it is a class, it must be instantiable with no args
-expect(double).to receive(:msg).and_raise(StandardError.new(some_arg))
-  # instantiated error object for class which requires args
 expect(double).to receive(:msg).and_throw(:msg)
 expect(double).to receive(:msg).and_yield(values, to, yield)
 expect(double).to receive(:msg).and_yield(values, to, yield).and_yield(some, other, values, this, time)

--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ expect(double).to receive(:msg).exactly(3).times.and_return(value1, value2, valu
 expect(double).to receive(:msg).and_raise(error)
   # error can be an instantiated object or a class
   # if it is a class, it must be instantiable with no args
+expect(double).to receive(:msg).and_raise(StandardError.new(some_arg))
+  # instantiated error object for class which requires args
 expect(double).to receive(:msg).and_throw(:msg)
 expect(double).to receive(:msg).and_yield(values, to, yield)
 expect(double).to receive(:msg).and_yield(values, to, yield).and_yield(some, other, values, this, time)


### PR DESCRIPTION
I would like to update the documentation for raising errors with required parameters. I have run into an issue multiple times where I've tried to raise an error class, but the class requires args for instantiation, like
```
expect(double).to receive(:msg).and_raise(ErrorWhichRequiresArgs)
```
without realizing the issue. Ruby gives an error message about "wrong number of arguments", which has repeatedly led me (personally) down the wrong path of troubleshooting other issues.

If we added this example, I think it would help us avoid this issue (or fix it faster). For justification that I'm not the only one with the issue, this question on StackOverflow has an accepted answer with 15 points: https://stackoverflow.com/questions/40775978/rspec-wrong-number-of-arguments-when-raising-error

Thanks!