### PR TITLE
Get rid of redefinition of `__send__`

### DIFF
--- a/lib/rspec/mocks/verifying_double.rb
+++ b/lib/rspec/mocks/verifying_double.rb
@@ -17,7 +17,8 @@ module RSpec
         end
       end
 
-      if ::NoMethodError.method_defined?(:private_call?) # >= Ruby 2.4
+      if ::NoMethodError.method_defined?(:private_call?) && # >= Ruby 2.4
+         !(defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby")
         # Get rid of calling overridden `method_missing`
         missing_method = ::BasicObject.instance_method(:method_missing)
 

--- a/lib/rspec/mocks/verifying_double.rb
+++ b/lib/rspec/mocks/verifying_double.rb
@@ -34,23 +34,15 @@ module RSpec
         super
       end
 
-      # @private
-      module SilentIO
-        def self.method_missing(*); end
-        def self.respond_to?(*)
-          true
-        end
-      end
-
       # Redefining `__send__` causes ruby to issue a warning.
-      old, $stderr = $stderr, SilentIO
+      old, $VERBOSE = $VERBOSE, nil
       def __send__(name, *args, &block)
         @__sending_message = name
         super
       ensure
         @__sending_message = nil
       end
-      $stderr = old
+      $VERBOSE = old
 
       def send(name, *args, &block)
         __send__(name, *args, &block)


### PR DESCRIPTION
It may not be guaranteed in future versions.
