### PR TITLE
Handle keyword arguments separately for and_call_original in supported rubies

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:53:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # This file contains defaults for RSpec projects. Individual projects

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:53:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # In order to install old Rubies, we need to use old Ubuntu distibution.
@@ -22,10 +22,10 @@ rvm:
   - 2.1
   - 2.2.10
   - 2.3.8
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
   - ruby-head
   - ree
   - rbx-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
   include:
     - rvm: jruby-1.7
       env: JRUBY_OPTS='--dev --1.8'
+    - rvm: 2.7.1
+      env: DIFF_LCS_VERSION='~> 1.3.0'
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Enhancements:
 * Add the ability to set a custom error generator in `MessageExpectation`.
   This will allow rspec-expectations to inject a custom failure message.
   (Benoit Tigeot and Nicolas Zermati, #1312)
+* Return the result of the block passed to `RSpec::Mocks.with_temporary_scope`
+  when block run. (@expeehaa, #1329)
 
 ### 3.9.1 / 2019-12-31
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.9.0...v3.9.1)

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,12 @@ else
   gem 'rake', '> 12.3.2'
 end
 
+if ENV['DIFF_LCS_VERSION']
+  gem 'diff-lcs', ENV['DIFF_LCS_VERSION']
+else
+  gem 'diff-lcs', '~> 1.4', '>= 1.4.3'
+end
+
 gem 'yard', '~> 0.9.24', :require => false
 
 # No need to run rubocop on earlier versions

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,14 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
   end
 end
 
+if RUBY_VERSION < '1.9.3'
+  gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later
+elsif RUBY_VERSION < '2.0.0'
+  gem 'rake', '< 12.0.0' # rake 12 requires Ruby 2.0.0 or later
+else
+  gem 'rake', '> 12.3.2'
+end
+
 gem 'yard', '~> 0.9.24', :require => false
 
 # No need to run rubocop on earlier versions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:53:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 version: "{build}"

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -87,15 +87,19 @@ module RSpec
 
     # Call the passed block and verify mocks after it has executed. This allows
     # mock usage in arbitrary places, such as a `before(:all)` hook.
+    # Returns the result of the passed block.
     def self.with_temporary_scope
       setup
 
+      result = nil
       begin
-        yield
+        result = yield
         verify
       ensure
         teardown
       end
+
+      result
     end
 
     class << self

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -87,7 +87,8 @@ module RSpec
 
     # Call the passed block and verify mocks after it has executed. This allows
     # mock usage in arbitrary places, such as a `before(:all)` hook.
-    # Returns the result of the passed block.
+    # 
+    # @return [Object] the return value from the block
     def self.with_temporary_scope
       setup
 

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -91,15 +91,13 @@ module RSpec
     def self.with_temporary_scope
       setup
 
-      result = nil
       begin
         result = yield
         verify
+        result
       ensure
         teardown
       end
-
-      result
     end
 
     class << self

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -87,7 +87,7 @@ module RSpec
 
     # Call the passed block and verify mocks after it has executed. This allows
     # mock usage in arbitrary places, such as a `before(:all)` hook.
-    # 
+    #
     # @return [Object] the return value from the block
     def self.with_temporary_scope
       setup

--- a/rspec-mocks.gemspec
+++ b/rspec-mocks.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
 
-  s.add_development_dependency 'rake',     '~> 10.0.0'
+  s.add_development_dependency 'rake',     '> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.3.15'
   s.add_development_dependency 'aruba',    '~> 0.14.10'
   s.add_development_dependency 'minitest', '~> 5.2'

--- a/script/clone_all_rspec_repos
+++ b/script/clone_all_rspec_repos
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:53:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:53:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:53:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 function is_mri {

--- a/script/run_build
+++ b/script/run_build
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:53:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/travis_functions.sh
+++ b/script/travis_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:53:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # Taken from:

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2020-03-30T16:31:25+02:00 from the rspec-dev repo.
+# This file was generated on 2020-04-03T18:53:23+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe "and_call_original" do
           yield x, :additional_yielded_arg
         end
 
+        if RSpec::Support::RubyFeatures.kw_args_supported?
+          binding.eval(<<-CODE, __FILE__, __LINE__)
+          def meth_3(keyword_arg: nil)
+            keyword_arg
+          end
+          CODE
+        end
+
         def self.new_instance
           new
         end
@@ -57,6 +65,15 @@ RSpec.describe "and_call_original" do
       expect(instance).to receive(:meth_2).and_call_original
       value = instance.meth_2(:submitted_arg) { |a, b| [a, b] }
       expect(value).to eq([:submitted_arg, :additional_yielded_arg])
+    end
+
+    if RSpec::Support::RubyFeatures.kw_args_supported?
+      it 'works with keyword arguments' do
+        expect(instance).to receive(:meth_3).and_call_original
+        binding.eval(<<-CODE, __FILE__, __LINE__)
+        expect(instance.meth_3(keyword_arg: :original_arg)).to eq :original_arg
+        CODE
+      end
     end
 
     it 'errors when you pass through the wrong number of args' do

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe "and_call_original" do
           def meth_3(keyword_arg: nil)
             keyword_arg
           end
+
+          def initialize(initialize_arg: nil)
+            @initialize_arg = initialize_arg
+          end
+          attr_reader :initialize_arg
           CODE
         end
 
@@ -72,6 +77,15 @@ RSpec.describe "and_call_original" do
         expect(instance).to receive(:meth_3).and_call_original
         binding.eval(<<-CODE, __FILE__, __LINE__)
         expect(instance.meth_3(keyword_arg: :original_arg)).to eq :original_arg
+        CODE
+      end
+
+      it 'works with keyword arguments for .initialize' do
+        expect(klass).to receive(:new).with(initialize_arg: :initialize_arg)
+          .and_call_original
+        binding.eval(<<-CODE, __FILE__, __LINE__)
+        instance = klass.new(initialize_arg: :initialize_arg)
+        expect(instance.initialize_arg).to eq :initialize_arg
         CODE
       end
     end

--- a/spec/rspec/mocks/diffing_spec.rb
+++ b/spec/rspec/mocks/diffing_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 require "pp"
 
 RSpec.describe "Diffs printed when arguments don't match" do
+  include RSpec::Support::Spec::DiffHelpers
+
   before do
     allow(RSpec::Mocks.configuration).to receive(:color?).and_return(false)
   end
@@ -68,7 +70,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
         expect(d).to receive(:foo).with(expected_hash)
         expect {
           d.foo(:bad => :hash)
-        }.to fail_with(/\A#<Double "double"> received :foo with unexpected arguments\n  expected: \(#{hash_regex_inspect expected_hash}\)\n       got: \(#{hash_regex_inspect actual_hash}\)\nDiff:\n@@ \-1\,2 \+1\,2 @@\n\-\[#{hash_regex_inspect expected_hash}\]\n\+\[#{hash_regex_inspect actual_hash}\]\n\z/)
+        }.to fail_with(/\A#<Double "double"> received :foo with unexpected arguments\n  expected: \(#{hash_regex_inspect expected_hash}\)\n       got: \(#{hash_regex_inspect actual_hash}\)\nDiff:\n@@ #{Regexp.escape one_line_header} @@\n\-\[#{hash_regex_inspect expected_hash}\]\n\+\[#{hash_regex_inspect actual_hash}\]\n\z/)
       end
     end
 
@@ -101,7 +103,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
         expect(d).to receive(:foo).with([:a, :b, :c])
         expect {
           d.foo([])
-        }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: ([:a, :b, :c])\n       got: ([])\nDiff:\n@@ -1,2 +1,2 @@\n-[[:a, :b, :c]]\n+[[]]\n")
+        }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: ([:a, :b, :c])\n       got: ([])\nDiff:\n@@ #{one_line_header} @@\n-[[:a, :b, :c]]\n+[[]]\n")
       end
     end
 
@@ -117,7 +119,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
             d.foo([])
           }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n" \
             "  expected: (#{collab_inspect})\n" \
-            "       got: ([])\nDiff:\n@@ -1,2 +1,2 @@\n-[#{collab_inspect}]\n+[[]]\n")
+            "       got: ([])\nDiff:\n@@ #{one_line_header} @@\n-[#{collab_inspect}]\n+[[]]\n")
         end
       end
     end
