### PR TITLE
Use true/false for Constant#previously_defined

### DIFF
--- a/lib/rspec/mocks/mutate_const.rb
+++ b/lib/rspec/mocks/mutate_const.rb
@@ -66,7 +66,7 @@ module RSpec
 
       # @private
       def self.unmutated(name)
-        previously_defined = recursive_const_defined?(name)
+        previously_defined = !!recursive_const_defined?(name)
       rescue NameError
         new(name) do |c|
           c.valid_name = false


### PR DESCRIPTION
```
  1) RSpec::Mocks::Constant.original for a previously defined unstubbed constant indicates it was previously defined
     Failure/Error: it("indicates it was previously defined") { expect(const).to be_previously_defined }
       expected `#<RSpec::Mocks::Constant TestClass::M>.previously_defined?` to return true, got [:m, "TestClass::M"]
     # ./spec/rspec/mocks/mutate_const_spec.rb:446:in `block (4 levels) in <module:Mocks>'
```