### PR TITLE
Drop Ruby < 2.3 support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+### Development (unreleased)
+
+Breaking Changes:
+
+* Ruby < 2.3 is no longer supported. (Phil Pirozhkov, #1349)
+
 ### 3.10.0 / 2020-10-30
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.9.1...v3.10.0)
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,10 +27,6 @@ if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
   gem 'rubocop', "~> 0.52.1"
 end
 
-if RUBY_VERSION <= '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
-  gem "childprocess", "< 1.0.0"
-end
-
 # Version 5.12 of minitest requires Ruby 2.4
 if RUBY_VERSION < '2.4.0'
   gem 'minitest', '< 5.12.0'

--- a/Gemfile
+++ b/Gemfile
@@ -12,19 +12,13 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
   end
 end
 
-if RUBY_VERSION < '1.9.3'
-  gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later
-elsif RUBY_VERSION < '2.0.0'
-  gem 'rake', '< 12.0.0' # rake 12 requires Ruby 2.0.0 or later
-else
-  gem 'rake', '> 12.3.2'
-end
-
 if ENV['DIFF_LCS_VERSION']
   gem 'diff-lcs', ENV['DIFF_LCS_VERSION']
 else
   gem 'diff-lcs', '~> 1.4', '>= 1.4.3'
 end
+
+gem 'ffi', '> 1.9.24' # prevent Github security vulnerability warning
 
 gem 'yard', '~> 0.9.24', :require => false
 
@@ -33,23 +27,8 @@ if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
   gem 'rubocop', "~> 0.52.1"
 end
 
-# allow gems to be installed on older rubies and/or windows
-if RUBY_VERSION < '2.2.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
-  gem 'ffi', '< 1.10'
-elsif RUBY_VERSION < '1.9'
-  gem 'ffi', '< 1.9.19' # ffi dropped Ruby 1.8 support in 1.9.19
-elsif RUBY_VERSION < '2.0'
-  gem 'ffi', '< 1.11.0' # ffi dropped Ruby 1.9 support in 1.11.0
-else
-  gem 'ffi', '> 1.9.24' # prevent Github security vulnerability warning
-end
-
 if RUBY_VERSION <= '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
   gem "childprocess", "< 1.0.0"
-end
-
-if RUBY_VERSION < '1.9.2'
-  gem 'contracts', '~> 0.15.0' # is a dependency of aruba
 end
 
 # Version 5.12 of minitest requires Ruby 2.4
@@ -65,21 +44,6 @@ end
 
 gem 'simplecov', '~> 0.8'
 
-if RUBY_VERSION < '2.0.0' || RUBY_ENGINE == 'java'
-  gem 'json', '< 2.0.0' # this is a dependency of simplecov
-else
-  gem 'json', '> 2.3.0'
-end
-
-platforms :jruby do
-  if RUBY_VERSION < '1.9.0'
-    # Pin jruby-openssl on older J Ruby
-    gem "jruby-openssl", "< 0.10.0"
-    # Pin child-process on older J Ruby
-    gem "childprocess", "< 1.0.0"
-  else
-    gem "jruby-openssl"
-  end
-end
+gem "jruby-openssl", platforms: [:jruby]
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,4 @@ gem 'simplecov', '~> 0.8'
 
 gem "jruby-openssl", platforms: [:jruby]
 
-eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')
+eval_gemfile 'Gemfile-custom' if File.exist?('Gemfile-custom')

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ else
   gem 'diff-lcs', '~> 1.4', '>= 1.4.3'
 end
 
-gem 'ffi', '> 1.9.24' # prevent Github security vulnerability warning
+gem 'ffi', '~> 1.12.0'
 
 gem 'yard', '~> 0.9.24', :require => false
 

--- a/Gemfile-custom.sample
+++ b/Gemfile-custom.sample
@@ -3,17 +3,10 @@ group :development do
   gem 'relish', '~> 0.6.0'
   gem 'guard-rspec', '~> 1.2.1'
   gem 'growl', '1.0.3'
-  gem 'spork', '0.9.0'
 
   platform :mri do
     gem 'rb-fsevent', '~> 0.9.0'
     gem 'ruby-prof', '~> 0.10.0'
-
-    case RUBY_VERSION
-    when /^1.8/
-      gem 'ruby-debug'
-    when /^1.9/
-      gem 'debugger'
-    end
+    gem 'pry-byebug'
   end
 end

--- a/lib/rspec/mocks.rb
+++ b/lib/rspec/mocks.rb
@@ -1,7 +1,6 @@
 require 'rspec/support'
 RSpec::Support.require_rspec_support 'caller_filter'
 RSpec::Support.require_rspec_support 'warnings'
-RSpec::Support.require_rspec_support 'ruby_features'
 
 RSpec::Support.define_optimized_require_for_rspec(:mocks) { |f| require_relative f }
 

--- a/lib/rspec/mocks/any_instance/proxy.rb
+++ b/lib/rspec/mocks/any_instance/proxy.rb
@@ -96,14 +96,8 @@ module RSpec
           @targets = targets
         end
 
-        if RUBY_VERSION.to_f > 1.8
-          def respond_to_missing?(method_name, include_private=false)
-            super || @targets.first.respond_to?(method_name, include_private)
-          end
-        else
-          def respond_to?(method_name, include_private=false)
-            super || @targets.first.respond_to?(method_name, include_private)
-          end
+        def respond_to_missing?(method_name, include_private=false)
+          super || @targets.first.respond_to?(method_name, include_private)
         end
 
         def method_missing(*args, &block)

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -257,6 +257,7 @@ module RSpec
           @observed_methods << method_name
           backup_method!(method_name)
           recorder = self
+          # In Ruby 2.4 and earlier, `define_method` is private
           @klass.__send__(:define_method, method_name) do |*args, &blk|
             recorder.playback!(self, method_name)
             __send__(method_name, *args, &blk)

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -275,18 +275,12 @@ module RSpec
           end
         end
 
-        if Support::RubyFeatures.module_prepends_supported?
-          def allow_no_prepended_module_definition_of(method_name)
-            prepended_modules = RSpec::Mocks::Proxy.prepended_modules_of(@klass)
-            problem_mod = prepended_modules.find { |mod| mod.method_defined?(method_name) }
-            return unless problem_mod
+        def allow_no_prepended_module_definition_of(method_name)
+          prepended_modules = RSpec::Mocks::Proxy.prepended_modules_of(@klass)
+          problem_mod = prepended_modules.find { |mod| mod.method_defined?(method_name) }
+          return unless problem_mod
 
-            AnyInstance.error_generator.raise_not_supported_with_prepend_error(method_name, problem_mod)
-          end
-        else
-          def allow_no_prepended_module_definition_of(_method_name)
-            # nothing to do; prepends aren't supported on this version of ruby
-          end
+          AnyInstance.error_generator.raise_not_supported_with_prepend_error(method_name, problem_mod)
         end
       end
     end

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -266,6 +266,7 @@ module RSpec
         def mark_invoked!(method_name)
           backup_method!(method_name)
           recorder = self
+          # In Ruby 2.4 and earlier, `define_method` is private
           @klass.__send__(:define_method, method_name) do |*_args, &_blk|
             invoked_instance = recorder.instance_that_received(method_name)
             inspect = "#<#{self.class}:#{object_id} #{instance_variables.map { |name| "#{name}=#{instance_variable_get name}" }.join(', ')}>"

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -200,24 +200,17 @@ module RSpec
             remove_method method_name
 
             # A @klass can have methods implemented (see Method#owner) in @klass
-            # or inherited from a superclass. In ruby 2.2 and earlier, we can copy
-            # a method regardless of the 'owner' and restore it to @klass after
-            # because a call to 'super' from @klass's copied method would end up
-            # calling the original class's superclass's method.
+            # or inherited from a superclass.
             #
-            # With the commit below, available starting in 2.3.0, ruby changed
-            # this behavior and a call to 'super' from the method copied to @klass
+            # A call to 'super' from the method copied to @klass
             # will call @klass's superclass method, which is the original
             # implementer of this method!  This leads to very strange errors
             # if @klass's copied method calls 'super', since it would end up
             # calling itself, the original method implemented in @klass's
             # superclass.
             #
