### PR TITLE
Prevent error formatting from causing recursive errors

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -390,7 +390,7 @@ module RSpec
           @expectation_type = type
           @ordered = false
           @at_least = @at_most = @exactly = nil
-          @raised = false
+          @failed = false
 
           # Initialized to nil so that we don't allocate an array for every
           # mock or stub. See also comment in `and_yield`.
@@ -425,7 +425,7 @@ module RSpec
         end
 
         def invoke(parent_stub, *args, &block)
-          if @raised
+          if @failed
             invoke_incrementing_actual_calls_by(0, false, parent_stub, *args, &block)
           else
             invoke_incrementing_actual_calls_by(1, true, parent_stub, *args, &block)
@@ -561,7 +561,7 @@ module RSpec
           args.unshift(orig_object) if yield_receiver_to_implementation_block?
 
           if negative? || (allowed_to_fail && (@exactly || @at_most) && (@actual_received_count == @expected_received_count))
-            @raised = true
+            @failed = true
             # args are the args we actually received, @argument_list_matcher is the
             # list of args we were expecting
             @error_generator.raise_expectation_error(

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -390,6 +390,7 @@ module RSpec
           @expectation_type = type
           @ordered = false
           @at_least = @at_most = @exactly = nil
+          @raised = false
 
           # Initialized to nil so that we don't allocate an array for every
           # mock or stub. See also comment in `and_yield`.
@@ -424,7 +425,11 @@ module RSpec
         end
 
         def invoke(parent_stub, *args, &block)
-          invoke_incrementing_actual_calls_by(1, true, parent_stub, *args, &block)
+          if @raised
+            invoke_incrementing_actual_calls_by(0, false, parent_stub, *args, &block)
+          else
+            invoke_incrementing_actual_calls_by(1, true, parent_stub, *args, &block)
+          end
         end
 
         def invoke_without_incrementing_received_count(parent_stub, *args, &block)
@@ -556,6 +561,7 @@ module RSpec
           args.unshift(orig_object) if yield_receiver_to_implementation_block?
 
           if negative? || (allowed_to_fail && (@exactly || @at_most) && (@actual_received_count == @expected_received_count))
+            @raised = true
             # args are the args we actually received, @argument_list_matcher is the
             # list of args we were expecting
             @error_generator.raise_expectation_error(

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -152,6 +152,34 @@ module RSpec
         }.to fail_with(/MyClass/)
       end
 
+      it "formats an error message when inspect fails" do
+        klass = Struct.new(:name) do
+          def inspect
+            "<Inspector(#{name})>"
+          end
+        end
+
+        object = klass.new('foo')
+
+        expect(object).to receive(:name).once.and_return('bar')
+
+        object.name
+
+        expect do
+          object.name
+        end.to raise_error(
+          RSpec::Mocks::MockExpectationError,
+          %|(<Inspector(bar)>).name(no args)\n    expected: 1 time with any arguments\n    received: 2 times|
+        )
+
+        expect do
+          verify object
+        end.to raise_error(
+          RSpec::Mocks::MockExpectationError,
+          %|(<Inspector(bar)>).name(*(any args))\n    expected: 1 time with any arguments\n    received: 2 times with any arguments|
+        )
+      end
+
       it "shares message expectations with clone" do
         expect(object).to receive(:foobar)
         twin = object.clone

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -160,22 +160,17 @@ module RSpec
         end
 
         object = klass.new('foo')
-
         expect(object).to receive(:name).once.and_return('bar')
-
         object.name
 
-        expect do
+        expect {
           object.name
-        end.to raise_error(
-          RSpec::Mocks::MockExpectationError,
+        }.to fail_with(
           %|(<Inspector(bar)>).name(no args)\n    expected: 1 time with any arguments\n    received: 2 times|
         )
-
-        expect do
+        expect {
           verify object
-        end.to raise_error(
-          RSpec::Mocks::MockExpectationError,
+        }.to fail_with(
           %|(<Inspector(bar)>).name(*(any args))\n    expected: 1 time with any arguments\n    received: 2 times with any arguments|
         )
       end


### PR DESCRIPTION
This comes from tracking down https://github.com/rspec/rspec-rails/issues/2049 wherein

```
it 'should show only 2 times' do
  expect(@student).to     receive(:email).once.and_call_original
  @student.email
  @student.email
end
```

overflows. There `Devise` has defined an `inspect` method which calls `email`, so when the second call to `email` errors, the [error generator's `inspect` call](https://github.com/rspec/rspec-mocks/blob/55f0b116dc8c15a7acef9e7619bb0a3925bd18fa/lib/rspec/mocks/error_generator.rb#L230) goes into a loop.

I've added a spec that I think describes the desired behavior, but which is currently failing against master.

The included `lib` change fixes the spec, but this is my first time digging into the RSpec codebase, and it's entirely possible there's a better place to make that change.

Please let me know if I've mis-understood the desired behavior, or if there's anything else you'd like to see changed. Thanks!