### PR TITLE
Add deprecation warnings for features to be removed/changed in RSpec 4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@ Bug Fixes:
 * Support keyword argument semantics when constraining argument expectations using
   `with` on Ruby 3.0+ (Yusuke Endoh, #1394)
 
+Deprecations:
+
+* Add RSpec 4 deprecation warnings. (Phil Pirozhkov, #1418)
+
 ### 3.10.2 / 2021-01-27
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.10.1...v3.10.2)
 

--- a/lib/rspec/mocks/configuration.rb
+++ b/lib/rspec/mocks/configuration.rb
@@ -80,6 +80,11 @@ module RSpec
       #
       def syntax=(*values)
         syntaxes = values.flatten
+        if self.class.warn_about_syntax?
+          RSpec.deprecate('Mocks syntax configuration',
+                          :replacement => 'the default `expect` syntax',
+                          :call_site => nil)
+        end
         if syntaxes.include?(:expect)
           Syntax.enable_expect
         else
@@ -87,6 +92,11 @@ module RSpec
         end
 
         if syntaxes.include?(:should)
+          if self.class.warn_about_syntax?
+            RSpec.deprecate('`:should` Mocks syntax',
+                            :replacement => 'the default `expect` syntax',
+                            :call_site => nil)
+          end
           Syntax.enable_should
         else
           Syntax.disable_should
@@ -199,6 +209,18 @@ module RSpec
         self.syntax = [:should, :expect]
         RSpec::Mocks::Syntax.warn_about_should!
       end
+
+      # @private
+      def self.warn_about_syntax?
+        @warn_about_syntax
+      end
+
+      # @private
+      def self.warn_about_syntax!
+        @warn_about_syntax = true
+      end
+
+      @warn_about_syntax = false
     end
 
     # Mocks specific configuration, as distinct from `RSpec.configuration`
@@ -208,5 +230,6 @@ module RSpec
     end
 
     configuration.reset_syntaxes_to_default
+    Configuration.warn_about_syntax!
   end
 end

--- a/lib/rspec/mocks/example_methods.rb
+++ b/lib/rspec/mocks/example_methods.rb
@@ -199,6 +199,8 @@ module RSpec
       # early on.
       # @deprecated Use {RSpec::Mocks::Configuration#allow_message_expectations_on_nil} instead.
       def allow_message_expectations_on_nil
+        RSpec.deprecate("`allow_message_expectations_on_nil` example method",
+                        :replacement => "`allow_message_expectations_on_nil` configuration option")
         RSpec::Mocks.space.proxy_for(nil).warn_about_expectations = false
       end
 

--- a/spec/rspec/mocks/configuration_spec.rb
+++ b/spec/rspec/mocks/configuration_spec.rb
@@ -68,6 +68,11 @@ module RSpec
             expect(::RSpec::Mocks::ExampleMethods).not_to receive(:method_added)
             configure_syntax :expect
           end
+
+          it 'emits a deprecation warning' do
+            expect_deprecation_without_call_site(/Mocks syntax configuration/)
+            configure_syntax :expect
+          end
         end
 
         context 'when configured to :should' do
@@ -89,14 +94,15 @@ module RSpec
             expect(configured_syntax).to eq([:should])
           end
 
-          it "does not warn about the should syntax" do
-            RSpec.should_not_receive(:deprecate)
-            Object.new.should_not_receive(:bees)
-          end
-
           it 'is a no-op when configured a second time' do
             Syntax.default_should_syntax_host.should_not_receive(:method_added)
             ::RSpec::Mocks::ExampleMethods.should_not_receive(:method_undefined)
+          end
+
+          it 'emits two deprecation warnings' do
+            configure_syntax :expect
+            expect_deprecation_without_call_site(/`:should` Mocks syntax/)
+            expect_deprecation_without_call_site(/Mocks syntax configuration/)
             configure_syntax :should
           end
         end
@@ -123,6 +129,12 @@ module RSpec
           it "does not warn about the should syntax" do
             expect(RSpec).not_to receive(:deprecate)
             expect(Object.new).not_to receive(:bees)
+          end
+
+          it 'emits two deprecation warnings' do
+            expect_deprecation_without_call_site(/`:should` Mocks syntax/)
+            expect_deprecation_without_call_site(/Mocks syntax configuration/)
+            configure_syntax [:should, :expect]
           end
         end
       end

--- a/spec/rspec/mocks/example_methods_spec.rb
+++ b/spec/rspec/mocks/example_methods_spec.rb
@@ -33,6 +33,17 @@ module RSpec
           expect(dbl.foo).to eq(1)
         end
       end
+
+      describe '#allow_message_expectations_on_nil' do
+        it "emits a deprecation warning on use" do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 3, /allow_message_expectations_on_nil/)
+          RSpec.describe do
+            it do
+              allow_message_expectations_on_nil
+            end
+          end.run
+        end
+      end
     end
   end
 end

--- a/spec/rspec/mocks/should_syntax_spec.rb
+++ b/spec/rspec/mocks/should_syntax_spec.rb
@@ -551,16 +551,6 @@ RSpec.context "with default syntax configuration" do
     o2.unstub(:faces)
   end
 
-  it "doesn't warn about stubbing after a reset and setting should" do
-    expect(RSpec).not_to receive(:deprecate)
-    RSpec::Mocks.configuration.reset_syntaxes_to_default
-    RSpec::Mocks.configuration.syntax = :should
-    o = Object.new
-    o2 = Object.new
-    o.stub(:faces)
-    o2.stub(:faces)
-  end
-
   it "includes the call site in the deprecation warning" do
     obj = Object.new
     expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,10 +87,7 @@ RSpec.configure do |config|
     expectations.syntax = :expect
   end
 
-  config.mock_with :rspec do |mocks|
-    $default_rspec_mocks_syntax = mocks.syntax
-    mocks.syntax = :expect
-  end
+  $default_rspec_mocks_syntax = [:should, :expect]
 
   old_verbose = nil
   config.before(:each, :silence_warnings) do


### PR DESCRIPTION
According to https://github.com/rspec/rspec-mocks/blob/4-0-dev/Changelog.md, only those two deprecation warnings are needed.

This is purposed to be released as version 3.99. Similar PRs for Expectations will follow.
Sibling PRs:
- https://github.com/rspec/rspec-core/pull/2880
- https://github.com/rspec/rspec-expectations/pull/1301

Release strategy: https://github.com/rspec/rspec-core/pull/2880#issuecomment-797756681
See https://github.com/rspec/rspec/issues/61
RSpec 4 plan: https://github.com/rspec/rspec/issues/61
Changes https://github.com/rspec/rspec-mocks/blob/4-0-dev/Changelog.md#development