### PR TITLE
Allow Cucumber to run across Rubies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,10 @@ else
   gem 'json', '> 2.3.0'
 end
 
+if RUBY_VERSION < '2.0.0'
+  gem 'cucumber', "<= 1.3.22"
+end
+
 platforms :jruby do
   if RUBY_VERSION < '1.9.0'
     # Pin jruby-openssl on older J Ruby

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,2 +1,9 @@
-default: --require features --tags ~@wip features --format progress
+<%
+
+USE_TILDE_TAGS = !defined?(::RUBY_ENGINE_VERSION) || (::RUBY_ENGINE_VERSION < '2.0.0')
+NOT_WIP_TAG = USE_TILDE_TAGS ? '~@wip' : '"not @wip"'
+
+%>
+
+default: --require features --tags <%= NOT_WIP_TAG %> features --format progress
 wip: --require features --tags @wip:3 --wip features

--- a/features/support/disallow_certain_apis.rb
+++ b/features/support/disallow_certain_apis.rb
@@ -3,7 +3,8 @@
 
 if defined?(Cucumber)
   require 'shellwords'
-  Before('~@allow-old-syntax') do
+  tag = !defined?(::RUBY_ENGINE_VERSION) || (::RUBY_ENGINE_VERSION < '2.0.0') ? '~@allow-old-syntax' : 'not @allow-old-syntax'
+  Before(tag) do
     set_environment_variable('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
   end
 else

--- a/rspec-mocks.gemspec
+++ b/rspec-mocks.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
 
   s.add_development_dependency 'rake',     '> 10.0.0'
-  s.add_development_dependency 'cucumber', '~> 1.3.15'
+  s.add_development_dependency 'cucumber', '>= 1.3'
   s.add_development_dependency 'aruba',    '~> 0.14.10'
   s.add_development_dependency 'minitest', '~> 5.2'
 end


### PR DESCRIPTION
Makes the version of Cucumber to be more free-floating
Detect the current version of Cucumber (specifically for old JRubies) and use an appropriate tag syntax