-            # For ruby 2.3 and above, we need to only restore methods that
-            # @klass originally owned.
-            #
-            # https://github.com/ruby/ruby/commit/c8854d2ca4be9ee6946e6d17b0e17d9ef130ee81
-            if RUBY_VERSION < "2.3" || backed_up_method_owner[method_name.to_sym] == self
+            # We need to only restore methods that @klass originally owned.
+            if backed_up_method_owner[method_name.to_sym] == self
               alias_method method_name, alias_method_name
             end
             remove_method alias_method_name

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -1,4 +1,5 @@
 RSpec::Support.require_rspec_support "object_formatter"
+RSpec::Support.require_rspec_support 'ruby_features'
 
 module RSpec
   module Mocks

--- a/lib/rspec/mocks/instance_method_stasher.rb
+++ b/lib/rspec/mocks/instance_method_stasher.rb
@@ -5,6 +5,8 @@ module RSpec
       def initialize(object, method)
         @object = object
         @method = method
+        # We don't want to create singleton class if it doesn't exist,
+        # so we don't use `object.singleton_class`.
         @klass = (class << object; self; end)
 
         @original_method = nil
@@ -21,6 +23,7 @@ module RSpec
       def stash
         return unless method_defined_directly_on_klass?
         @original_method ||= ::RSpec::Support.method_handle_for(@object, @method)
+        # In Ruby 2.4 and earlier, `undef_method` is private
         @klass.__send__(:undef_method, @method)
       end
 
@@ -28,11 +31,13 @@ module RSpec
       def restore
         return unless @original_method
 
-        if @klass.__send__(:method_defined?, @method)
+        if @klass.method_defined?(@method)
+          # In Ruby 2.4 and earlier, `undef_method` is private
           @klass.__send__(:undef_method, @method)
         end
 
         handle_restoration_failures do
+          # In Ruby 2.4 and earlier, `define_method` is private
           @klass.__send__(:define_method, @method, @original_method)
         end
 

--- a/lib/rspec/mocks/instance_method_stasher.rb
+++ b/lib/rspec/mocks/instance_method_stasher.rb
@@ -36,17 +36,10 @@ module RSpec
           @klass.__send__(:undef_method, @method)
         end
 
-        handle_restoration_failures do
-          # In Ruby 2.4 and earlier, `define_method` is private
-          @klass.__send__(:define_method, @method, @original_method)
-        end
+        # In Ruby 2.4 and earlier, `define_method` is private
+        @klass.__send__(:define_method, @method, @original_method)
 
         @original_method = nil
-      end
-
-      def handle_restoration_failures
-        # No known reasons for restoration to fail on other rubies.
-        yield
       end
 
     private

--- a/lib/rspec/mocks/instance_method_stasher.rb
+++ b/lib/rspec/mocks/instance_method_stasher.rb
@@ -8,90 +8,40 @@ module RSpec
         @klass = (class << object; self; end)
 
         @original_method = nil
-        @method_is_stashed = false
       end
 
       attr_reader :original_method
 
-      if RUBY_VERSION.to_f < 1.9
-        # @private
-        def method_is_stashed?
-          @method_is_stashed
-        end
+      # @private
+      def method_is_stashed?
+        !!@original_method
+      end
 
-        # @private
-        def stash
-          return if !method_defined_directly_on_klass? || @method_is_stashed
+      # @private
+      def stash
+        return unless method_defined_directly_on_klass?
+        @original_method ||= ::RSpec::Support.method_handle_for(@object, @method)
+        @klass.__send__(:undef_method, @method)
+      end
 
-          @klass.__send__(:alias_method, stashed_method_name, @method)
-          @method_is_stashed = true
-        end
+      # @private
+      def restore
+        return unless @original_method
 
-        # @private
-        def stashed_method_name
-          "obfuscated_by_rspec_mocks__#{@method}"
-        end
-
-        # @private
-        def restore
-          return unless @method_is_stashed
-
-          if @klass.__send__(:method_defined?, @method)
-            @klass.__send__(:undef_method, @method)
-          end
-          @klass.__send__(:alias_method, @method, stashed_method_name)
-          @klass.__send__(:remove_method, stashed_method_name)
-          @method_is_stashed = false
-        end
-      else
-
-        # @private
-        def method_is_stashed?
-          !!@original_method
-        end
-
-        # @private
-        def stash
-          return unless method_defined_directly_on_klass?
-          @original_method ||= ::RSpec::Support.method_handle_for(@object, @method)
+        if @klass.__send__(:method_defined?, @method)
           @klass.__send__(:undef_method, @method)
         end
 
-        # @private
-        def restore
-          return unless @original_method
-
-          if @klass.__send__(:method_defined?, @method)
-            @klass.__send__(:undef_method, @method)
-          end
-
-          handle_restoration_failures do
-            @klass.__send__(:define_method, @method, @original_method)
-          end
-
-          @original_method = nil
+        handle_restoration_failures do
+          @klass.__send__(:define_method, @method, @original_method)
         end
+
+        @original_method = nil
       end
 
-      if RUBY_DESCRIPTION.include?('2.0.0p247') || RUBY_DESCRIPTION.include?('2.0.0p195')
-        # ruby 2.0.0-p247 and 2.0.0-p195 both have a bug that we can't work around :(.
-        # https://bugs.ruby-lang.org/issues/8686
-        def handle_restoration_failures
-          yield
-        rescue TypeError
-          RSpec.warn_with(
-            "RSpec failed to properly restore a partial double (#{@object.inspect}) " \
-            "to its original state due to a known bug in MRI 2.0.0-p195 & p247 " \
-            "(https://bugs.ruby-lang.org/issues/8686). This object may remain " \
-            "screwed up for the rest of this process. Please upgrade to 2.0.0-p353 or above.",
-            :call_site => nil, :use_spec_location_as_call_site => true
-          )
-        end
-      else
-        def handle_restoration_failures
-          # No known reasons for restoration to fail on other rubies.
-          yield
-        end
+      def handle_restoration_failures
+        # No known reasons for restoration to fail on other rubies.
+        yield
       end
 
     private
@@ -109,36 +59,11 @@ module RSpec
       def method_owned_by_klass?
         owner = @klass.instance_method(@method).owner
 
-        # On Ruby 2.0.0+ the owner of a method on a class which has been
+        # The owner of a method on a class which has been
         # `prepend`ed may actually be an instance, e.g.
         # `#<MyClass:0x007fbb94e3cd10>`, rather than the expected `MyClass`.
         owner = owner.class unless Module === owner
 
-        # On some 1.9s (e.g. rubinius) aliased methods
-        # can report the wrong owner. Example:
-        # class MyClass
-        #   class << self
-        #     alias alternate_new new
-        #   end
-        # end
-        #
-        # MyClass.owner(:alternate_new) returns `Class` when incorrect,
-        # but we need to consider the owner to be `MyClass` because
-        # it is not actually available on `Class` but is on `MyClass`.
-        # Hence, we verify that the owner actually has the method defined.
-        # If the given owner does not have the method defined, we assume
-        # that the method is actually owned by @klass.
-        #
-        # On 1.8, aliased methods can also report the wrong owner. Example:
-        # module M
-        #   def a; end
-        #   module_function :a
-        #   alias b a
-        #   module_function :b
-        # end
-        # The owner of M.b is the raw Module object, instead of the expected
-        # singleton class of the module
-        return true if RUBY_VERSION < '1.9' && owner == @object
         owner == @klass || !(method_defined_on_klass?(owner))
       end
     end

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -1,4 +1,4 @@
-RSpec::Support.require_rspec_support 'mutex'
+RSpec::Support.require_rspec_support 'reentrant_mutex'
 
 module RSpec
   module Mocks

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -258,11 +258,7 @@ module RSpec
         #
         # Note: we could avoid rescuing this by checking
         # `definition_target.instance_method(@method_name).owner == definition_target`,
