### PR TITLE
Add tests and fix for ruby 3 keyword arguments issues

### DIFF
--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -261,6 +261,7 @@ module RSpec
             recorder.playback!(self, method_name)
             __send__(method_name, *args, &blk)
           end
+          @klass.__send__(:ruby2_keywords, method_name) if @klass.respond_to?(:ruby2_keywords, true)
         end
 
         def mark_invoked!(method_name)

--- a/spec/rspec/mocks/and_call_original_spec.rb
+++ b/spec/rspec/mocks/and_call_original_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe "and_call_original" do
           yield x, :additional_yielded_arg
         end
 
+        def meth_3(x:)
+          x
+        end
+
         def self.new_instance
           new
         end
@@ -123,6 +127,11 @@ RSpec.describe "and_call_original" do
       it 'works for instance methods defined on the class' do
         expect_any_instance_of(klass).to receive(:meth_1).and_call_original
         expect(klass.new.meth_1).to eq(:original)
+      end
+
+      it 'works for instance methods that use keyword arguments' do
+        expect_any_instance_of(klass).to receive(:meth_3).and_call_original
+        expect(klass.new.meth_3(x: :kwarg)).to eq(:kwarg)
       end
 
       it 'works for instance methods defined on the superclass of the class' do

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -62,12 +62,44 @@ module RSpec
           expect(receiver.foo).to eq(4)
         end
 
-        it 'allows a `do...end` block implementation with keyword args to be provided' do
-          wrapped.to receive(:foo) do |**kwargs|
-            kwargs[:kw]
+        if RSpec::Support::RubyFeatures.kw_args_supported?
+          binding.eval(<<-RUBY, __FILE__, __LINE__)
+          it 'allows a `do...end` block implementation with keyword args to be provided' do
+            wrapped.to receive(:foo) do |**kwargs|
+              kwargs[:kw]
+            end
+
+            expect(receiver.foo(kw: :arg)).to eq(:arg)
           end
 
-          expect(receiver.foo(kw: :arg)).to eq(:arg)
+          it 'allows a `do...end` block implementation with optional keyword args to be provided' do
+            wrapped.to receive(:foo) do |kw: :arg|
+              kw
+            end
+
+            expect(receiver.foo(kw: 1)).to eq(1)
+          end
+
+          it 'allows a `do...end` block implementation with optional keyword args to be provided' do
+            wrapped.to receive(:foo) do |kw: :arg|
+              kw
+            end
+
+            expect(receiver.foo).to eq(:arg)
+          end
+          RUBY
+        end
+
+        if RSpec::Support::RubyFeatures.required_kw_args_supported?
+          binding.eval(<<-RUBY, __FILE__, __LINE__)
+          it 'allows a `do...end` block implementation with required keyword args' do
+            wrapped.to receive(:foo) do |kw:|
+              kw
+            end
+
+            expect(receiver.foo(kw: :arg)).to eq(:arg)
+          end
+          RUBY
         end
 
         it 'allows chaining off a `do...end` block implementation to be provided' do

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -62,6 +62,14 @@ module RSpec
           expect(receiver.foo).to eq(4)
         end
 
+        it 'allows a `do...end` block implementation with keyword args to be provided' do
+          wrapped.to receive(:foo) do |**kwargs|
+            kwargs[:kw]
+          end
+
+          expect(receiver.foo(kw: :arg)).to eq(:arg)
+        end
+
         it 'allows chaining off a `do...end` block implementation to be provided' do
           wrapped.to receive(:foo) do
             4

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -54,52 +54,63 @@ module RSpec
           receiver.foo(1.1)
         end
 
-        it 'allows a `do...end` block implementation to be provided' do
-          wrapped.to receive(:foo) do
-            4
+        context 'without yielding receiver' do
+          # when `yield_receiver_to_any_instance_implementation_blocks` is `true`
+          # the block arguments are different for `expect` and `expect_any_instance_of`
+          around do |example|
+             previous_value = RSpec::Mocks.configuration.yield_receiver_to_any_instance_implementation_blocks?
+             RSpec::Mocks.configuration.yield_receiver_to_any_instance_implementation_blocks = false
+             example.run
+             RSpec::Mocks.configuration.yield_receiver_to_any_instance_implementation_blocks = previous_value
           end
 
