### PR TITLE
Support more recent Rubygems and bundler for recent Rubies

### DIFF
--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -5,7 +5,11 @@
 set -e
 source script/functions.sh
 
-if is_ruby_23_plus; then
+if is_ruby_31_plus; then
+  yes | gem update --system '3.3.6'
+  yes | gem install bundler -v '2.3.6'
+elif is_ruby_23_plus; then
+  echo "Warning installing 3.2 / 2.2 versions of Rubygems / Bundler"
   yes | gem update --system '3.2.22'
   yes | gem install bundler -v '2.2.22'
 else


### PR DESCRIPTION
This PR fixes the CI failure for ruby-head by allowing Ruby versions 3.1.x and later to use a more recent rubygems / bundler.