### PR TITLE
Improve (legacy) `any_instance` documentation example

### DIFF
--- a/features/working_with_legacy_code/any_instance.feature
+++ b/features/working_with_legacy_code/any_instance.feature
@@ -83,8 +83,8 @@ Feature: Any Instance
       """ruby
       RSpec.describe "allow_any_instance_of" do
         it 'yields the receiver to the block implementation' do
-          allow_any_instance_of(String).to receive(:slice) do |value, start, length|
-            value[start, length]
+          allow_any_instance_of(String).to receive(:slice) do |instance, start, length|
+            instance[start, length]
           end
 
           expect('string'.slice(2, 3)).to eq('rin')


### PR DESCRIPTION
Using the variable name `instance` keeps the general nature of the name, while making it more intuitive, due to proximity to the call `any_instance_of`.

See discussion (starting) at https://git.io/JUk98.