### PR TITLE
Update Cucumber

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,2 +1,2 @@
-default: --require features --tags ~@wip features --format progress
+default: --require features --tags 'not @wip' features --format progress
 wip: --require features --tags @wip:3 --wip features

--- a/rspec-mocks.gemspec
+++ b/rspec-mocks.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "diff-lcs", ">= 1.4.4", "< 2.0"
 
   s.add_development_dependency 'rake',     '> 12.3.2'
-  s.add_development_dependency 'cucumber', '~> 1.3.15'
+  s.add_development_dependency 'cucumber', '>= 3.2', '!= 4.0.0', '< 8.0.0'
   s.add_development_dependency 'aruba',    '~> 0.14.10'
   s.add_development_dependency 'minitest', '~> 5.2'
 end


### PR DESCRIPTION
1.3-2.0 don't work for me locally with a weird error:
```
undefined method `[]' for nil:NilClass (NoMethodError) /Users/pirj/.rvm/gems/ruby-2.7.1@rspec-core/gems/cucumber-1.3.20/lib/cucumber/core_ext/proc.rb:17:in `file_colon_line'
```

2.4.0 spits "undefined method `with_filtered_backtrace`" in some other repository (`rspec-core` to my best memory)
3.2.0 - "undefined method `ok?`" there as well
4.1 depends on `diff-lcs (< 1.4, >= 1.3, ~> 1.3)`, while we depend on `= 1.4.4`

5.2.0 only supports Ruby > 2.5. we support >=2.3. But it depends on `diff-lcs` `>= 1.4.4`.

I've checked 3.2.0, 4.1.0, 5.3.0, 6.1.0, and they work (except for 4.1.0).

I vaguely recall we were discussing not running `cucumber` on older Rubies (2.3-2.4), is this correct?
Otherwise I'll roll back to 3.2.0.

Sibling PRs:
 - https://github.com/rspec/rspec-expectations/pull/1320
 - https://github.com/rspec/rspec-support/pull/517
 -  https://github.com/rspec/rspec-core/pull/2877