### PR TITLE
Display keyword hashes in in expectation error messages

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -268,6 +268,17 @@ module RSpec
       def error_message(expectation, args_for_multiple_calls)
         expected_args = format_args(expectation.expected_args)
         actual_args = format_received_args(args_for_multiple_calls)
+
+        if RSpec::Support::RubyFeatures.distincts_kw_args_from_positional_hash? && expected_args == actual_args
+          expected_hash = expectation.expected_args.last
+          actual_hash = args_for_multiple_calls.last.last
+          if Hash === expected_hash && Hash === actual_hash &&
+            (Hash.ruby2_keywords_hash?(expected_hash) != Hash.ruby2_keywords_hash?(actual_hash))
+            actual_args += Hash.ruby2_keywords_hash?(actual_hash) ? " (keyword arguments)" : " (options hash)"
+            expected_args += Hash.ruby2_keywords_hash?(expected_hash) ? " (keyword arguments)" : " (options hash)"
+          end
+        end
+
         message = default_error_message(expectation, expected_args, actual_args)
 
         if args_for_multiple_calls.one?


### PR DESCRIPTION
Ref: https://github.com/vcr/vcr/pull/925
Ref: https://github.com/rspec/rspec-mocks/pull/1394

I spent quite a lot of time figuring this error:

```
  2) VCR.turned_on passes options through to .turn_off!
     Failure/Error: turn_off!(options)

       VCR received :turn_off! with unexpected arguments
         expected: ({:ignore_cassettes=>true})
              got: ({:ignore_cassettes=>true})
     # ./lib/vcr.rb:317:in `turned_on'
     # ./spec/lib/vcr_spec.rb:367:in `block (3 levels) in <top (required)>'
```

I quickly suspected it was a keyword argument issue, but it's far from
obvious to everyone, and even when you are familair with the issue
it doesn't tell you what was expected and what was received.

I doubt the way I implemented this is ok, but I think it's worth
opening the discussion

```
  2) VCR.turned_on passes options through to .turn_off!
     Failure/Error: turn_off!(options)

       VCR received :turn_off! with unexpected arguments
         expected: ({:ignore_cassettes=>true}) (keyword arguments)
              got: ({:ignore_cassettes=>true}) (options hash)
     # ./lib/vcr.rb:317:in `turned_on'
     # ./spec/lib/vcr_spec.rb:367:in `block (3 levels) in <top (required)>'
```