-        # saving us from the cost of the expensive exception, but this error is
-        # extremely rare (it was discovered on 2014-12-30, only happens on
-        # RUBY_VERSION < 2.0 and our spec suite only hits this condition once),
-        # so we'd rather avoid the cost of that check for every method double,
-        # and risk the rare situation where this exception will get raised.
+        # but this error is extremely rare, so we'd rather rescue this exception.
         RSpec.warn_with(
           "WARNING: RSpec could not fully restore #{@object.inspect}." \
           "#{@method_name}, possibly because the method has been redefined " \

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -259,7 +259,12 @@ module RSpec
         #
         # Note: we could avoid rescuing this by checking
         # `definition_target.instance_method(@method_name).owner == definition_target`,
-        # but this error is extremely rare, so we'd rather rescue this exception.
+        # saving us from the cost of the expensive exception, but this error is
+        # extremely rare so we'd rather avoid the cost of that check for every
+        # method double, and risk the rare situation where this exception will
+        # get raised. This was originally discovered in the core library of older
+        # unsupported Rubies, (< 2.0) but could happen in code under test
+        # during meta-programming.
         RSpec.warn_with(
           "WARNING: RSpec could not fully restore #{@object.inspect}." \
           "#{@method_name}, possibly because the method has been redefined " \

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -208,7 +208,7 @@ module RSpec
 
       private
 
-      # In Ruby 2.0.0 and above prepend will alter the method lookup chain.
+      # Prepend alters the method lookup chain.
       # We use an object's singleton class to define method doubles upon,
       # however if the object has had its singleton class (as opposed to
       # its actual class) prepended too then the the method lookup chain
@@ -218,7 +218,6 @@ module RSpec
       # This code works around that by providing a mock definition target
       # that is either the singleton class, or if necessary, a prepended module
       # of our own.
-      #
 
       # We subclass `Module` in order to be able to easily detect our prepended module.
       RSpecPrependedModule = Class.new(Module)

--- a/lib/rspec/mocks/method_reference.rb
+++ b/lib/rspec/mocks/method_reference.rb
@@ -124,20 +124,8 @@ module RSpec
       # definition of "implemented". However, it's the best we can do.
       alias method_defined? method_implemented?
 
-      # works around the fact that repeated calls for method parameters will
-      # falsely return empty arrays on JRuby in certain circumstances, this
-      # is necessary here because we can't dup/clone UnboundMethods.
-      #
-      # This is necessary due to a bug in JRuby prior to 1.7.5 fixed in:
-      # https://github.com/jruby/jruby/commit/99a0613fe29935150d76a9a1ee4cf2b4f63f4a27
-      if RUBY_PLATFORM == 'java' && RSpec::Support::ComparableVersion.new(JRUBY_VERSION) < '1.7.5'
-        def find_method(mod)
-          mod.dup.instance_method(@method_name)
-        end
-      else
-        def find_method(mod)
-          mod.instance_method(@method_name)
-        end
+      def find_method(mod)
+        mod.instance_method(@method_name)
       end
 
       def visibility_from(mod)

--- a/lib/rspec/mocks/method_reference.rb
+++ b/lib/rspec/mocks/method_reference.rb
@@ -1,5 +1,3 @@
-RSpec::Support.require_rspec_support 'comparable_version'
-
 module RSpec
   module Mocks
     # Represents a method on an object that may or may not be defined.

--- a/lib/rspec/mocks/method_reference.rb
+++ b/lib/rspec/mocks/method_reference.rb
@@ -150,6 +150,8 @@ module RSpec
       end
 
       def method_defined?(object)
+        # We don't want to create singleton class if it doesn't exist,
+        # so we don't use `object.singleton_class`.
         (class << object; self; end).method_defined?(@method_name)
       end
 

--- a/lib/rspec/mocks/minitest_integration.rb
+++ b/lib/rspec/mocks/minitest_integration.rb
@@ -28,7 +28,7 @@ module RSpec
   end
 end
 
-Minitest::Test.send(:include, RSpec::Mocks::MinitestIntegration)
+Minitest::Test.include(RSpec::Mocks::MinitestIntegration)
 
 if defined?(::Minitest::Expectation)
   if defined?(::RSpec::Expectations) && ::Minitest::Expectation.method_defined?(:to)

--- a/lib/rspec/mocks/mutate_const.rb
+++ b/lib/rspec/mocks/mutate_const.rb
@@ -248,7 +248,6 @@ module RSpec
           end
 
           if Array === @transfer_nested_constants
-            @transfer_nested_constants = @transfer_nested_constants.map(&:to_s) if RUBY_VERSION == '1.8.7'
             undefined_constants = @transfer_nested_constants - constants_defined_on(@original_value)
 
             if undefined_constants.any?

--- a/lib/rspec/mocks/object_reference.rb
+++ b/lib/rspec/mocks/object_reference.rb
@@ -27,14 +27,8 @@ module RSpec
         end
       end
 
-      if Module.new.name.nil?
-        def self.anonymous_module?(mod)
-          !name_of(mod)
-        end
-      else # 1.8.7
-        def self.anonymous_module?(mod)
-          name_of(mod) == ""
-        end
+      def self.anonymous_module?(mod)
+        !name_of(mod)
       end
       private_class_method :anonymous_module?
 

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -231,20 +231,18 @@ module RSpec
         :public
       end
 
-      if Support::RubyFeatures.module_prepends_supported?
-        def self.prepended_modules_of(klass)
-          ancestors = klass.ancestors
+      def self.prepended_modules_of(klass)
+        ancestors = klass.ancestors
 
-          # `|| 0` is necessary for Ruby 2.0, where the singleton class
-          # is only in the ancestor list when there are prepended modules.
-          singleton_index = ancestors.index(klass) || 0
+        # `|| 0` is necessary for Ruby 2.0, where the singleton class
+        # is only in the ancestor list when there are prepended modules.
+        singleton_index = ancestors.index(klass) || 0
 
-          ancestors[0, singleton_index]
-        end
+        ancestors[0, singleton_index]
+      end
 
-        def prepended_modules_of_singleton_class
-          @prepended_modules_of_singleton_class ||= RSpec::Mocks::Proxy.prepended_modules_of(@object.singleton_class)
-        end
+      def prepended_modules_of_singleton_class
+        @prepended_modules_of_singleton_class ||= RSpec::Mocks::Proxy.prepended_modules_of(@object.singleton_class)
       end
 
       # @private

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -1,3 +1,5 @@
+RSpec::Support.require_rspec_support "reentrant_mutex"
+
 module RSpec
   module Mocks
     # @private
@@ -7,11 +9,6 @@ module RSpec
         def ==(expectation)
           expectation.orig_object == object && expectation.matches?(message, *args)
         end
-      end
-
-      unless defined?(Mutex)
-        Support.require_rspec_support 'mutex'
-        Mutex = Support::Mutex
       end
 
       # @private
@@ -25,7 +22,7 @@ module RSpec
         @order_group = order_group
         @error_generator = ErrorGenerator.new(object)
         @messages_received = []
-        @messages_received_mutex = Mutex.new
+        @messages_received_mutex = Support::Mutex.new
         @options = options
         @null_object = false
         @method_doubles = Hash.new { |h, k| h[k] = MethodDouble.new(@object, k, self) }

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -233,11 +233,7 @@ module RSpec
 
       def self.prepended_modules_of(klass)
         ancestors = klass.ancestors
-
-        # `|| 0` is necessary for Ruby 2.0, where the singleton class
-        # is only in the ancestor list when there are prepended modules.
-        singleton_index = ancestors.index(klass) || 0
-
+        singleton_index = ancestors.index(klass)
         ancestors[0, singleton_index]
       end
 

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -393,19 +393,6 @@ module RSpec
 
         return super unless unbound_method
         unbound_method.bind(object)
-        # :nocov:
-      rescue TypeError
-        if RUBY_VERSION == '1.8.7'
-          # In MRI 1.8.7, a singleton method on a class cannot be rebound to its subclass
-          if unbound_method && unbound_method.owner.ancestors.first != unbound_method.owner
-            # This is a singleton method; we can't do anything with it
-            # But we can work around this using a different implementation
-            double = method_double_from_ancestor_for(message)
-            return object.method(double.method_stasher.stashed_method_name)
-          end
-        end
-        raise
-        # :nocov:
       end
 
     protected

--- a/lib/rspec/mocks/space.rb
+++ b/lib/rspec/mocks/space.rb
@@ -137,6 +137,8 @@ module RSpec
 
         # We access the ancestors through the singleton class, to avoid calling
         # `class` in case `class` has been stubbed.
+        # We can't use `object.singleton_class` here, as this method creates
+        # a new singleton class for the object if the object doesn't have one.
         (class << object; ancestors; end).map do |klass|
           any_instance_recorders[klass.__id__]
         end.compact

--- a/lib/rspec/mocks/space.rb
+++ b/lib/rspec/mocks/space.rb
@@ -185,23 +185,8 @@ module RSpec
         any_instance_recorders[id] = AnyInstance::Recorder.new(klass)
       end
 
-      if defined?(::BasicObject) && !::BasicObject.method_defined?(:__id__) # for 1.9.2
-        require 'securerandom'
-
-        def id_for(object)
-          id = object.__id__
-
-          return id if object.equal?(::ObjectSpace._id2ref(id))
-          # this suggests that object.__id__ is proxying through to some wrapped object
-
-          object.instance_exec do
-            @__id_for_rspec_mocks_space ||= ::SecureRandom.uuid
-          end
-        end
-      else
-        def id_for(object)
-          object.__id__
-        end
+      def id_for(object)
+        object.__id__
       end
     end
 

--- a/lib/rspec/mocks/syntax.rb
+++ b/lib/rspec/mocks/syntax.rb
@@ -179,20 +179,6 @@ module RSpec
       # @api private
       # Determines where the methods like `should_receive`, and `stub` are added.
       def self.default_should_syntax_host
-        # JRuby 1.7.4 introduces a regression whereby `defined?(::BasicObject) => nil`
-        # yet `BasicObject` still exists and patching onto ::Object breaks things
-        # e.g. SimpleDelegator expectations won't work
-        #
-        # See: https://github.com/jruby/jruby/issues/814
-        if defined?(JRUBY_VERSION) && JRUBY_VERSION == '1.7.4' && RUBY_VERSION.to_f > 1.8
-          return ::BasicObject
-        end
-
-        # On 1.8.7, Object.ancestors.last == Kernel but
-        # things blow up if we include `RSpec::Mocks::Methods`
-        # into Kernel...not sure why.
-        return Object unless defined?(::BasicObject)
-
         # MacRuby has BasicObject but it's not the root class.
         return Object unless Object.ancestors.last == ::BasicObject
 

--- a/lib/rspec/mocks/syntax.rb
+++ b/lib/rspec/mocks/syntax.rb
@@ -23,8 +23,8 @@ module RSpec
 
       # @api private
       # Enables the should syntax (`dbl.stub`, `dbl.should_receive`, etc).
-      def self.enable_should(syntax_host=default_should_syntax_host)
-        @warn_about_should = false if syntax_host == default_should_syntax_host
+      def self.enable_should(syntax_host=::BasicObject)
+        @warn_about_should = false if syntax_host == ::BasicObject
         return if should_enabled?(syntax_host)
 
         syntax_host.class_exec do
@@ -86,7 +86,7 @@ module RSpec
 
       # @api private
       # Disables the should syntax (`dbl.stub`, `dbl.should_receive`, etc).
-      def self.disable_should(syntax_host=default_should_syntax_host)
+      def self.disable_should(syntax_host=::BasicObject)
         return unless should_enabled?(syntax_host)
 
         syntax_host.class_exec do
@@ -166,7 +166,7 @@ module RSpec
 
       # @api private
       # Indicates whether or not the should syntax is enabled.
-      def self.should_enabled?(syntax_host=default_should_syntax_host)
+      def self.should_enabled?(syntax_host=::BasicObject)
         syntax_host.method_defined?(:should_receive)
       end
 
@@ -175,109 +175,98 @@ module RSpec
       def self.expect_enabled?(syntax_host=::RSpec::Mocks::ExampleMethods)
         syntax_host.method_defined?(:allow)
       end
-
-      # @api private
-      # Determines where the methods like `should_receive`, and `stub` are added.
-      def self.default_should_syntax_host
-        # MacRuby has BasicObject but it's not the root class.
-        return Object unless Object.ancestors.last == ::BasicObject
-
-        ::BasicObject
-      end
     end
   end
 end
 
-if defined?(BasicObject)
-  # The legacy `:should` syntax adds the following methods directly to
-  # `BasicObject` so that they are available off of any object. Note, however,
-  # that this syntax does not always play nice with delegate/proxy objects.
-  # We recommend you use the non-monkeypatching `:expect` syntax instead.
-  # @see Class
-  class BasicObject
-    # @method should_receive
-    # Sets an expectation that this object should receive a message before
-    # the end of the example.
-    #
-    # @example
-    #   logger = double('logger')
-    #   thing_that_logs = ThingThatLogs.new(logger)
-    #   logger.should_receive(:log)
-    #   thing_that_logs.do_something_that_logs_a_message
-    #
-    # @note This is only available when you have enabled the `should` syntax.
-    # @see RSpec::Mocks::ExampleMethods#expect
+# The legacy `:should` syntax adds the following methods directly to
+# `BasicObject` so that they are available off of any object. Note, however,
+# that this syntax does not always play nice with delegate/proxy objects.
+# We recommend you use the non-monkeypatching `:expect` syntax instead.
+# @see Class
+class BasicObject
+  # @method should_receive
+  # Sets an expectation that this object should receive a message before
+  # the end of the example.
+  #
+  # @example
+  #   logger = double('logger')
+  #   thing_that_logs = ThingThatLogs.new(logger)
+  #   logger.should_receive(:log)
+  #   thing_that_logs.do_something_that_logs_a_message
+  #
+  # @note This is only available when you have enabled the `should` syntax.
+  # @see RSpec::Mocks::ExampleMethods#expect
 
-    # @method should_not_receive
-    # Sets and expectation that this object should _not_ receive a message
-    # during this example.
-    # @see RSpec::Mocks::ExampleMethods#expect
+  # @method should_not_receive
+  # Sets and expectation that this object should _not_ receive a message
+  # during this example.
+  # @see RSpec::Mocks::ExampleMethods#expect
 
-    # @method stub
-    # Tells the object to respond to the message with the specified value.
-    #
-    # @example
-    #   counter.stub(:count).and_return(37)
-    #   counter.stub(:count => 37)
-    #   counter.stub(:count) { 37 }
-    #
-    # @note This is only available when you have enabled the `should` syntax.
-    # @see RSpec::Mocks::ExampleMethods#allow
+  # @method stub
+  # Tells the object to respond to the message with the specified value.
+  #
+  # @example
+  #   counter.stub(:count).and_return(37)
+  #   counter.stub(:count => 37)
+  #   counter.stub(:count) { 37 }
+  #
+  # @note This is only available when you have enabled the `should` syntax.
+  # @see RSpec::Mocks::ExampleMethods#allow
 
-    # @method unstub
-    # Removes a stub. On a double, the object will no longer respond to
-    # `message`. On a real object, the original method (if it exists) is
-    # restored.
-    #
-    # This is rarely used, but can be useful when a stub is set up during a
-    # shared `before` hook for the common case, but you want to replace it
-    # for a special case.
-    #
-    # @note This is only available when you have enabled the `should` syntax.
+  # @method unstub
+  # Removes a stub. On a double, the object will no longer respond to
+  # `message`. On a real object, the original method (if it exists) is
+  # restored.
+  #
+  # This is rarely used, but can be useful when a stub is set up during a
+  # shared `before` hook for the common case, but you want to replace it
+  # for a special case.
+  #
+  # @note This is only available when you have enabled the `should` syntax.
 
-    # @method stub_chain
-    # @overload stub_chain(method1, method2)
-    # @overload stub_chain("method1.method2")
-    # @overload stub_chain(method1, method_to_value_hash)
-    #
-    # Stubs a chain of methods.
-    #
-    # ## Warning:
-    #
-    # Chains can be arbitrarily long, which makes it quite painless to
-    # violate the Law of Demeter in violent ways, so you should consider any
-    # use of `stub_chain` a code smell. Even though not all code smells
-    # indicate real problems (think fluent interfaces), `stub_chain` still
-    # results in brittle examples.  For example, if you write
-    # `foo.stub_chain(:bar, :baz => 37)` in a spec and then the
-    # implementation calls `foo.baz.bar`, the stub will not work.
-    #
-    # @example
-    #   double.stub_chain("foo.bar") { :baz }
-    #   double.stub_chain(:foo, :bar => :baz)
-    #   double.stub_chain(:foo, :bar) { :baz }
-    #
-    #     # Given any of ^^ these three forms ^^:
-    #     double.foo.bar # => :baz
-    #
-    #     # Common use in Rails/ActiveRecord:
-    #     Article.stub_chain("recent.published") { [Article.new] }
-    #
-    # @note This is only available when you have enabled the `should` syntax.
-    # @see RSpec::Mocks::ExampleMethods#receive_message_chain
+  # @method stub_chain
+  # @overload stub_chain(method1, method2)
+  # @overload stub_chain("method1.method2")
+  # @overload stub_chain(method1, method_to_value_hash)
+  #
+  # Stubs a chain of methods.
+  #
+  # ## Warning:
+  #
+  # Chains can be arbitrarily long, which makes it quite painless to
+  # violate the Law of Demeter in violent ways, so you should consider any
+  # use of `stub_chain` a code smell. Even though not all code smells
+  # indicate real problems (think fluent interfaces), `stub_chain` still
+  # results in brittle examples.  For example, if you write
+  # `foo.stub_chain(:bar, :baz => 37)` in a spec and then the
+  # implementation calls `foo.baz.bar`, the stub will not work.
+  #
+  # @example
+  #   double.stub_chain("foo.bar") { :baz }
+  #   double.stub_chain(:foo, :bar => :baz)
+  #   double.stub_chain(:foo, :bar) { :baz }
+  #
+  #     # Given any of ^^ these three forms ^^:
+  #     double.foo.bar # => :baz
+  #
+  #     # Common use in Rails/ActiveRecord:
+  #     Article.stub_chain("recent.published") { [Article.new] }
+  #
+  # @note This is only available when you have enabled the `should` syntax.
+  # @see RSpec::Mocks::ExampleMethods#receive_message_chain
 
-    # @method as_null_object
-    # Tells the object to respond to all messages. If specific stub values
-    # are declared, they'll work as expected. If not, the receiver is
-    # returned.
-    #
-    # @note This is only available when you have enabled the `should` syntax.
+  # @method as_null_object
+  # Tells the object to respond to all messages. If specific stub values
+  # are declared, they'll work as expected. If not, the receiver is
+  # returned.
+  #
+  # @note This is only available when you have enabled the `should` syntax.
 
-    # @method null_object?
-    # Returns true if this object has received `as_null_object`
-    #
-    # @note This is only available when you have enabled the `should` syntax.
-  end
+  # @method null_object?
+  # Returns true if this object has received `as_null_object`
+  #
+  # @note This is only available when you have enabled the `should` syntax.
 end
 
 # The legacy `:should` syntax adds the `any_instance` to `Class`.

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -84,13 +84,16 @@ module RSpec
           end
         end
 
+        visibility = proxy.visibility_for(message)
+
         # Defined private and protected methods will still trigger `method_missing`
         # when called publicly. We want ruby's method visibility error to get raised,
         # so we simply delegate to `super` in that case.
+        #   return super if visibility == :private || visibility == :protected
         # ...well, we would delegate to `super`, but there's a JRuby
         # bug, so we raise our own visibility error instead:
         # https://github.com/jruby/jruby/issues/1398
-        visibility = proxy.visibility_for(message)
+        # Only works without this workaround with JRuby 9.2
         if visibility == :private || visibility == :protected
           ErrorGenerator.new(self).raise_non_public_error(
             message, visibility

--- a/lib/rspec/mocks/test_double.rb
+++ b/lib/rspec/mocks/test_double.rb
@@ -97,8 +97,7 @@ module RSpec
           )
         end
 
-        # Required wrapping doubles in an Array on Ruby 1.9.2
-        raise NoMethodError if [:to_a, :to_ary].include? message
+        raise NoMethodError if message == :to_ary || message == :to_a
         proxy.raise_unexpected_message_error(message, args)
       end
 

--- a/lib/rspec/mocks/verifying_double.rb
+++ b/lib/rspec/mocks/verifying_double.rb
@@ -12,7 +12,7 @@ module RSpec
         case method_ref.visibility
         when :public    then true
         when :private   then include_private
-        when :protected then include_private || RUBY_VERSION.to_f < 2.0
+        when :protected then include_private
         else !method_ref.unimplemented?
         end
       end

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -147,13 +147,11 @@ module RSpec
       end
 
       def add_expectation(*args, &block)
-        # explict params necessary for 1.8.7 see #626
-        super(*args, &block).tap { |x| x.method_reference = @method_reference }
+        super.tap { |x| x.method_reference = @method_reference }
       end
 
       def add_stub(*args, &block)
-        # explict params necessary for 1.8.7 see #626
-        super(*args, &block).tap { |x| x.method_reference = @method_reference }
+        super.tap { |x| x.method_reference = @method_reference }
       end
 
       def proxy_method_invoked(obj, *args, &block)

--- a/rspec-mocks.gemspec
+++ b/rspec-mocks.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
 
-  s.add_development_dependency 'rake',     '> 10.0.0'
+  s.add_development_dependency 'rake',     '> 12.3.2'
   s.add_development_dependency 'cucumber', '~> 1.3.15'
   s.add_development_dependency 'aruba',    '~> 0.14.10'
   s.add_development_dependency 'minitest', '~> 5.2'

--- a/rspec-mocks.gemspec
+++ b/rspec-mocks.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_path     = "lib"
 
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 2.3.0'
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "and_call_original" do
         expect(instance.foo).to eq(:bar)
       end
 
-      it 'works for SimpleDelegator subclasses', :if => (RUBY_VERSION.to_f > 1.8) do
+      it 'works for SimpleDelegator subclasses' do
         inst = Class.new(SimpleDelegator).new(1)
         def inst.foo; :bar; end
         expect(inst).to receive(:foo).and_call_original

--- a/spec/rspec/mocks/and_yield_spec.rb
+++ b/spec/rspec/mocks/and_yield_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe RSpec::Mocks::Double do
           verify yielded_arg
         end
 
-        context "that are optional", :if => RSpec::Support::RubyFeatures.optional_and_splat_args_supported? do
+        context "that are optional" do
           it "yields the default argument when the argument is not given" do
             pending "Not sure how to achieve this yet. See rspec/rspec-mocks#714 and rspec/rspec-support#85."
             default_arg = Object.new

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -770,7 +770,7 @@ module RSpec
           end
         end
 
-        it 'works with a BasicObject subclass that mixes in Kernel', :if => defined?(BasicObject) do
+        it 'works with a BasicObject subclass that mixes in Kernel' do
           klazz = Class.new(BasicObject) do
             include ::Kernel
             def foo; end

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -168,7 +168,7 @@ module RSpec
           end
         end
 
-        context "when the class has a prepended module", :if => Support::RubyFeatures.module_prepends_supported? do
+        context "when the class has a prepended module" do
           it 'allows stubbing a method that is not defined on the prepended module' do
             klass.class_eval { prepend Module.new { def other; end } }
             allow_any_instance_of(klass).to receive(:foo).and_return(45)
@@ -582,7 +582,7 @@ module RSpec
           expect(object.foo).to eq(3)
         end
 
-        context "when the class has a prepended module", :if => Support::RubyFeatures.module_prepends_supported? do
+        context "when the class has a prepended module" do
           it 'allows mocking a method that is not defined on the prepended module' do
             klass.class_eval { prepend Module.new { def other; end } }
             expect_any_instance_of(klass).to receive(:foo).and_return(45)

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -780,7 +780,7 @@ module RSpec
           klazz.new.foo
         end
 
-        it 'works with a SimpleDelegator subclass', :if => (RUBY_VERSION.to_f > 1.8) do
+        it 'works with a SimpleDelegator subclass' do
           klazz = Class.new(SimpleDelegator) do
             def foo; end
           end

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -1239,8 +1239,6 @@ module RSpec
 
       context 'when used in conjunction with a `dup`' do
         it "doesn't cause an infinite loop" do
-          skip "This intermittently fails on JRuby" if RUBY_PLATFORM == 'java'
-
           allow_any_instance_of(Object).to receive(:some_method)
           o = Object.new
           o.some_method

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -306,9 +306,7 @@ module RSpec
 
         it "matches against a Matcher", :reset => true do
           expect(a_double).to receive(:msg).with(equal(3))
-          # This spec is generating warnings on 1.8.7, not sure why so
-          # this does with_isolated_stderr to kill them. @samphippen 3rd Jan 2013.
-          expect { with_isolated_stderr { a_double.msg(37) } }.to fail_including "expected: (equal 3)"
+          expect { a_double.msg(37) }.to fail_including "expected: (equal 3)"
         end
 
         it "fails when given an arbitrary object that returns false from #===", :reset => true do

--- a/spec/rspec/mocks/block_return_value_spec.rb
+++ b/spec/rspec/mocks/block_return_value_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe "a double declaration with a block handed to:" do
       expect(obj.foo).to eq('bar')
     end
 
-    # The "receives a block" part is important: 1.8.7 has a bug that reports the
-    # wrong arity when a block receives a block.
     it 'forwards all given args to the block, even when it receives a block' do
       obj = Object.new
       yielded_args = []

--- a/spec/rspec/mocks/configuration_spec.rb
+++ b/spec/rspec/mocks/configuration_spec.rb
@@ -64,7 +64,7 @@ module RSpec
           end
 
           it 'is a no-op when configured a second time' do
-            expect(Syntax.default_should_syntax_host).not_to receive(:method_undefined)
+            expect(::BasicObject).not_to receive(:method_undefined)
             expect(::RSpec::Mocks::ExampleMethods).not_to receive(:method_added)
             configure_syntax :expect
           end
@@ -95,7 +95,7 @@ module RSpec
           end
 
           it 'is a no-op when configured a second time' do
-            Syntax.default_should_syntax_host.should_not_receive(:method_added)
+            ::BasicObject.should_not_receive(:method_added)
             ::RSpec::Mocks::ExampleMethods.should_not_receive(:method_undefined)
             configure_syntax :should
           end

--- a/spec/rspec/mocks/diffing_spec.rb
+++ b/spec/rspec/mocks/diffing_spec.rb
@@ -83,19 +83,8 @@ RSpec.describe "Diffs printed when arguments don't match" do
       end
     end
 
-    if RUBY_VERSION.to_f < 1.9
-      # Ruby 1.8 hashes are not ordered, but `#inspect` on a particular unchanged
-      # hash instance should return consistent output. However, on Travis that does
-      # not always seem to be true and we have no idea why. Somehow, the travis build
-      # has occasionally failed due to the output ordering varying between `inspect`
-      # calls to the same hash. This regex allows us to work around that.
-      def hash_regex_inspect(hash)
-        "\\{(#{hash.map { |key, value| "#{key.inspect}=>#{value.inspect}.*" }.join "|"}){#{hash.size}}\\}"
-      end
-    else
-      def hash_regex_inspect(hash)
-        Regexp.escape(hash.inspect)
-      end
+    def hash_regex_inspect(hash)
+      Regexp.escape(hash.inspect)
     end
 
     it "prints a diff with array args" do

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -524,13 +524,11 @@ module RSpec
         }.to fail_with "#<Double \"test double\"> yielded |\"wha\", \"zup\"| to block with arity of 1"
       end
 
-      if kw_args_supported?
-        it 'fails when calling yielding method with invalid kw args' do
-          expect(@double).to receive(:yield_back).and_yield(:x => 1, :y => 2)
-          expect {
-            eval("@double.yield_back { |x: 1| }")
-          }.to fail_with '#<Double "test double"> yielded |{:x=>1, :y=>2}| to block with optional keyword args (:x)'
-        end
+      it 'fails when calling yielding method with invalid kw args' do
+        expect(@double).to receive(:yield_back).and_yield(:x => 1, :y => 2)
+        expect {
+          eval("@double.yield_back { |x: 1| }")
+        }.to fail_with '#<Double "test double"> yielded |{:x=>1, :y=>2}| to block with optional keyword args (:x)'
       end
 
       it "fails when calling yielding method consecutively with wrong arity" do

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -304,13 +304,7 @@ module RSpec
       end
 
       it "responds to to_a as a null object" do
-        if RUBY_VERSION.to_f > 1.8
-          expect(@double.as_null_object.to_a).to eq nil
-        else
-          with_isolated_stderr do
-            expect(@double.as_null_object.to_a).to eq [@double]
-          end
-        end
+        expect(@double.as_null_object.to_a).to eq nil
       end
 
       it "passes proc to expectation block without an argument" do
@@ -724,7 +718,7 @@ module RSpec
         end
       end
 
-      describe "#to_str", :unless => RUBY_VERSION == '1.9.2' do
+      describe "#to_str" do
         it "should not respond to #to_str to avoid being coerced to strings by the runtime" do
           dbl = double("Foo")
           expect { dbl.to_str }.to raise_error(

--- a/spec/rspec/mocks/instance_method_stasher_spec.rb
+++ b/spec/rspec/mocks/instance_method_stasher_spec.rb
@@ -55,7 +55,7 @@ module RSpec
         expect(obj.hello).to eql :overridden_hello
       end
 
-      it "does not unnecessarily create obfuscated aliased methods", :if => (RUBY_VERSION.to_f > 1.8) do
+      it "does not unnecessarily create obfuscated aliased methods" do
         obj = Object.new
         def obj.hello; :hello_defined_on_singleton_class; end;
 
@@ -64,7 +64,7 @@ module RSpec
         expect(obj.methods.grep(/rspec/)).to eq([])
       end
 
-      it "undefines the original method", :if => (RUBY_VERSION.to_f > 1.8) do
+      it "undefines the original method" do
         obj = Object.new
         def obj.hello; :hello_defined_on_singleton_class; end;
 

--- a/spec/rspec/mocks/null_object_double_spec.rb
+++ b/spec/rspec/mocks/null_object_double_spec.rb
@@ -15,13 +15,7 @@ module RSpec
       end
 
       it "raises an error when interpolated in a string as an integer" do
-        # Not sure why, but 1.9.2 (but not JRuby --1.9) raises a different
-        # error than 1.8.7 and 1.9.3...
-        expected_error = (RUBY_VERSION == '1.9.2' && RUBY_PLATFORM !~ /java/) ?
-                         RSpec::Mocks::MockExpectationError :
-                         TypeError
-
-        expect { "%i" % @double }.to raise_error(expected_error)
+        expect { "%i" % @double }.to raise_error(TypeError)
       end
     end
 

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -184,7 +184,7 @@ module RSpec
         yield
       end
 
-      it "allows `write` to be stubbed and reset", :unless => Support::Ruby.jruby? do
+      it "allows `write` to be stubbed and reset" do
         allow(file_1).to receive(:write)
         file_1.reopen(file_2)
         expect_output_warning_on_ruby_lt_2 { reset file_1 }
@@ -197,7 +197,7 @@ module RSpec
       end
     end
 
-    RSpec.describe "Using a partial mock on a proxy object", :if => defined?(::BasicObject) do
+    RSpec.describe "Using a partial mock on a proxy object" do
       let(:proxy_class) do
         Class.new(::BasicObject) do
           def initialize(target)

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -180,14 +180,10 @@ module RSpec
         file_2.close
       end
 
-      def expect_output_warning_on_ruby_lt_2
-        yield
-      end
-
       it "allows `write` to be stubbed and reset" do
         allow(file_1).to receive(:write)
         file_1.reopen(file_2)
-        expect_output_warning_on_ruby_lt_2 { reset file_1 }
+        reset file_1
 
         expect {
           # Writing to a file that's been reopened to a 2nd file writes to both files.

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -93,7 +93,6 @@ module RSpec
       end
 
       it 'allows a class and a subclass to both be stubbed' do
-        pending "Does not work on 1.8.7 due to singleton method restrictions" if RUBY_VERSION == "1.8.7" && RSpec::Support::Ruby.mri?
         the_klass = Class.new
         the_subklass = Class.new(the_klass)
 
@@ -182,13 +181,7 @@ module RSpec
       end
 
       def expect_output_warning_on_ruby_lt_2
-        if RUBY_VERSION >= '2.0'
-          yield
-        else
-          expect { yield }.to output(a_string_including(
-            "RSpec could not fully restore", file_1.inspect, "write"
-          )).to_stderr
-        end
+        yield
       end
 
       it "allows `write` to be stubbed and reset", :unless => Support::Ruby.jruby? do

--- a/spec/rspec/mocks/should_syntax_spec.rb
+++ b/spec/rspec/mocks/should_syntax_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe "Using the legacy should syntax" do
       expect { verify_all }.to fail
     end
 
-    it 'can get method objects for the fluent interface', :if => RUBY_VERSION.to_f > 1.8 do
+    it 'can get method objects for the fluent interface' do
       and_return = klass.any_instance.stub(:foo).method(:and_return)
       and_return.call(23)
 

--- a/spec/rspec/mocks/space_spec.rb
+++ b/spec/rspec/mocks/space_spec.rb
@@ -1,4 +1,3 @@
-
 module RSpec::Mocks
   RSpec.describe Space do
     let(:space) { Space.new }
@@ -19,7 +18,7 @@ module RSpec::Mocks
 
       def define_singleton_method_on_recorder_for(klass, name, &block)
         recorder = space.any_instance_recorder_for(klass)
-        (class << recorder; self; end).send(:define_method, name, &block)
+        recorder.singleton_class.send(:define_method, name, &block)
       end
 
       it 'verifies all any_instance recorders within' do
@@ -39,7 +38,7 @@ module RSpec::Mocks
       it 'does not reset the proxies (as that should be delayed until reset_all)' do
         proxy = space.proxy_for(dbl_1)
         reset = false
-        (class << proxy; self; end).__send__(:define_method, :reset) { reset = true }
+        proxy.singleton_class.__send__(:define_method, :reset) { reset = true }
 
         space.verify_all
         expect(reset).to eq(false)

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -115,7 +115,7 @@ module RSpec
 
       context "when the stubbed method is called" do
         it "does not call any methods on the passed args, since that could mutate them", :issue => 892 do
-          recorder = Class.new(defined?(::BasicObject) ? ::BasicObject : ::Object) do
+          recorder = Class.new(::BasicObject) do
             def called_methods
               @called_methods ||= []
             end

--- a/spec/rspec/mocks/syntax_spec.rb
+++ b/spec/rspec/mocks/syntax_spec.rb
@@ -1,7 +1,0 @@
-module RSpec
-  RSpec.describe Mocks do
-    it "does not inadvertently define BasicObject on 1.8", :if => RUBY_VERSION.to_f < 1.9 do
-      expect(defined?(::BasicObject)).to be nil
-    end
-  end
-end

--- a/spec/rspec/mocks/to_ary_spec.rb
+++ b/spec/rspec/mocks/to_ary_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "a double receiving to_ary" do
       expect(obj).not_to respond_to(:to_ary)
     end
 
-    it "doesn't respond to to_a", :if => (RUBY_VERSION.to_f > 1.8) do
+    it "doesn't respond to to_a" do
       expect(obj).not_to respond_to(:to_a)
     end
 

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_not_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_not_loaded_spec.rb
@@ -22,7 +22,7 @@ module RSpec
         expect(o.undefined_instance_method(:arg)).to eq(1)
       end
 
-      specify "trying to raise a class_double raises a TypeError", :unless => RUBY_VERSION == '1.9.2' do
+      specify "trying to raise a class_double raises a TypeError" do
         subject = Object.new
         class_double("StubbedError").as_stubbed_const
         allow(subject).to receive(:some_method).and_raise(StubbedError)

--- a/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
@@ -75,30 +75,26 @@ module RSpec
             }.to fail_with("Wrong number of arguments. Expected 2, got 0.")
           end
 
-          if RSpec::Support::RubyFeatures.required_kw_args_supported?
-            context "for a method with required keyword args" do
-              it 'covers the required args when `any_args` is last' do
-                expect {
-                  expect(dbl).to receive(:kw_args_method).with(1, any_args)
-                }.not_to raise_error
-              end
+          context "for a method with required keyword args" do
+            it 'covers the required args when `any_args` is last' do
+              expect {
+                expect(dbl).to receive(:kw_args_method).with(1, any_args)
+              }.not_to raise_error
+            end
 
-              it 'does not cover the required args when there are args after `any_args`' do
-                expect {
-                  # Use eval to avoid syntax error on 1.8 and 1.9
-                  eval("expect(dbl).to receive(:kw_args_method).with(any_args, optional_arg: 3)")
-                }.to fail_with("Missing required keyword arguments: required_arg")
-              end
+            it 'does not cover the required args when there are args after `any_args`' do
+              expect {
+                # Use eval to avoid syntax error on 1.8 and 1.9
+                eval("expect(dbl).to receive(:kw_args_method).with(any_args, optional_arg: 3)")
+              }.to fail_with("Missing required keyword arguments: required_arg")
             end
           end
         end
 
-        if RSpec::Support::RubyFeatures.required_kw_args_supported?
-          it 'does not cover required args when `any_args` is not used' do
-            expect {
-              expect(dbl).to receive(:kw_args_method).with(anything)
-            }.to fail_with("Missing required keyword arguments: required_arg")
-          end
+        it 'does not cover required args when `any_args` is not used' do
+          expect {
+            expect(dbl).to receive(:kw_args_method).with(anything)
+          }.to fail_with("Missing required keyword arguments: required_arg")
         end
 
         context "when a list of args is provided" do

--- a/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
@@ -84,8 +84,7 @@ module RSpec
 
             it 'does not cover the required args when there are args after `any_args`' do
               expect {
-                # Use eval to avoid syntax error on 1.8 and 1.9
-                eval("expect(dbl).to receive(:kw_args_method).with(any_args, optional_arg: 3)")
+                expect(dbl).to receive(:kw_args_method).with(any_args, optional_arg: 3)
               }.to fail_with("Missing required keyword arguments: required_arg")
             end
           end

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -83,60 +83,58 @@ module RSpec
         }.to raise_error(ArgumentError, "Wrong number of arguments. Expected 0, got 1.")
       end
 
-      if required_kw_args_supported?
-        it 'allows keyword arguments' do
-          o = instance_double('LoadedClass', :kw_args_method => true)
-          expect(o.kw_args_method(1, :required_arg => 'something')).to eq(true)
+      it 'allows keyword arguments' do
+        o = instance_double('LoadedClass', :kw_args_method => true)
+        expect(o.kw_args_method(1, :required_arg => 'something')).to eq(true)
+      end
+
+      context 'for a method that only accepts keyword args' do
+        it 'allows hash matchers like `hash_including` to be used in place of the keywords arg hash' do
+          o = instance_double('LoadedClass')
+          expect(o).to receive(:kw_args_method).
+            with(1, hash_including(:required_arg => 1))
+          o.kw_args_method(1, :required_arg => 1)
         end
 
-        context 'for a method that only accepts keyword args' do
-          it 'allows hash matchers like `hash_including` to be used in place of the keywords arg hash' do
-            o = instance_double('LoadedClass')
+        it 'allows anything matcher to be used in place of the keywords arg hash' do
+          o = instance_double('LoadedClass')
+          expect(o).to receive(:kw_args_method).with(1, anything)
+          o.kw_args_method(1, :required_arg => 1)
+        end
+
+        it 'still checks positional arguments when matchers used for keyword args' do
+          o = instance_double('LoadedClass')
+          prevents(/Expected 1, got 3/) {
             expect(o).to receive(:kw_args_method).
-              with(1, hash_including(:required_arg => 1))
-            o.kw_args_method(1, :required_arg => 1)
-          end
-
-          it 'allows anything matcher to be used in place of the keywords arg hash' do
-            o = instance_double('LoadedClass')
-            expect(o).to receive(:kw_args_method).with(1, anything)
-            o.kw_args_method(1, :required_arg => 1)
-          end
-
-          it 'still checks positional arguments when matchers used for keyword args' do
-            o = instance_double('LoadedClass')
-            prevents(/Expected 1, got 3/) {
-              expect(o).to receive(:kw_args_method).
-                with(1, 2, 3, hash_including(:required_arg => 1))
-            }
-            reset o
-          end
-
-          it 'does not allow matchers to be used in an actual method call' do
-            o = instance_double('LoadedClass')
-            matcher = hash_including(:required_arg => 1)
-            allow(o).to receive(:kw_args_method).with(1, matcher)
-            expect {
-              o.kw_args_method(1, matcher)
-            }.to raise_error(ArgumentError)
-          end
+              with(1, 2, 3, hash_including(:required_arg => 1))
+          }
+          reset o
         end
 
-        context 'for a method that accepts a mix of optional keyword and positional args' do
-          it 'allows hash matchers like `hash_including` to be used in place of the keywords arg hash' do
-            o = instance_double('LoadedClass')
-            expect(o).to receive(:mixed_args_method).with(1, 2, hash_including(:optional_arg_1 => 1))
-            o.mixed_args_method(1, 2, :optional_arg_1 => 1)
-          end
-        end
-
-        it 'checks that stubbed methods with required keyword args are ' \
-           'invoked with the required arguments' do
-          o = instance_double('LoadedClass', :kw_args_method => true)
+        it 'does not allow matchers to be used in an actual method call' do
+          o = instance_double('LoadedClass')
+          matcher = hash_including(:required_arg => 1)
+          allow(o).to receive(:kw_args_method).with(1, matcher)
           expect {
-            o.kw_args_method(:optional_arg => 'something')
+            o.kw_args_method(1, matcher)
           }.to raise_error(ArgumentError)
         end
+      end
+
+      context 'for a method that accepts a mix of optional keyword and positional args' do
+        it 'allows hash matchers like `hash_including` to be used in place of the keywords arg hash' do
+          o = instance_double('LoadedClass')
+          expect(o).to receive(:mixed_args_method).with(1, 2, hash_including(:optional_arg_1 => 1))
+          o.mixed_args_method(1, 2, :optional_arg_1 => 1)
+        end
+      end
+
+      it 'checks that stubbed methods with required keyword args are ' \
+         'invoked with the required arguments' do
+        o = instance_double('LoadedClass', :kw_args_method => true)
+        expect {
+          o.kw_args_method(:optional_arg => 'something')
+        }.to raise_error(ArgumentError)
       end
 
       it 'validates `with` args against the method signature when stubbing a method' do

--- a/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/instance_double_with_class_loaded_spec.rb
@@ -211,18 +211,10 @@ module RSpec
           expect(obj.respond_to?(:defined_private_method, false)).to be false
         end
 
-        if RUBY_VERSION.to_f < 2.0 # respond_to?(:protected_method) changed behavior in Ruby 2.0.
-          it 'reports that it responds to protected methods' do
-            expect(obj.respond_to?(:defined_protected_method)).to be true
-            expect(obj.respond_to?(:defined_protected_method, true)).to be true
-            expect(obj.respond_to?(:defined_protected_method, false)).to be true
-          end
-        else
-          it 'reports that it responds to protected methods when the appropriate arg is passed' do
-            expect(obj.respond_to?(:defined_protected_method)).to be false
-            expect(obj.respond_to?(:defined_protected_method, true)).to be true
-            expect(obj.respond_to?(:defined_protected_method, false)).to be false
-          end
+        it 'reports that it responds to protected methods when the appropriate arg is passed' do
+          expect(obj.respond_to?(:defined_protected_method)).to be false
+          expect(obj.respond_to?(:defined_protected_method, true)).to be true
+          expect(obj.respond_to?(:defined_protected_method, false)).to be false
         end
       end
     end

--- a/spec/rspec/mocks/verifying_doubles/method_visibility_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/method_visibility_spec.rb
@@ -111,8 +111,7 @@ module RSpec
         unless double.null_object?
           # Null object doubles use `method_missing` and so the singleton class
           # doesn't know what methods are defined.
-          singleton_class = class << double; self; end
-          expect(singleton_class.send("#{visibility}_method_defined?", method_name)).to be true
+          expect(double.singleton_class.send("#{visibility}_method_defined?", method_name)).to be true
         end
       end
 

--- a/spec/rspec/mocks/verifying_doubles/naming_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/naming_spec.rb
@@ -45,37 +45,37 @@ module RSpec
 
       describe "instance_double" do
         it_behaves_like "a named verifying double", "InstanceDouble" do
-          alias :create_double :instance_double
+          alias_method :create_double, :instance_double
         end
       end
 
       describe "instance_spy" do
         it_behaves_like "a named verifying double", "InstanceDouble" do
-          alias :create_double :instance_spy
+          alias_method :create_double, :instance_spy
         end
       end
 
       describe "class_double" do
         it_behaves_like "a named verifying double", "ClassDouble" do
-          alias :create_double :class_double
+          alias_method :create_double, :class_double
         end
       end
 
       describe "class_spy" do
         it_behaves_like "a named verifying double", "ClassDouble" do
-          alias :create_double :class_spy
+          alias_method :create_double, :class_spy
         end
       end
 
       describe "object_double" do
         it_behaves_like "a named verifying double", "ObjectDouble" do
-          alias :create_double :object_double
+          alias_method :create_double, :object_double
         end
       end
 
       describe "object_spy" do
         it_behaves_like "a named verifying double", "ObjectDouble" do
-          alias :create_double :object_spy
+          alias_method :create_double, :object_spy
         end
       end
     end

--- a/spec/rspec/mocks_spec.rb
+++ b/spec/rspec/mocks_spec.rb
@@ -12,31 +12,11 @@ RSpec.describe RSpec::Mocks do
     'require "rspec/mocks/any_instance"'
   ]
 
