### PR TITLE
Fix persistence warning on JRuby when mocking a Java object wrapper

### DIFF
--- a/lib/rspec/mocks/instance_method_stasher.rb
+++ b/lib/rspec/mocks/instance_method_stasher.rb
@@ -5,6 +5,7 @@ module RSpec
       def initialize(object, method)
         @object = object
         @method = method
+        object.class.__persistent__ = true if object.respond_to?(:java_class)  # https://github.com/jruby/jruby/wiki/Persistence
         @klass = (class << object; self; end)
 
         @original_method = nil


### PR DESCRIPTION
This is enough to fix https://github.com/rspec/rspec-mocks/issues/1444