### PR TITLE
Add missing ruby2_keywords calls in rspec-mocks

### DIFF
--- a/lib/rspec/mocks/argument_list_matcher.rb
+++ b/lib/rspec/mocks/argument_list_matcher.rb
@@ -46,7 +46,7 @@ module RSpec
         @expected_args = expected_args
         ensure_expected_args_valid!
       end
-      ruby2_keywords :initialize if Module.private_method_defined?(:ruby2_keywords)
+      ruby2_keywords :initialize if respond_to?(:ruby2_keywords, true)
 
       # @api public
       # @param [Array] actual_args
@@ -71,6 +71,7 @@ module RSpec
 
         Support::FuzzyMatcher.values_match?(expected_args, actual_args)
       end
+      ruby2_keywords :args_match? if respond_to?(:ruby2_keywords, true)
 
       # @private
       # Resolves abstract arg placeholders like `no_args` and `any_args` into

--- a/lib/rspec/mocks/matchers/receive.rb
+++ b/lib/rspec/mocks/matchers/receive.rb
@@ -62,7 +62,7 @@ module RSpec
             @recorded_customizations << ExpectationCustomization.new(method, args, block)
             self
           end
-          ruby2_keywords(method) if Module.private_method_defined?(:ruby2_keywords)
+          ruby2_keywords(method) if respond_to?(:ruby2_keywords, true)
         end
 
       private

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -139,9 +139,12 @@ module RSpec
       #   counter.increment
       #   expect(counter.count).to eq(original_count + 1)
       def and_call_original
-        wrap_original(__method__) do |original, *args, &block|
-          original.call(*args, &block)
+        block = lambda do |original, *args, &b|
+          original.call(*args, &b)
         end
+        block = block.ruby2_keywords if block.respond_to?(:ruby2_keywords)
+
+        wrap_original(__method__, &block)
       end
 
       # Decorates the stubbed method with the supplied block. The original
@@ -364,7 +367,7 @@ module RSpec
         @argument_list_matcher = ArgumentListMatcher.new(*args)
         self
       end
-      ruby2_keywords(:with) if Module.private_method_defined?(:ruby2_keywords)
+      ruby2_keywords(:with) if respond_to?(:ruby2_keywords, true)
 
       # Expect messages to be received in a specific order.
       #
@@ -461,18 +464,22 @@ module RSpec
         def matches?(message, *args)
           @message == message && @argument_list_matcher.args_match?(*args)
         end
+        ruby2_keywords :matches? if respond_to?(:ruby2_keywords, true)
 
         def safe_invoke(parent_stub, *args, &block)
           invoke_incrementing_actual_calls_by(1, false, parent_stub, *args, &block)
         end
+        ruby2_keywords :safe_invoke if respond_to?(:ruby2_keywords, true)
 
         def invoke(parent_stub, *args, &block)
           invoke_incrementing_actual_calls_by(1, true, parent_stub, *args, &block)
         end
+        ruby2_keywords :invoke if respond_to?(:ruby2_keywords, true)
 
         def invoke_without_incrementing_received_count(parent_stub, *args, &block)
           invoke_incrementing_actual_calls_by(0, true, parent_stub, *args, &block)
         end
+        ruby2_keywords :invoke_without_incrementing_received_count if respond_to?(:ruby2_keywords, true)
 
         def negative?
           @expected_received_count == 0 && !@at_least
@@ -621,6 +628,7 @@ module RSpec
             @actual_received_count += increment
           end
         end
+        ruby2_keywords :invoke_incrementing_actual_calls_by if respond_to?(:ruby2_keywords, true)
 
         def has_been_invoked?
           @actual_received_count > 0
@@ -755,6 +763,7 @@ module RSpec
           action.call(*args, &block)
         end.last
       end
+      ruby2_keywords :call if respond_to?(:ruby2_keywords, true)
 
       def present?
         actions.any?