-  # On 1.9.2 we load securerandom to get around the lack of `BasicObject#__id__.
-  # Loading securerandom loads many other stdlibs it depends on. Rather than
-  # declaring it (and all the stdlibs it loads) as allowed, it's easier just
-  # to prevent the loading of securerandom by faking out `BasicObject#__id__
-  lib_preamble.unshift "class BasicObject; def __id__; end; end" if RUBY_VERSION == '1.9.2'
-
   it_behaves_like 'library wide checks', 'rspec-mocks',
     :preamble_for_lib => lib_preamble,
     :allowed_loaded_feature_regexps => [
       /rbconfig/ # loaded by rspec-support
-    ] do
-
-      if RSpec::Support::Ruby.jruby? && JRUBY_VERSION =~ /9\.1\.7\.0/
-        before(:example, :description => /spec files/) do
-          pending "JRuby 9.1.7.0 currently generates a circular warning which" \
-                  " is unrelated to our suite."
-        end
-      end
-
-    if RUBY_VERSION == '1.9.2'
-      before(:example, :description => /spec files/) do
-        pending "Loading psych and syck on 1.9.2 (as our test suite does) triggers warnings"
-      end
-    end
-  end
+    ]
 
   describe ".verify" do
     it "delegates to the space" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'rspec/support/spec'
