### PR TITLE
Update RSpec::Mocks.with_temporary_scope to return the result of the passed block.

### DIFF
--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -87,15 +87,19 @@ module RSpec
 
     # Call the passed block and verify mocks after it has executed. This allows
     # mock usage in arbitrary places, such as a `before(:all)` hook.
+    # Returns the result of the passed block.
     def self.with_temporary_scope
       setup
 
+      result = nil
       begin
-        yield
+        result = yield
         verify
       ensure
         teardown
       end
+
+      result
     end
 
     class << self

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -87,7 +87,8 @@ module RSpec
 
     # Call the passed block and verify mocks after it has executed. This allows
     # mock usage in arbitrary places, such as a `before(:all)` hook.
-    # Returns the result of the passed block.
+    # 
+    # @return [Object] the return value from the block
     def self.with_temporary_scope
       setup
 

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -91,15 +91,13 @@ module RSpec
     def self.with_temporary_scope
       setup
 
-      result = nil
       begin
         result = yield
         verify
+        result
       ensure
         teardown
       end
-
-      result
     end
 
     class << self

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -87,7 +87,7 @@ module RSpec
 
     # Call the passed block and verify mocks after it has executed. This allows
     # mock usage in arbitrary places, such as a `before(:all)` hook.
-    # 
+    #
     # @return [Object] the return value from the block
     def self.with_temporary_scope
       setup

--- a/spec/rspec/mocks_spec.rb
+++ b/spec/rspec/mocks_spec.rb
@@ -209,6 +209,10 @@ RSpec.describe RSpec::Mocks do
       }.to raise_error("boom") # rather than MockExpectationError
     end
 
+    it 'returns the result of the passed block' do
+      expect(RSpec::Mocks.with_temporary_scope { 5 }).to eq 5
+    end
+
     def capture_error
       yield
     rescue Exception => @error


### PR DESCRIPTION
This implements #1328.