### PR TITLE
Update Aruba to version 0.14.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,10 @@ if RUBY_VERSION < '2.2.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|min
   gem "childprocess", "< 1.0.0"
 end
 
+if RUBY_VERSION < '1.9.2'
+  gem 'contracts', '~> 0.15.0' # is a dependency of aruba
+end
+
 ### deps for rdoc.info
 group :documentation do
   gem 'redcarpet',     '2.1.1' unless RUBY_PLATFORM == 'java'

--- a/features/support/disallow_certain_apis.rb
+++ b/features/support/disallow_certain_apis.rb
@@ -4,7 +4,7 @@
 if defined?(Cucumber)
   require 'shellwords'
   Before('~@allow-old-syntax') do
-    set_env('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
+    set_environment_variable('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
   end
 else
   module DisallowOneLinerShould

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,22 +1,22 @@
 require 'aruba/cucumber'
 require 'rspec/expectations'
 
-Before do
+Aruba.configure do |config|
   if RUBY_PLATFORM =~ /java/ || defined?(Rubinius)
-    @aruba_timeout_seconds = 60
+    config.exit_timeout = 60
   else
-    @aruba_timeout_seconds = 5
+    config.exit_timeout = 5
   end
 end
 
-Aruba.configure do |config|
-  config.before_cmd do
-    set_env('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
+Before do
+  if RUBY_PLATFORM == 'java'
+    # disable JIT since these processes are so short lived
+    set_environment_variable('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}")
   end
-end if RUBY_PLATFORM == 'java'
 
-Aruba.configure do |config|
-  config.before_cmd do
-    set_env('RBXOPT', "-Xint=true #{ENV['RBXOPT']}") # disable JIT since these processes are so short lived
+  if defined?(Rubinius)
+    # disable JIT since these processes are so short lived
+    set_environment_variable('RBXOPT', "-Xint=true #{ENV['RBXOPT']}")
   end
-end if defined?(Rubinius)
+end

--- a/rspec-mocks.gemspec
+++ b/rspec-mocks.gemspec
@@ -47,6 +47,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.3.15'
-  s.add_development_dependency 'aruba',    '~> 0.6.2' # 0.7 is broken on ruby 1.8.7
+  s.add_development_dependency 'aruba',    '~> 0.14.10'
   s.add_development_dependency 'minitest', '~> 5.2'
 end


### PR DESCRIPTION
- Bump dependency version
- Fix deprecations
- Limit version of transitive dependency on contracts gem on old Rubies