@@ -800,6 +809,7 @@ module RSpec
       def call(*args, &block)
         @block.call(@method, *args, &block)
       end
+      ruby2_keywords :call if respond_to?(:ruby2_keywords, true)
 
     private
 

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -63,6 +63,8 @@ module RSpec
           define_method(method_name) do |*args, &block|
             method_double.proxy_method_invoked(self, *args, &block)
           end
+          # This can't be `if respond_to?(:ruby2_keywords, true)`,
+          # see https://github.com/rspec/rspec-mocks/pull/1385#issuecomment-755340298
           ruby2_keywords(method_name) if Module.private_method_defined?(:ruby2_keywords)
           __send__(visibility, method_name)
         end
@@ -77,6 +79,7 @@ module RSpec
       def proxy_method_invoked(_obj, *args, &block)
         @proxy.message_received method_name, *args, &block
       end
+      ruby2_keywords :proxy_method_invoked if respond_to?(:ruby2_keywords, true)
 
       # @private
       def restore_original_method

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -230,6 +230,7 @@ module RSpec
           @object.__send__(:method_missing, message, *args, &block)
         end
       end
+      ruby2_keywords :message_received if respond_to?(:ruby2_keywords, true)
 
       # @private
       def raise_unexpected_message_error(method_name, args)
@@ -279,12 +280,14 @@ module RSpec
           expectation.matches?(method_name, *args)
         end
       end
+      ruby2_keywords :find_matching_expectation if respond_to?(:ruby2_keywords, true)
 
       def find_almost_matching_expectation(method_name, *args)
         find_best_matching_expectation_for(method_name) do |expectation|
           expectation.matches_name_but_not_args(method_name, *args)
         end
       end
+      ruby2_keywords :find_almost_matching_expectation if respond_to?(:ruby2_keywords, true)
 
       def find_best_matching_expectation_for(method_name)
         first_match = nil
@@ -301,10 +304,12 @@ module RSpec
       def find_matching_method_stub(method_name, *args)
         method_double_for(method_name).stubs.find { |stub| stub.matches?(method_name, *args) }
       end
+      ruby2_keywords :find_matching_method_stub if respond_to?(:ruby2_keywords, true)
 
       def find_almost_matching_stub(method_name, *args)
         method_double_for(method_name).stubs.find { |stub| stub.matches_name_but_not_args(method_name, *args) }
       end
+      ruby2_keywords :find_almost_matching_stub if respond_to?(:ruby2_keywords, true)
     end
 
     # @private
@@ -360,6 +365,7 @@ module RSpec
         end
         super
       end
+      ruby2_keywords :message_received if respond_to?(:ruby2_keywords, true)
 
     private
 


### PR DESCRIPTION
* And standardize checks to `if respond_to?(:ruby2_keywords, true)`.

cc @bjfish

This is progress towards https://github.com/rspec/rspec-metagem/issues/68.
Before: 25 failures, After: 2 failures left (which seem unrelated):
```
Failures:

  1) #any_instance when stubbing aliased methods tracks aliased method calls
     Failure/Error: parent_aliased_method
     
     NameError:
       undefined local variable or method `parent_aliased_method' for #<AnyInstanceSpec::ParentClass:0x2bb88>
     # ./spec/rspec/mocks/any_instance_spec.rb:20:in `caller_of_parent_aliased_method'
     # ./spec/rspec/mocks/any_instance_spec.rb:210:in `block (4 levels) in <module:Mocks>'

  2) Marshal extensions #dump when rspec-mocks has been fully initialized applying and unapplying patch is idempotent
     Failure/Error: expect { Marshal.dump(obj) }.to raise_error(TypeError)
       expected TypeError but nothing was raised
     # ./spec/rspec/mocks/marshal_extension_spec.rb:46:in `block (4 levels) in <top (required)>'
```

BTW, the reason the code worked before these `ruby2_keywords` seems accidental and due to a bug/inconsistency in CRuby: https://bugs.ruby-lang.org/issues/18625