### PR TITLE
Be more permissive when detecting frozen objects

### DIFF
--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -77,7 +77,7 @@ module RSpec
         # TODO: drop in favor of FrozenError in ruby 2.5+
         #  RuntimeError (and FrozenError) for ruby 2.x
         #  TypeError for ruby 1.x
-        if FROZEN_ERROR_MSG === e.message
+        if (defined?(FrozenError) && e.is_a?(FrozenError)) || FROZEN_ERROR_MSG === e.message
           raise ArgumentError, "Cannot proxy frozen objects, rspec-mocks relies on proxies for method stubbing and expectations."
         end
         raise
@@ -105,7 +105,9 @@ module RSpec
         # TODO: drop in favor of FrozenError in ruby 2.5+
         #  RuntimeError (and FrozenError) for ruby 2.x
         #  TypeError for ruby 1.x
-        return show_frozen_warning if FROZEN_ERROR_MSG === e.message
+        if (defined?(FrozenError) && e.is_a?(FrozenError)) || FROZEN_ERROR_MSG === e.message
+          return show_frozen_warning
+        end
         raise
       end
 

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -2,6 +2,9 @@ module RSpec
   module Mocks
     # @private
     class MethodDouble
+      # @private TODO: drop in favor of FrozenError in ruby 2.5+
+      FROZEN_ERROR_MSG = /can't modify frozen/
+
       # @private
       attr_reader :method_name, :object, :expectations, :stubs, :method_stasher
 
@@ -70,6 +73,14 @@ module RSpec
         end
 
         @method_is_proxied = true
+      rescue RuntimeError, TypeError => e
+        # TODO: drop in favor of FrozenError in ruby 2.5+
+        #  RuntimeError (and FrozenError) for ruby 2.x
+        #  TypeError for ruby 1.x
+        if FROZEN_ERROR_MSG === e.message
+          raise ArgumentError, "Cannot proxy frozen objects, rspec-mocks relies on proxies for method stubbing and expectations."
+        end
+        raise
       end
 
       # The implementation of the proxied method. Subclasses may override this
@@ -83,7 +94,6 @@ module RSpec
 
       # @private
       def restore_original_method
-        return show_frozen_warning if object_singleton_class.frozen?
         return unless @method_is_proxied
 
         remove_method_from_definition_target
@@ -91,6 +101,12 @@ module RSpec
         restore_original_visibility
 
         @method_is_proxied = false
+      rescue RuntimeError, TypeError => e
+        # TODO: drop in favor of FrozenError in ruby 2.5+
+        #  RuntimeError (and FrozenError) for ruby 2.x
+        #  TypeError for ruby 1.x
+        return show_frozen_warning if FROZEN_ERROR_MSG === e.message
+        raise
       end
 
       # @private

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -35,8 +35,7 @@ module RSpec
 
       # @private
       def ensure_can_be_proxied!(object)
-        return unless object.is_a?(Symbol) || object.frozen?
-        return if object.nil?
+        return unless object.is_a?(Symbol) || (object.is_a?(String) && object.frozen?)
 
         msg = "Cannot proxy frozen objects"
         if Symbol === object

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -35,14 +35,9 @@ module RSpec
 
       # @private
       def ensure_can_be_proxied!(object)
-        return unless object.is_a?(Symbol) || (object.is_a?(String) && object.frozen?)
+        return unless object.is_a?(Symbol)
 
-        msg = "Cannot proxy frozen objects"
-        if Symbol === object
-          msg << ". Symbols such as #{object} cannot be mocked or stubbed."
-        else
-          msg << ", rspec-mocks relies on proxies for method stubbing and expectations."
-        end
+        msg = "Cannot proxy frozen objects. Symbols such as #{object} cannot be mocked or stubbed."
         raise ArgumentError, msg
       end
 

--- a/spec/rspec/mocks/space_spec.rb
+++ b/spec/rspec/mocks/space_spec.rb
@@ -240,14 +240,6 @@ module RSpec::Mocks
       expect { space1.proxy_for(object) }.to raise_error(ArgumentError, expected_message)
     end
 
-    it 'raises ArgumentError with message if object is frozen' do
-      space1 = Space.new
-      object = "subject".freeze
-      expected_message = "Cannot proxy frozen objects, rspec-mocks relies on proxies for method stubbing and expectations."
-
-      expect { space1.proxy_for(object) }.to raise_error(ArgumentError, expected_message)
-    end
-
     def in_new_space_scope
       RSpec::Mocks.setup
       yield


### PR DESCRIPTION
Rather than rely on an object's #frozen? method, always attempt to
proxy a method when requested. Catch the errors resulting from failed
attempts to proxy and reraise (or log) them with helpful messages.

One notable use case for this is rails' activerecord's Model objects
becoming frozen after be deleted. In reality, only the underlying hash
of attributes is frozen and it should still be possible to write
proxies for these objects.