-          expect(receiver.foo).to eq(4)
-        end
-
-        if RSpec::Support::RubyFeatures.kw_args_supported?
-          binding.eval(<<-RUBY, __FILE__, __LINE__)
-          it 'allows a `do...end` block implementation with keyword args to be provided' do
-            wrapped.to receive(:foo) do |**kwargs|
-              kwargs[:kw]
+          it 'allows a `do...end` block implementation to be provided' do
+            wrapped.to receive(:foo) do
+              4
             end
 
-            expect(receiver.foo(kw: :arg)).to eq(:arg)
+            expect(receiver.foo).to eq(4)
           end
 
-          it 'allows a `do...end` block implementation with optional keyword args to be provided' do
-            wrapped.to receive(:foo) do |kw: :arg|
-              kw
+          if RSpec::Support::RubyFeatures.kw_args_supported?
+            binding.eval(<<-RUBY, __FILE__, __LINE__)
+            it 'allows a `do...end` block implementation with keyword args to be provided' do
+              wrapped.to receive(:foo) do |**kwargs|
+                kwargs[:kw]
+              end
+
+              expect(receiver.foo(kw: :arg)).to eq(:arg)
             end
 
-            expect(receiver.foo(kw: 1)).to eq(1)
-          end
+            it 'allows a `do...end` block implementation with optional keyword args to be provided' do
+              wrapped.to receive(:foo) do |kw: :arg|
+                kw
+              end
 
-          it 'allows a `do...end` block implementation with optional keyword args to be provided' do
-            wrapped.to receive(:foo) do |kw: :arg|
-              kw
+              expect(receiver.foo(kw: 1)).to eq(1)
             end
 
-            expect(receiver.foo).to eq(:arg)
-          end
-          RUBY
-        end
+            it 'allows a `do...end` block implementation with optional keyword args to be provided' do
+              wrapped.to receive(:foo) do |kw: :arg|
+                kw
+              end
 
-        if RSpec::Support::RubyFeatures.required_kw_args_supported?
-          binding.eval(<<-RUBY, __FILE__, __LINE__)
-          it 'allows a `do...end` block implementation with required keyword args' do
-            wrapped.to receive(:foo) do |kw:|
-              kw
+              expect(receiver.foo).to eq(:arg)
             end
-
-            expect(receiver.foo(kw: :arg)).to eq(:arg)
+            RUBY
           end
-          RUBY
+
+          if RSpec::Support::RubyFeatures.required_kw_args_supported?
+            binding.eval(<<-RUBY, __FILE__, __LINE__)
+            it 'allows a `do...end` block implementation with required keyword args' do
+              wrapped.to receive(:foo) do |kw:|
+                kw
+              end
+
+              expect(receiver.foo(kw: :arg)).to eq(:arg)
+            end
+            RUBY
+          end
         end
 
         it 'allows chaining off a `do...end` block implementation to be provided' do


### PR DESCRIPTION
I recently ran into a similar issue to #1396 when upgrading our codebase to ruby 3.

This PR adds tests for both scenarios (`receive` with a block with kwargs and `and_call_original` when mocking a method that uses keyword arguments).  The tests may be redundant since fixing recorder fixed both tests.

I noticed other spots where define_method is used to intercept method calls (e.g. https://github.com/rspec/rspec-mocks/blob/0a52e0a86b126b4bab94d277b2ad99a7492dc37d/lib/rspec/mocks/any_instance/chain.rb#L27 and  https://github.com/rspec/rspec-mocks/blob/0a52e0a86b126b4bab94d277b2ad99a7492dc37d/lib/rspec/mocks/matchers/receive.rb#L61) so this PR may not be sufficient to fix all keyword argument issues