### PR TITLE
Backport strict predicate fix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Bug Fixes:
 
 * Support keyword arguments with `and_call_original` on Ruby 3.0.
   (Bryan Powell, #1385)
+* `RSpec::Mocks::Constant#previously_defined?` is now always a boolean.
+  (Phil Pirozhkov, #1397)
 
 ### 3.10.1 / 2020-12-27
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.10.0...v3.10.1)

--- a/lib/rspec/mocks/mutate_const.rb
+++ b/lib/rspec/mocks/mutate_const.rb
@@ -66,7 +66,7 @@ module RSpec
 
       # @private
       def self.unmutated(name)
-        previously_defined = recursive_const_defined?(name)
+        previously_defined = !!recursive_const_defined?(name)
       rescue NameError
         new(name) do |c|
           c.valid_name = false


### PR DESCRIPTION
This fix was initialy made in `4-0-dev` but is arguably a bug fix so can be backported to 3.10