### PR TITLE
Use a better and more reliable check for whether a method is the same as Class#new

### DIFF
--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -622,6 +622,24 @@ module RSpec
           end
         end
 
+        context "on a class with a twice-aliased `new`" do
+          it 'uses the method signature from `#initialize` for arg verification' do
+            if RUBY_VERSION.to_i < 3
+              pending "Failing due to Ruby 2's Method#== being too strict"
+            end
+
+            subclass = Class.new(klass) do
+              class << self
+                alias_method :_new, :new
+                alias_method :new, :_new
+              end
+            end
+
+            prevents(/arguments/) { allow(subclass).to receive(:new).with(1) }
+            allow(subclass).to receive(:new).with(1, 2)
+          end
+        end
+
         context 'on a class that has redefined `self.method`' do
           it 'allows the stubbing of :new' do
             subclass = Class.new(klass) do

--- a/spec/rspec/mocks/partial_double_spec.rb
+++ b/spec/rspec/mocks/partial_double_spec.rb
@@ -623,11 +623,7 @@ module RSpec
         end
 
         context "on a class with a twice-aliased `new`" do
-          it 'uses the method signature from `#initialize` for arg verification' do
-            if RUBY_VERSION.to_i < 3
-              pending "Failing due to Ruby 2's Method#== being too strict"
-            end
-
+          it 'uses the method signature from `#initialize` for arg verification', :if => (RUBY_VERSION.to_i >= 3) do
             subclass = Class.new(klass) do
               class << self
                 alias_method :_new, :new


### PR DESCRIPTION
* See https://bugs.ruby-lang.org/issues/18729#note-5

The added test would fail without the change.
This also helps for TruffleRuby support (https://github.com/rspec/rspec-metagem/issues/68), as TruffleRuby does not plan to replicate that CRuby inconsistency/bug (https://bugs.ruby-lang.org/issues/18729).