### PR TITLE
Make `with` support Ruby 3 keywords

### DIFF
--- a/lib/rspec/mocks/argument_list_matcher.rb
+++ b/lib/rspec/mocks/argument_list_matcher.rb
@@ -46,16 +46,30 @@ module RSpec
         @expected_args = expected_args
         ensure_expected_args_valid!
       end
+      ruby2_keywords :initialize if Module.private_method_defined?(:ruby2_keywords)
 
       # @api public
-      # @param [Array] args
+      # @param [Array] actual_args
       #
       # Matches each element in the `expected_args` against the element in the same
       # position of the arguments passed to `new`.
       #
       # @see #initialize
-      def args_match?(*args)
-        Support::FuzzyMatcher.values_match?(resolve_expected_args_based_on(args), args)
+      def args_match?(*actual_args)
+        expected_args = resolve_expected_args_based_on(actual_args)
+
+        return false if expected_args.size != actual_args.size
+
+        if Hash.respond_to?(:ruby2_keywords_hash?, true)
+          # if both arguments end with Hashes, and if one is a keyword hash and the other is not, they don't match
+          if Hash === expected_args.last && Hash === actual_args.last
+            if Hash.ruby2_keywords_hash?(actual_args.last) != Hash.ruby2_keywords_hash?(expected_args.last)
+              return false
+            end
+          end
+        end
+
+        Support::FuzzyMatcher.values_match?(expected_args, actual_args)
       end
 
       # @private

--- a/lib/rspec/mocks/argument_list_matcher.rb
+++ b/lib/rspec/mocks/argument_list_matcher.rb
@@ -63,7 +63,7 @@ module RSpec
         if Hash.respond_to?(:ruby2_keywords_hash?, true)
           # if both arguments end with Hashes, and if one is a keyword hash and the other is not, they don't match
           if Hash === expected_args.last && Hash === actual_args.last
-            if Hash.ruby2_keywords_hash?(actual_args.last) != Hash.ruby2_keywords_hash?(expected_args.last)
+            if !Hash.ruby2_keywords_hash?(actual_args.last) && Hash.ruby2_keywords_hash?(expected_args.last)
               return false
             end
           end

--- a/lib/rspec/mocks/argument_list_matcher.rb
+++ b/lib/rspec/mocks/argument_list_matcher.rb
@@ -60,7 +60,7 @@ module RSpec
 
         return false if expected_args.size != actual_args.size
 
-        if Hash.respond_to?(:ruby2_keywords_hash?, true)
+        if RUBY_VERSION >= "3"
           # if both arguments end with Hashes, and if one is a keyword hash and the other is not, they don't match
           if Hash === expected_args.last && Hash === actual_args.last
             if !Hash.ruby2_keywords_hash?(actual_args.last) && Hash.ruby2_keywords_hash?(expected_args.last)

--- a/lib/rspec/mocks/matchers/receive.rb
+++ b/lib/rspec/mocks/matchers/receive.rb
@@ -62,6 +62,7 @@ module RSpec
             @recorded_customizations << ExpectationCustomization.new(method, args, block)
             self
           end
+          ruby2_keywords(method) if Module.private_method_defined?(:ruby2_keywords)
         end
 
       private

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -322,6 +322,7 @@ module RSpec
         @argument_list_matcher = ArgumentListMatcher.new(*args)
         self
       end
+      ruby2_keywords(:with) if Module.private_method_defined?(:ruby2_keywords)
 
       # Expect messages to be received in a specific order.
       #

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -387,8 +387,8 @@ module RSpec
           a_double.random_call(:a => "a", :b => "b")
         end
 
-        if RUBY_VERSION >= "2.7"
-          it "fails to matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 2.7 or later", :reset => true do
+        if RUBY_VERSION >= "3"
+          it "fails to matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 3.0 or later", :reset => true do
             opts = {:a => "a", :b => "b"}
             expect(a_double).to receive(:random_call).with(:a => "a", :b => "b")
             expect do

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -381,20 +381,10 @@ module RSpec
           a_double.random_call(:a => "a", :b => "b")
         end
 
