### PR TITLE
Do not change method visibility when stubbing private class methods.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,10 @@ Enhancements:
   `expect(Class).to receive(:method).exactly(1).time`.
   (Pistos, Benoit Tigeot, #1271)
 
+Bug Fixes:
+
+* Do not change the visibility of stubbed private class methods. (Kevin Boschert)
+
 ### 3.8.0 / 2018-08-04
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.7.0...v3.8.0)
 

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -59,7 +59,7 @@ module RSpec
         return if @method_is_proxied
 
         save_original_implementation_callable!
-        definition_target.class_exec(self, method_name, visibility) do |method_double, method_name, visibility|
+        definition_target.class_exec(self, method_name, @original_visibility || visibility) do |method_double, method_name, visibility|
           define_method(method_name) do |*args, &block|
             method_double.proxy_method_invoked(self, *args, &block)
           end

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -19,6 +19,7 @@ module RSpec
             existing_private_instance_method
           end
 
+        private
           def existing_private_instance_method
             :original_value
           end
@@ -82,6 +83,16 @@ module RSpec
       it "is cleared when stubbed object when `dup`ed" do
         allow(@stub).to receive(:foobar).and_return(1)
         expect { @stub.dup.foobar }.to raise_error NoMethodError, /foobar/
+      end
+
+      it "remains private when it stubs a private instance method" do
+        allow(@instance).to receive(:existing_private_instance_method).and_return(1)
+        expect { @instance.existing_private_instance_method }.to raise_error NoMethodError, /private method `existing_private_instance_method/
+      end
+
+      it "remains private when it stubs a private class method" do
+        allow(@class).to receive(:existing_private_class_method).and_return(1)
+        expect { @class.existing_private_class_method }.to raise_error NoMethodError, /private method `existing_private_class_method/
       end
 
       context "using `with`" do


### PR DESCRIPTION
This fixes an issue where stubbing a private class method creates the stub as a public class method.