### PR TITLE
Fix `with` for instance doubles didn't verify Ruby 3 keyword arguments

### DIFF
--- a/lib/rspec/mocks/verifying_message_expectation.rb
+++ b/lib/rspec/mocks/verifying_message_expectation.rb
@@ -31,6 +31,7 @@ module RSpec
           end
         end
       end
+      ruby2_keywords(:with) if respond_to?(:ruby2_keywords, true)
 
     private
 

--- a/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
@@ -122,6 +122,29 @@ module RSpec
             }.to raise_error(ArgumentError, /no_args/)
           end
         end
+
+        if RSpec::Support::RubyFeatures.required_kw_args_supported?
+          context "for a method with keyword args" do
+            it "matches against a hash submitted as keyword arguments and received as positional argument (in both Ruby 2 and Ruby 3)" do
+              expect(dbl).to receive(:kw_args_method).with(1, {:required_arg => 2, :optional_arg => 3})
+              dbl.kw_args_method(1, :required_arg => 2, :optional_arg => 3)
+            end
+
+            if RUBY_VERSION >= "3"
+              it "fails to match against a hash submitted as a positional argument and received as keyword arguments in Ruby 3.0 or later", :reset => true do
+                expect(dbl).to receive(:kw_args_method).with(1, :required_arg => 2, :optional_arg => 3)
+                expect do
+                  dbl.kw_args_method(1, {:required_arg => 2, :optional_arg => 3})
+                end.to fail_with(/expected: \(1, {:optional_arg=>3, :required_arg=>2}\) \(keyword arguments\).*got: \(1, {:optional_arg=>3, :required_arg=>2}\) \(options hash\)/m)
+              end
+            else
+              it "matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 2.7 or before" do
+                expect(dbl).to receive(:kw_args_method).with(1, :required_arg => 2, :optional_arg => 3)
+                dbl.kw_args_method(1, {:required_arg => 2, :optional_arg => 3})
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
@@ -135,7 +135,7 @@ module RSpec
                 expect(dbl).to receive(:kw_args_method).with(1, :required_arg => 2, :optional_arg => 3)
                 expect do
                   dbl.kw_args_method(1, {:required_arg => 2, :optional_arg => 3})
-                end.to fail_with(/expected: \(1, {:optional_arg=>3, :required_arg=>2}\) \(keyword arguments\).*got: \(1, {:optional_arg=>3, :required_arg=>2}\) \(options hash\)/m)
+                end.to fail_with(a_string_including("expected: (1, {:optional_arg=>3, :required_arg=>2}) (keyword arguments)", "got: (1, {:optional_arg=>3, :required_arg=>2}) (options hash)"))
               end
             else
               it "matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 2.7 or before" do


### PR DESCRIPTION
This is a follow-up to https://github.com/rspec/rspec-mocks/pull/1394.

The change introduced in that PR handle a pure double, but not an instance double. 

The reason is that `VerifyingMessageExpectation` is a subclass of `MessageExpectation` with `with` method being overridden. That makes `ruby2_keywords` definition declared in the superclass to be "dropped" (and therefore to confuse the [`Hash.ruby2_keywords_hash?`](https://github.com/nashbridges/rspec-mocks/blob/7a0e363f3c081f0a49a3340e9eb0f41eba76af82/lib/rspec/mocks/argument_list_matcher.rb#L66-L68) check). 

I'm not fully sure if this is an expected Ruby behavior, but the current fix is to repeat the definition in the subclass.