### PR TITLE
Make features global configuration proof

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,6 +10,12 @@ Before do
 end
 
 Aruba.configure do |config|
+  config.before_cmd do |cmd|
+    set_env('XDG_CONFIG_HOME', 'nonexistent-directory') # skip loading global configuration
+  end
+end
+
+Aruba.configure do |config|
   config.before_cmd do
     set_env('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
   end


### PR DESCRIPTION
If a `~/.config/rspec/options` file contains the following:

    --color
    --profile 2
    --format progress
    --require pry

a number of features fail, since options are picked up and used by the
code under test.

Setting `XDG_CONFIG_HOME` to a directory that does exist skips loading
the global configuration.

Related:
https://github.com/rspec/rspec-dev/issues/217
https://github.com/rspec/rspec-core/pull/2602


*NOTE*: Unfortunately, this doesn't fix the issue for configuration stored in `~/.rspec`. My advice is to move it over to `~/.config/rspec/options`.