### PR TITLE
Resolve an issue using method doubles with keyword arguments on Ruby 3

### DIFF
--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -63,6 +63,7 @@ module RSpec
           define_method(method_name) do |*args, &block|
             method_double.proxy_method_invoked(self, *args, &block)
           end
+          ruby2_keywords(method_name)
           __send__(visibility, method_name)
         end
 

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -63,7 +63,7 @@ module RSpec
           define_method(method_name) do |*args, &block|
             method_double.proxy_method_invoked(self, *args, &block)
           end
-          ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
+          ruby2_keywords(method_name) if Module.private_method_defined?(:ruby2_keywords)
           __send__(visibility, method_name)
         end
 

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -63,7 +63,7 @@ module RSpec
           define_method(method_name) do |*args, &block|
             method_double.proxy_method_invoked(self, *args, &block)
           end
-          ruby2_keywords(method_name)
+          ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
           __send__(visibility, method_name)
         end
 

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -185,10 +185,14 @@ RSpec.describe "and_call_original" do
       expect(klazz.alternate_new).to be_an_instance_of(klazz)
     end
 
-    it "works for methods that accept keyword arguments" do
-      def instance.foo(bar:); bar; end
-      expect(instance).to receive(:foo).and_call_original
-      expect(instance.foo(bar: "baz")).to eq("baz")
+    if RSpec::Support::RubyFeatures.kw_args_supported?
+      binding.eval(<<-CODE, __FILE__, __LINE__)
+      it "works for methods that accept keyword arguments" do
+        def instance.foo(bar:); bar; end
+        expect(instance).to receive(:foo).and_call_original
+        expect(instance.foo(bar: "baz")).to eq("baz")
+      end
+      CODE
     end
 
     context 'on an object that defines method_missing' do

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe "and_call_original" do
     if RSpec::Support::RubyFeatures.kw_args_supported?
       binding.eval(<<-CODE, __FILE__, __LINE__)
       it "works for methods that accept keyword arguments" do
-        def instance.foo(bar:); bar; end
+        def instance.foo(bar: nil); bar; end
         expect(instance).to receive(:foo).and_call_original
         expect(instance.foo(bar: "baz")).to eq("baz")
       end

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -185,6 +185,12 @@ RSpec.describe "and_call_original" do
       expect(klazz.alternate_new).to be_an_instance_of(klazz)
     end
 
+    it "works for methods that accept keyword arguments" do
+      def instance.foo(bar:); bar; end
+      expect(instance).to receive(:foo).and_call_original
+      expect(instance.foo(bar: "baz")).to eq("baz")
+    end
+
     context 'on an object that defines method_missing' do
       before do
         klass.class_exec do


### PR DESCRIPTION
This captures and resolves an issue I encountered when running my test suite on Ruby 3. It may resolve more issues than just with `and_call_original` but that needs more investigation. Happy to fill in more test cases here but I haven't gone through to see what else uses `MethodDouble` yet.