-        if RSpec::Support::RubyFeatures.required_kw_args_supported?
-          it "fails to match against a hash submitted by reference and received by value in Ruby 3", :reset => true do
-            opts = {:a => "a", :b => "b"}
-            expect(a_double).to receive(:random_call).with(opts)
-            expect do
-              a_double.random_call(:a => "a", :b => "b")
-            end.to fail_with(/expected: \(\{:a=>"a", :b=>"b"|:b=>"b", :a=>"a"\}\)/)
-          end
-        else
-          it "matches against a hash submitted by reference and received by value in Ruby 2" do
-            opts = {:a => "a", :b => "b"}
-            expect(a_double).to receive(:random_call).with(opts)
-            a_double.random_call(:a => "a", :b => "b")
-          end
+        it "matches against a hash submitted by reference and received by value (in both Ruby 2 and Ruby 3)" do
+          opts = {:a => "a", :b => "b"}
+          expect(a_double).to receive(:random_call).with(opts)
+          a_double.random_call(:a => "a", :b => "b")
         end
 
         if RUBY_VERSION >= "2.7"

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -381,14 +381,14 @@ module RSpec
           a_double.random_call(:a => "a", :b => "b")
         end
 
-        it "matches against a hash submitted by reference and received by value (in both Ruby 2 and Ruby 3)" do
+        it "matches against a hash submitted as keyword arguments a and received as a positional argument (in both Ruby 2 and Ruby 3)" do
           opts = {:a => "a", :b => "b"}
           expect(a_double).to receive(:random_call).with(opts)
           a_double.random_call(:a => "a", :b => "b")
         end
 
         if RUBY_VERSION >= "2.7"
-          it "fails to match against a hash submitted by value and received by reference in Ruby 2.7 or later", :reset => true do
+          it "fails to matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 2.7 or later", :reset => true do
             opts = {:a => "a", :b => "b"}
             expect(a_double).to receive(:random_call).with(:a => "a", :b => "b")
             expect do
