### PR TITLE
Fix kwargs delegation warning in `and_call_original`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Bug Fixes:
 
 * Issue `ArgumentError` rather than `TypeError` when unsupported methods on
   unsupported objects are attempted to be stubbed. (@zhisme, #1357)
+* Fix kwargs delegation warning in `and_call_original`. (@pirj, #????)
 
 ### 3.10.0 / 2020-10-30
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.9.1...v3.10.0)

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
-%w[rspec rspec-core rspec-expectations rspec-support].each do |lib|
+%w[rspec rspec-core rspec-expectations].each do |lib|
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
@@ -11,6 +11,8 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
     gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch
   end
 end
+
+gem 'rspec-support', github: 'rspec/rspec-support', branch: 'add-proc-kwargs-detection-support'
 
 if ENV['DIFF_LCS_VERSION']
   gem 'diff-lcs', ENV['DIFF_LCS_VERSION']

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -1,4 +1,5 @@
 RSpec::Support.require_rspec_support 'reentrant_mutex'
+RSpec::Support.require_rspec_support "with_keywords_when_needed"
 
 module RSpec
   module Mocks
@@ -98,7 +99,7 @@ module RSpec
       #   expect(counter.count).to eq(original_count + 1)
       def and_call_original
         wrap_original(__method__) do |original, *args, &block|
-          original.call(*args, &block)
+          RSpec::Support::WithKeywordsWhenNeeded.call(original, *args, &block)
         end
       end
 

--- a/lib/rspec/mocks/verifying_message_expectation.rb
+++ b/lib/rspec/mocks/verifying_message_expectation.rb
@@ -1,5 +1,3 @@
-RSpec::Support.require_rspec_support 'method_signature_verifier'
-
 module RSpec
   module Mocks
     # A message expectation that knows about the real implementation of the

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe "and_call_original" do
           yield x, :additional_yielded_arg
         end
 
+        def meth_3(a: '')
+          a
+        end
+
         def self.new_instance
           new
         end
@@ -51,6 +55,12 @@ RSpec.describe "and_call_original" do
       allow(instance).to receive(:meth_1).and_return(:stubbed_value)
       expect(instance).to receive(:meth_1).and_call_original
       expect(instance.meth_1).to eq(:original)
+    end
+
+    it 'supports keyword arguments' do
+      expect(instance).to receive(:meth_3).and_call_original
+      value = instance.meth_3(a: :a)
+      expect(value).to eq(:a)
     end
 
     it 'passes args and blocks through to the original method' do


### PR DESCRIPTION
Depends on: https://github.com/rspec/rspec-support/pull/475
Fixes: https://github.com/rspec/rspec-mocks/issues/1306
Supersedes: https://github.com/rspec/rspec-mocks/pull/1324
Based on: https://github.com/rspec/rspec-mocks/pull/1324/files#diff-afc11368b62c27a5bd155b766ec9cf4e96a9331d073b6123a9bce36a270de640R359

[ ] **revert changes to `Gemfile` before merging (preferably after merging the accompanying `rspec-support` PR**