-require 'rspec/support/ruby_features'
 
 RSpec::Support::Spec.setup_simplecov do
   minimum_coverage 93
@@ -105,8 +104,6 @@ RSpec.configure do |config|
   config.include VerifyAndResetHelpers
   config.include MatcherHelpers
   config.include VerificationHelpers
-  config.extend RSpec::Support::RubyFeatures
-  config.include RSpec::Support::RubyFeatures
 
   config.define_derived_metadata :ordered_and_vague_counts_unsupported do |meta|
     meta[:pending] = "`.ordered` combined with a vague count (e.g. `at_least` or `at_most`) is not yet supported (see #713)"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'rspec/support/spec'
 
 RSpec::Support::Spec.setup_simplecov do
-  minimum_coverage 93
+  minimum_coverage 90
 end
 
 require 'yaml'

--- a/spec/support/doubled_classes.rb
+++ b/spec/support/doubled_classes.rb
@@ -1,6 +1,4 @@
 class LoadedClass
-  extend RSpec::Support::RubyFeatures
-
   M = :m
   N = :n
   INSTANCE = LoadedClass.new
@@ -47,15 +45,10 @@ class LoadedClass
   def defined_instance_and_class_method
   end
 
-  if required_kw_args_supported?
-    # Need to eval this since it is invalid syntax on earlier rubies.
-    eval <<-RUBY
-      def kw_args_method(foo, optional_arg:'hello', required_arg:)
-      end
+  def kw_args_method(foo, optional_arg:'hello', required_arg:)
+  end
 
