### PR TITLE
Test against Class#new and not Class.new for the "is it #new from Class" check

### DIFF
--- a/lib/rspec/mocks/method_reference.rb
+++ b/lib/rspec/mocks/method_reference.rb
@@ -193,7 +193,7 @@ module RSpec
       end
 
       if RUBY_VERSION.to_i >= 3
-        CLASS_NEW = ::Class.singleton_class.instance_method(:new)
+        CLASS_NEW = ::Class.instance_method(:new)
 
         def self.uses_class_new?(klass)
           ::RSpec::Support.method_handle_for(klass, :new) == CLASS_NEW.bind(klass)


### PR DESCRIPTION
* On CRuby this makes currently no difference (there is no Class.new, only Class#new),
  but on TruffleRuby there is both (in order for Class objects to be fully initialized on creation, https://github.com/oracle/truffleruby/commit/8e8c501b3df2f54022be6f09304fd907e59a68ed).

Improves over https://github.com/rspec/rspec-mocks/pull/1470.

This helps for TruffleRuby support (https://github.com/rspec/rspec-metagem/issues/68).
Specifically it fixes this error: https://github.com/bjfish/rspec-core/runs/6857305517?check_suite_focus=true