@@ -136,7 +138,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
             d.foo([:a, :b])
           }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n" \
             "  expected: (#{collab_description})\n" \
-            "       got: ([:a, :b])\nDiff:\n@@ -1,2 +1,2 @@\n-[\"#{collab_description}\"]\n+[[:a, :b]]\n")
+            "       got: ([:a, :b])\nDiff:\n@@ #{one_line_header} @@\n-[\"#{collab_description}\"]\n+[[:a, :b]]\n")
         end
       end
     end
@@ -164,7 +166,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
             d.foo([:a, :b])
           }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n" \
             "  expected: (#{collab_inspect})\n" \
-            "       got: ([:a, :b])\nDiff:\n@@ -1,2 +1,2 @@\n-[#{collab_pp}]\n+[[:a, :b]]\n")
+            "       got: ([:a, :b])\nDiff:\n@@ #{one_line_header} @@\n-[#{collab_pp}]\n+[[:a, :b]]\n")
         end
       end
     end

--- a/spec/rspec/mocks/formatting_spec.rb
+++ b/spec/rspec/mocks/formatting_spec.rb
@@ -3,6 +3,7 @@ require 'support/doubled_classes'
 
 RSpec.describe "Test doubles format well in failure messages" do
   include RSpec::Matchers::FailMatchers
+  include RSpec::Support::Spec::DiffHelpers
 
   RSpec::Matchers.define :format_in_failures_as do |expected|
     match do |dbl|
@@ -101,7 +102,7 @@ RSpec.describe "Test doubles format well in failure messages" do
     }.to fail_with(<<-EOS.gsub(/^\s+\|/, ''))
       |expected [#<Double "Foo">] to include #<Double "Bar">
       |Diff:
-      |@@ -1,2 +1,2 @@
+      |@@ #{one_line_header} @@
       |-[#<Double "Bar">]
       |+[#<Double "Foo">]
     EOS

--- a/spec/rspec/mocks_spec.rb
+++ b/spec/rspec/mocks_spec.rb
@@ -209,6 +209,10 @@ RSpec.describe RSpec::Mocks do
       }.to raise_error("boom") # rather than MockExpectationError
     end
 
+    it 'returns the result of the passed block' do
+      expect(RSpec::Mocks.with_temporary_scope { 5 }).to eq 5
+    end
+
     def capture_error
       yield
     rescue Exception => @error


### PR DESCRIPTION
Fixes #1306 