-      def mixed_args_method(foo, bar, optional_arg_1:1, optional_arg_2:2)
-      end
-    RUBY
+  def mixed_args_method(foo, bar, optional_arg_1:1, optional_arg_2:2)
   end
 
   def send(*)


### PR DESCRIPTION
Better viewed ignoring indentation changes https://github.com/rspec/rspec-mocks/pull/1349/files?diff=split&w=1


Sibling PRs:
 - https://github.com/rspec/rspec-support/pull/436
 - https://github.com/rspec/rspec-expectations/pull/1231
 - https://github.com/rspec/rspec-core/pull/2787


As per rspec/rspec#61 (comment)

 - [x] Is this needed in spec_helper.rb
  config.extend RSpec::Support::RubyFeatures
  config.include RSpec::Support::RubyFeatures
 - [x] RSpec::Support.require_rspec_support 'ruby_features'
 - [x] Usage of RubyFeatures
 - [x] clean predicate_functions
 - [-] check respond_to?
 - [x] check method_defined?
 - [x] check send (where we call private methods that later became public)
 - [x] check if we require_rspec_support ruby_features where RubyFeatures are not used
 - [x] check define_method where def would suffice
 - [x] check 1.8, 1.9, 2.0, 2.1, jruby, 9.0, 9.1, mri
 - [x] check eval
 - [x] clean up if RUBY_VERSION < "2.3" || backed_up_method_owner[method_name.to_sym] == self
 - [x] change old ruby induced rubocop settings, fix offences
 - [#] https://github.com/jruby/jruby/issues/1398 - only fixed in JRuby 9.2
 - [x] Can work without this check?  Gemfile|28| 4:if RUBY_VERSION <= '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
 - [x] skip "This intermittently fails on JRuby" if RUBY_PLATFORM == 'java'
 - [x] remove handle_restoration_failures?
 - [x] remove expect_output_warning_on_ruby_lt_2
 - [x] check "jruby"
 - [x] clean?  return Object unless Object.ancestors.last == ::BasicObject
 - [x] clean if defined?(BasicObject)