### PR TITLE
Support ruby-head/2.8

### DIFF
--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -129,10 +129,10 @@ module RSpec
         end
 
         # @private
-        def notify_received_message(_object, message, args, _blk)
+        def notify_received_message(_object, message, args, opts, _blk)
           has_expectation = false
 
-          message_chains.each_unfulfilled_expectation_matching(message, *args) do |expectation|
+          message_chains.each_unfulfilled_expectation_matching(message, *args, **opts) do |expectation|
             has_expectation = true
             expectation.expectation_fulfilled!
           end
@@ -257,9 +257,9 @@ module RSpec
           @observed_methods << method_name
           backup_method!(method_name)
           recorder = self
-          @klass.__send__(:define_method, method_name) do |*args, &blk|
+          @klass.__send__(:define_method, method_name) do |*args, **opts, &blk|
             recorder.playback!(self, method_name)
-            __send__(method_name, *args, &blk)
+            __send__(method_name, *args, **opts, &blk)
           end
         end
 

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -60,8 +60,8 @@ module RSpec
 
         save_original_implementation_callable!
         definition_target.class_exec(self, method_name, @original_visibility || visibility) do |method_double, method_name, visibility|
-          define_method(method_name) do |*args, &block|
-            method_double.proxy_method_invoked(self, *args, &block)
+          define_method(method_name) do |*args, **opts, &block|
+            method_double.proxy_method_invoked(self, *args, **opts, &block)
           end
           __send__(visibility, method_name)
         end
@@ -73,8 +73,8 @@ module RSpec
       # method to perform additional operations.
       #
       # @private
-      def proxy_method_invoked(_obj, *args, &block)
-        @proxy.message_received method_name, *args, &block
+      def proxy_method_invoked(_obj, *args, **opts, &block)
+        @proxy.message_received method_name, *args, **opts, &block
       end
 
       # @private


### PR DESCRIPTION
ruby-head does not pass keyword arguments, making [this test](https://github.com/p-mongo/tests/blob/master/rspec-ruby-head/test.rb) fail:

<pre>
class Foo
  def m(a, b: nil)
    p [a, b]
  end
end

describe 'foo' do
  it 'bars' do
    expect_any_instance_of(Foo).to receive(:m).and_call_original

    Foo.new.m(1, b: 2)
  end
end
</pre>

<pre>
Failures:

  1) foo bars
     Failure/Error:
       def m(a, b: nil)
         p [a, b]
       end
     
     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./test.rb:5:in `m'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/message_expectation.rb:102:in `call'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/message_expectation.rb:102:in `block in and_call_original'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/message_expectation.rb:743:in `call'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/message_expectation.rb:574:in `invoke_incrementing_actual_calls_by'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/message_expectation.rb:428:in `invoke'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/proxy.rb:202:in `message_received'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/proxy.rb:348:in `message_received'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/method_double.rb:77:in `proxy_method_invoked'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/method_double.rb:64:in `block (2 levels) in define_proxy_method'
     # /home/me/apps/exp/rspec-mocks/lib/rspec/mocks/any_instance/recorder.rb:262:in `block in observe!'
     # ./test.rb:14:in `block (2 levels) in <top (required)>'
     # /home/me/apps/exp/rspec-core/lib/rspec/core/example.rb:257:in `instance_exec'
     # /home/me/apps/exp/rspec-core/lib/rspec/core/example.rb:257:in `block in run'
     # /home/me/apps/exp/rspec-core/lib/rspec/core/example.rb:503:in `block in with_around_and_singleton_context_hooks'
     # /home/me/apps/exp/rspec-core/lib/rspec/core/example.rb:460:in `block in with_around_example_hooks'
     # /home/me/apps/exp/rspec-core/lib/rspec/core/hooks.rb:481:in `block in run'
</pre>

Proposed solution is to take *args and **opts separately in all methods.