### PR TITLE
Fix differ support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
   include:
     - rvm: jruby-1.7
       env: JRUBY_OPTS='--dev --1.8'
+    - rvm: 2.7.1
+      env: DIFF_LCS_VERSION='~> 1.3.0'
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,12 @@ else
   gem 'rake', '> 12.3.2'
 end
 
+if ENV['DIFF_LCS_VERSION']
+  gem 'diff-lcs', ENV['DIFF_LCS_VERSION']
+else
+  gem 'diff-lcs', '~> 1.4', '>= 1.4.3'
+end
+
 gem 'yard', '~> 0.9.24', :require => false
 
 # No need to run rubocop on earlier versions

--- a/spec/rspec/mocks/diffing_spec.rb
+++ b/spec/rspec/mocks/diffing_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 require "pp"
 
 RSpec.describe "Diffs printed when arguments don't match" do
+  include RSpec::Support::Spec::DiffHelpers
+
   before do
     allow(RSpec::Mocks.configuration).to receive(:color?).and_return(false)
   end
@@ -68,7 +70,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
         expect(d).to receive(:foo).with(expected_hash)
         expect {
           d.foo(:bad => :hash)
-        }.to fail_with(/\A#<Double "double"> received :foo with unexpected arguments\n  expected: \(#{hash_regex_inspect expected_hash}\)\n       got: \(#{hash_regex_inspect actual_hash}\)\nDiff:\n@@ \-1\,2 \+1\,2 @@\n\-\[#{hash_regex_inspect expected_hash}\]\n\+\[#{hash_regex_inspect actual_hash}\]\n\z/)
+        }.to fail_with(/\A#<Double "double"> received :foo with unexpected arguments\n  expected: \(#{hash_regex_inspect expected_hash}\)\n       got: \(#{hash_regex_inspect actual_hash}\)\nDiff:\n@@ #{Regexp.escape one_line_header} @@\n\-\[#{hash_regex_inspect expected_hash}\]\n\+\[#{hash_regex_inspect actual_hash}\]\n\z/)
       end
     end
 
@@ -101,7 +103,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
         expect(d).to receive(:foo).with([:a, :b, :c])
         expect {
           d.foo([])
-        }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: ([:a, :b, :c])\n       got: ([])\nDiff:\n@@ -1,2 +1,2 @@\n-[[:a, :b, :c]]\n+[[]]\n")
+        }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  expected: ([:a, :b, :c])\n       got: ([])\nDiff:\n@@ #{one_line_header} @@\n-[[:a, :b, :c]]\n+[[]]\n")
       end
     end
 
@@ -117,7 +119,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
             d.foo([])
           }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n" \
             "  expected: (#{collab_inspect})\n" \
-            "       got: ([])\nDiff:\n@@ -1,2 +1,2 @@\n-[#{collab_inspect}]\n+[[]]\n")
+            "       got: ([])\nDiff:\n@@ #{one_line_header} @@\n-[#{collab_inspect}]\n+[[]]\n")
         end
       end
     end
@@ -136,7 +138,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
             d.foo([:a, :b])
           }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n" \
             "  expected: (#{collab_description})\n" \
-            "       got: ([:a, :b])\nDiff:\n@@ -1,2 +1,2 @@\n-[\"#{collab_description}\"]\n+[[:a, :b]]\n")
+            "       got: ([:a, :b])\nDiff:\n@@ #{one_line_header} @@\n-[\"#{collab_description}\"]\n+[[:a, :b]]\n")
         end
       end
     end
@@ -164,7 +166,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
             d.foo([:a, :b])
           }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n" \
             "  expected: (#{collab_inspect})\n" \
-            "       got: ([:a, :b])\nDiff:\n@@ -1,2 +1,2 @@\n-[#{collab_pp}]\n+[[:a, :b]]\n")
+            "       got: ([:a, :b])\nDiff:\n@@ #{one_line_header} @@\n-[#{collab_pp}]\n+[[:a, :b]]\n")
         end
       end
     end

--- a/spec/rspec/mocks/formatting_spec.rb
+++ b/spec/rspec/mocks/formatting_spec.rb
@@ -3,6 +3,7 @@ require 'support/doubled_classes'
 
 RSpec.describe "Test doubles format well in failure messages" do
   include RSpec::Matchers::FailMatchers
+  include RSpec::Support::Spec::DiffHelpers
 
   RSpec::Matchers.define :format_in_failures_as do |expected|
     match do |dbl|
@@ -101,7 +102,7 @@ RSpec.describe "Test doubles format well in failure messages" do
     }.to fail_with(<<-EOS.gsub(/^\s+\|/, ''))
       |expected [#<Double "Foo">] to include #<Double "Bar">
       |Diff:
-      |@@ -1,2 +1,2 @@
+      |@@ #{one_line_header} @@
       |-[#<Double "Bar">]
       |+[#<Double "Foo">]
     EOS


### PR DESCRIPTION
Builds on rspec/rspec-support#421 to add support for both diff-lcs versions in rspec-mocks spec suite.

Once again this is pretty much just header changes.