@@ -396,7 +396,7 @@ module RSpec
             end.to fail_with(/expected: \(\{(:a=>\"a\", :b=>\"b\"|:b=>\"b\", :a=>\"a\")\}\)/)
           end
         else
-          it "matches against a hash submitted by value and received by reference in Ruby 2.6 or before" do
+          it "matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 2.6 or before" do
             opts = {:a => "a", :b => "b"}
             expect(a_double).to receive(:random_call).with(:a => "a", :b => "b")
             a_double.random_call(opts)

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -396,7 +396,7 @@ module RSpec
             end.to fail_with(/expected: \(\{(:a=>\"a\", :b=>\"b\"|:b=>\"b\", :a=>\"a\")\}\)/)
           end
         else
-          it "matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 2.6 or before" do
+          it "matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 2.7 or before" do
             opts = {:a => "a", :b => "b"}
             expect(a_double).to receive(:random_call).with(:a => "a", :b => "b")
             a_double.random_call(opts)

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -381,16 +381,36 @@ module RSpec
           a_double.random_call(:a => "a", :b => "b")
         end
 
-        it "matches against a hash submitted by reference and received by value" do
-          opts = {:a => "a", :b => "b"}
-          expect(a_double).to receive(:random_call).with(opts)
-          a_double.random_call(:a => "a", :b => "b")
+        if RSpec::Support::RubyFeatures.required_kw_args_supported?
+          it "fails to match against a hash submitted by reference and received by value in Ruby 3", :reset => true do
+            opts = {:a => "a", :b => "b"}
+            expect(a_double).to receive(:random_call).with(opts)
+            expect do
+              a_double.random_call(:a => "a", :b => "b")
+            end.to fail_with(/expected: \(\{:a=>"a", :b=>"b"|:b=>"b", :a=>"a"\}\)/)
+          end
+        else
+          it "matches against a hash submitted by reference and received by value in Ruby 2" do
+            opts = {:a => "a", :b => "b"}
+            expect(a_double).to receive(:random_call).with(opts)
+            a_double.random_call(:a => "a", :b => "b")
+          end
         end
 
-        it "matches against a hash submitted by value and received by reference" do
-          opts = {:a => "a", :b => "b"}
-          expect(a_double).to receive(:random_call).with(:a => "a", :b => "b")
-          a_double.random_call(opts)
+        if RUBY_VERSION >= "2.7"
+          it "fails to match against a hash submitted by value and received by reference in Ruby 2.7 or later", :reset => true do
+            opts = {:a => "a", :b => "b"}
+            expect(a_double).to receive(:random_call).with(:a => "a", :b => "b")
+            expect do
+              a_double.random_call(opts)
+            end.to fail_with(/expected: \(\{(:a=>\"a\", :b=>\"b\"|:b=>\"b\", :a=>\"a\")\}\)/)
+          end
+        else
+          it "matches against a hash submitted by value and received by reference in Ruby 2.6 or before" do
+            opts = {:a => "a", :b => "b"}
+            expect(a_double).to receive(:random_call).with(:a => "a", :b => "b")
+            a_double.random_call(opts)
+          end
         end
 
         it "fails for a hash w/ wrong values", :reset => true do

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -84,7 +84,7 @@ module RSpec
       it "can accept an inner hash as a message argument" do
         hash = {:a => {:key => "value"}}
         expect(object).to receive(:foobar).with(:key => "value").and_return(1)
-        expect(object.foobar(hash[:a])).to equal(1)
+        expect(object.foobar(**hash[:a])).to equal(1)
       end
 
       it "can create a positive message expectation" do

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -87,6 +87,8 @@ module RSpec
           expect(object).to receive(:foobar).with(:key => "value").and_return(1)
           # Use eval to avoid syntax error on 1.8 and 1.9
           eval("expect(object.foobar(**hash[:a])).to equal(1)")
+          # Avoid warning: assigned but unused variable - hash
+          hash = hash
         end
       end
 

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -81,10 +81,13 @@ module RSpec
         expect(object.foobar(:key => "value")).to equal(1)
       end
 
-      it "can accept an inner hash as a message argument" do
-        hash = {:a => {:key => "value"}}
-        expect(object).to receive(:foobar).with(:key => "value").and_return(1)
-        expect(object.foobar(**hash[:a])).to equal(1)
+      if RSpec::Support::RubyFeatures.required_kw_args_supported?
+        it "can accept an inner hash as a message argument" do
+          hash = {:a => {:key => "value"}}
+          expect(object).to receive(:foobar).with(:key => "value").and_return(1)
+          # Use eval to avoid syntax error on 1.8 and 1.9
+          eval("expect(object.foobar(**hash[:a])).to equal(1)")
+        end
       end
 
       it "can create a positive message expectation" do

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -82,14 +82,14 @@ module RSpec
       end
 
       if RSpec::Support::RubyFeatures.required_kw_args_supported?
+        # Use eval to avoid syntax error on 1.8 and 1.9
+        binding.eval(<<-CODE, __FILE__, __LINE__)
         it "can accept an inner hash as a message argument" do
           hash = {:a => {:key => "value"}}
           expect(object).to receive(:foobar).with(:key => "value").and_return(1)
-          # Use eval to avoid syntax error on 1.8 and 1.9
-          eval("expect(object.foobar(**hash[:a])).to equal(1)")
-          # Avoid warning: assigned but unused variable - hash
-          hash = hash
+          expect(object.foobar(**hash[:a])).to equal(1)
         end
+        CODE
       end
 
       it "can create a positive message expectation" do

--- a/spec/rspec/mocks/should_syntax_spec.rb
+++ b/spec/rspec/mocks/should_syntax_spec.rb
@@ -466,12 +466,14 @@ RSpec.context "with default syntax configuration" do
   let(:expected_arguments) {
     [
       /Using.*without explicitly enabling/,
-      {:replacement => "the new `:expect` syntax or explicitly enable `:should`"}
     ]
+  }
+  let(:expected_keywords) {
+    {:replacement => "the new `:expect` syntax or explicitly enable `:should`"}
   }
 
   it "it warns about should once, regardless of how many times it is called" do
-    expect(RSpec).to receive(:deprecate).with(*expected_arguments)
+    expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)
     o = Object.new
     o2 = Object.new
     o.should_receive(:bees)
@@ -482,7 +484,7 @@ RSpec.context "with default syntax configuration" do
   end
 
   it "warns about should not once, regardless of how many times it is called" do
-    expect(RSpec).to receive(:deprecate).with(*expected_arguments)
+    expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)
     o = Object.new
     o2 = Object.new
     o.should_not_receive(:bees)
@@ -490,7 +492,7 @@ RSpec.context "with default syntax configuration" do
   end
 
   it "warns about stubbing once, regardless of how many times it is called" do
-    expect(RSpec).to receive(:deprecate).with(*expected_arguments)
+    expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)
     o = Object.new
     o2 = Object.new
 

--- a/spec/rspec/mocks/should_syntax_spec.rb
+++ b/spec/rspec/mocks/should_syntax_spec.rb
@@ -463,16 +463,15 @@ RSpec.context "with default syntax configuration" do
   after(:all)  { RSpec::Mocks.configuration.syntax = orig_syntax }
   before       { RSpec::Mocks.configuration.reset_syntaxes_to_default }
 
-  let(:expected_arguments) {
-    [
-      /Using.*without explicitly enabling/,
-    ]
-  }
-  let(:expected_keywords) {
-    {:replacement => "the new `:expect` syntax or explicitly enable `:should`"}
-  }
-
   if RSpec::Support::RubyFeatures.required_kw_args_supported?
+    let(:expected_arguments) {
+      [
+        /Using.*without explicitly enabling/,
+      ]
+    }
+    let(:expected_keywords) {
+      {:replacement => "the new `:expect` syntax or explicitly enable `:should`"}
+    }
     it "it warns about should once, regardless of how many times it is called" do
       # Use eval to avoid syntax error on 1.8 and 1.9
       eval("expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)")
@@ -497,6 +496,40 @@ RSpec.context "with default syntax configuration" do
     it "warns about stubbing once, regardless of how many times it is called" do
       # Use eval to avoid syntax error on 1.8 and 1.9
       eval("expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)")
+      o = Object.new
+      o2 = Object.new
+
+      o.stub(:faces)
+      o2.stub(:faces)
+    end
+  else
+    let(:expected_arguments) {
+      [
+        /Using.*without explicitly enabling/,
+        {:replacement => "the new `:expect` syntax or explicitly enable `:should`"}
+      ]
+    }
+    it "it warns about should once, regardless of how many times it is called" do
+      expect(RSpec).to receive(:deprecate).with(*expected_arguments)
+      o = Object.new
+      o2 = Object.new
+      o.should_receive(:bees)
+      o2.should_receive(:bees)
+
+      o.bees
+      o2.bees
+    end
+
+    it "warns about should not once, regardless of how many times it is called" do
+      expect(RSpec).to receive(:deprecate).with(*expected_arguments)
+      o = Object.new
+      o2 = Object.new
+      o.should_not_receive(:bees)
+      o2.should_not_receive(:bees)
+    end
+
+    it "warns about stubbing once, regardless of how many times it is called" do
+      expect(RSpec).to receive(:deprecate).with(*expected_arguments)
       o = Object.new
       o2 = Object.new
 

--- a/spec/rspec/mocks/should_syntax_spec.rb
+++ b/spec/rspec/mocks/should_syntax_spec.rb
@@ -472,32 +472,37 @@ RSpec.context "with default syntax configuration" do
     {:replacement => "the new `:expect` syntax or explicitly enable `:should`"}
   }
 
-  it "it warns about should once, regardless of how many times it is called" do
-    expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)
-    o = Object.new
-    o2 = Object.new
-    o.should_receive(:bees)
-    o2.should_receive(:bees)
+  if RSpec::Support::RubyFeatures.required_kw_args_supported?
+    it "it warns about should once, regardless of how many times it is called" do
+      # Use eval to avoid syntax error on 1.8 and 1.9
+      eval("expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)")
+      o = Object.new
+      o2 = Object.new
+      o.should_receive(:bees)
+      o2.should_receive(:bees)
 
-    o.bees
-    o2.bees
-  end
+      o.bees
+      o2.bees
+    end
 
-  it "warns about should not once, regardless of how many times it is called" do
-    expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)
-    o = Object.new
-    o2 = Object.new
-    o.should_not_receive(:bees)
-    o2.should_not_receive(:bees)
-  end
+    it "warns about should not once, regardless of how many times it is called" do
+      # Use eval to avoid syntax error on 1.8 and 1.9
+      eval("expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)")
+      o = Object.new
+      o2 = Object.new
+      o.should_not_receive(:bees)
+      o2.should_not_receive(:bees)
+    end
 
-  it "warns about stubbing once, regardless of how many times it is called" do
-    expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)
-    o = Object.new
-    o2 = Object.new
+    it "warns about stubbing once, regardless of how many times it is called" do
+      # Use eval to avoid syntax error on 1.8 and 1.9
+      eval("expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)")
+      o = Object.new
+      o2 = Object.new
 
-    o.stub(:faces)
-    o2.stub(:faces)
+      o.stub(:faces)
+      o2.stub(:faces)
+    end
   end
 
   it "warns about unstubbing once, regardless of how many times it is called" do


### PR DESCRIPTION
As you know, keyword arguments have been separated from positional ones in Ruby 3.
How about making `with` to match the semantics?
It would be good to allow rspec to check if positional or keyword arguments are passed appropriately.

For example, if a mock object has `with(a: 'a', b: 'b'), it should accept keywords, not a positional Hash.

```
class Foo
end

foo = Foo.new
allow(foo).to receive(:bar).with(a: 'a', b: 'b')
args = { a: 'a', b: 'b' }

foo.bar(args)   # fail
foo.bar(**args) # pass
```

Also, if a mock object has `with({ a: 'a', b: 'b' }), it should accept a positional Hash, not keywords.

```
foo = Foo.new
allow(foo).to receive(:bar).with({ a: 'a', b: 'b' })
args = { a: 'a', b: 'b' }

foo.bar(args)   # pass
foo.bar(**args) # fail
```

This PR is just a proof of concept and the change partially includes #1385. What do you think?