### PR TITLE
Document receive(:msg).with(satisfy{|arg| ... })

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ expect(double).to receive(:msg).with(hash_including(:a => 5)) # first arg is a h
 expect(double).to receive(:msg).with(array_including(5)) # first arg is an array with 5 as one of the key-values
 expect(double).to receive(:msg).with(hash_excluding(:a => 5)) # first arg is a hash without a: 5 as one of the key-values
 expect(double).to receive(:msg).with(start_with('a')) # any matcher, custom or from rspec-expectations
-expect(double).to receive(:msg).with(satisfy{|data| data.dig(:a, :b, :c) == 5 }) # any expectation
+expect(double).to receive(:msg).with(satisfy { |data| data.dig(:a, :b, :c) == 5 }) # assert anything you want
 ```
 
 ## Receive Counts

--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ expect(double).to receive(:msg).with(1, duck_type(:abs, :div), "b") #2nd argumen
 expect(double).to receive(:msg).with(hash_including(:a => 5)) # first arg is a hash with a: 5 as one of the key-values
 expect(double).to receive(:msg).with(array_including(5)) # first arg is an array with 5 as one of the key-values
 expect(double).to receive(:msg).with(hash_excluding(:a => 5)) # first arg is a hash without a: 5 as one of the key-values
-expect(double).to receive(:msg).with(start_with('a')) # any matcher from rspec-expectations
-expect(double).to receive(:msg).with(satisfy{|arg| arg[:a] == 5 }) # any expectation
+expect(double).to receive(:msg).with(start_with('a')) # any matcher, custom or from rspec-expectations
+expect(double).to receive(:msg).with(satisfy{|data| data.dig(:a, :b, :c) == 5 }) # any expectation
 ```
 
 ## Receive Counts

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ expect(double).to receive(:msg).with(1, duck_type(:abs, :div), "b") #2nd argumen
 expect(double).to receive(:msg).with(hash_including(:a => 5)) # first arg is a hash with a: 5 as one of the key-values
 expect(double).to receive(:msg).with(array_including(5)) # first arg is an array with 5 as one of the key-values
 expect(double).to receive(:msg).with(hash_excluding(:a => 5)) # first arg is a hash without a: 5 as one of the key-values
+expect(double).to receive(:msg).with(start_with('a')) # any matcher from rspec-expectations
+expect(double).to receive(:msg).with(satisfy{|arg| arg[:a] == 5 }) # any expectation
 ```
 
 ## Receive Counts

--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -111,7 +111,7 @@ Feature: Matching arguments
   Scenario: Using a RSpec matcher
     Given a file named "rspec_matcher_spec.rb" with:
       """ruby
-      RSpec.describe "Using a RSpec matcher" do
+      RSpec.describe "Using any matcher from rspec-expectations" do
         let(:dbl) { double }
         before { expect(dbl).to receive(:foo).with(a_collection_containing_exactly(1, 2)) }
 
@@ -132,6 +132,36 @@ Feature: Matching arguments
       | #<Double (anonymous)> received :foo with unexpected arguments |
       | expected: (a collection containing exactly 1 and 2)           |
       | got: ([1, 3])                                                 |
+
+  Scenario: Using satisfy for any expectation
+    Given a file named "rspec_satisfy_spec.rb" with:
+      """ruby
+      RSpec.describe "Using satisfy for any expectation" do
+        let(:dbl) { double }
+        before do
+          expectation = satisfy do |arg|
+            arg[:a] == 5
+          end
+          expect(dbl).to receive(:foo).with(expectation)
+        end
+
+        it "passes when the expectation is true" do
+          dbl.foo(a: 5)
+        end
+
+        it "fails when the expectation is false" do
+          dbl.foo(a: 3)
+        end
+      end
+      """
+    When I run `rspec rspec_satisfy_spec.rb`
+    Then it should fail with the following output:
+      | 2 examples, 1 failure                                         |
+      |                                                               |
+      | Failure/Error: dbl.foo(a: 3)                                  |
+      | #<Double (anonymous)> received :foo with unexpected arguments |
+      | expected: (satisfy expression `arg[:a] == 5`)                 |
+      |      got: ({:a=>3})                                           |
 
   Scenario: Using a custom matcher
     Given a file named "custom_matcher_spec.rb" with:

--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -140,7 +140,7 @@ Feature: Matching arguments
         let(:dbl) { double }
         before do
           expectation = satisfy do |data|
-            data.dig(:a, :b, :c) == 5
+            data[:a][:b][:c] == 5
           end
           expect(dbl).to receive(:foo).with(expectation)
         end
@@ -160,7 +160,7 @@ Feature: Matching arguments
       |                                                               |
       | Failure/Error: dbl.foo(a: { b: { c: 3 } })                    |
       | #<Double (anonymous)> received :foo with unexpected arguments |
-      | expected: (satisfy expression `data.dig(:a, :b, :c) == 5`)    |
+      | expected: (satisfy expression `data[:a][:b][:c] == 5`)        |
       |      got: ({:a=>{:b=>{:c=>3}}})                               |
 
   Scenario: Using a custom matcher

--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -133,6 +133,7 @@ Feature: Matching arguments
       | expected: (a collection containing exactly 1 and 2)           |
       | got: ([1, 3])                                                 |
 
+  @ripper
   Scenario: Using satisfy for complex custom expecations
     Given a file named "rspec_satisfy_spec.rb" with:
       """ruby

--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -138,18 +138,18 @@ Feature: Matching arguments
       """ruby
       RSpec.describe "Using satisfy for complex custom expecations" do
         let(:dbl) { double }
-        before do
-          expectation = satisfy do |data|
-            data[:a][:b][:c] == 5
-          end
-          expect(dbl).to receive(:foo).with(expectation)
+
+        def a_b_c_equals_5
+          satisfy { |data| data[:a][:b][:c] == 5 }
         end
 
         it "passes when the expectation is true" do
+          expect(dbl).to receive(:foo).with(a_b_c_equals_5)
           dbl.foo(a: { b: { c: 5 } })
         end
 
         it "fails when the expectation is false" do
+          expect(dbl).to receive(:foo).with(a_b_c_equals_5)
           dbl.foo(a: { b: { c: 3 } })
         end
       end

--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -111,7 +111,7 @@ Feature: Matching arguments
   Scenario: Using a RSpec matcher
     Given a file named "rspec_matcher_spec.rb" with:
       """ruby
-      RSpec.describe "Using a Rspec matcher" do
+      RSpec.describe "Using a RSpec matcher" do
         let(:dbl) { double }
         before { expect(dbl).to receive(:foo).with(a_collection_containing_exactly(1, 2)) }
 

--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -145,12 +145,12 @@ Feature: Matching arguments
 
         it "passes when the expectation is true" do
           expect(dbl).to receive(:foo).with(a_b_c_equals_5)
-          dbl.foo(a: { b: { c: 5 } })
+          dbl.foo({ :a => { :b=> { :c => 5 } } })
         end
 
         it "fails when the expectation is false" do
           expect(dbl).to receive(:foo).with(a_b_c_equals_5)
-          dbl.foo(a: { b: { c: 3 } })
+          dbl.foo({ :a => { :b=> { :c => 3 } } })
         end
       end
       """
@@ -158,7 +158,7 @@ Feature: Matching arguments
     Then it should fail with the following output:
       | 2 examples, 1 failure                                         |
       |                                                               |
-      | Failure/Error: dbl.foo(a: { b: { c: 3 } })                    |
+      | Failure/Error: dbl.foo({ :a => { :b=> { :c => 3 } } })        |
       | #<Double (anonymous)> received :foo with unexpected arguments |
       | expected: (satisfy expression `data[:a][:b][:c] == 5`)        |
       |      got: ({:a=>{:b=>{:c=>3}}})                               |

--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -111,7 +111,7 @@ Feature: Matching arguments
   Scenario: Using a RSpec matcher
     Given a file named "rspec_matcher_spec.rb" with:
       """ruby
-      RSpec.describe "Using any matcher from rspec-expectations" do
+      RSpec.describe "Using a Rspec matcher" do
         let(:dbl) { double }
         before { expect(dbl).to receive(:foo).with(a_collection_containing_exactly(1, 2)) }
 
@@ -133,24 +133,24 @@ Feature: Matching arguments
       | expected: (a collection containing exactly 1 and 2)           |
       | got: ([1, 3])                                                 |
 
-  Scenario: Using satisfy for any expectation
+  Scenario: Using satisfy for complex custom expecations
     Given a file named "rspec_satisfy_spec.rb" with:
       """ruby
-      RSpec.describe "Using satisfy for any expectation" do
+      RSpec.describe "Using satisfy for complex custom expecations" do
         let(:dbl) { double }
         before do
-          expectation = satisfy do |arg|
-            arg[:a] == 5
+          expectation = satisfy do |data|
+            data.dig(:a, :b, :c) == 5
           end
           expect(dbl).to receive(:foo).with(expectation)
         end
 
         it "passes when the expectation is true" do
-          dbl.foo(a: 5)
+          dbl.foo(a: { b: { c: 5 } })
         end
 
         it "fails when the expectation is false" do
-          dbl.foo(a: 3)
+          dbl.foo(a: { b: { c: 3 } })
         end
       end
       """
@@ -158,10 +158,10 @@ Feature: Matching arguments
     Then it should fail with the following output:
       | 2 examples, 1 failure                                         |
       |                                                               |
-      | Failure/Error: dbl.foo(a: 3)                                  |
+      | Failure/Error: dbl.foo(a: { b: { c: 3 } })                    |
       | #<Double (anonymous)> received :foo with unexpected arguments |
-      | expected: (satisfy expression `arg[:a] == 5`)                 |
-      |      got: ({:a=>3})                                           |
+      | expected: (satisfy expression `data.dig(:a, :b, :c) == 5`)    |
+      |      got: ({:a=>{:b=>{:c=>3}}})                               |
 
   Scenario: Using a custom matcher
     Given a file named "custom_matcher_spec.rb" with:

--- a/features/setting_constraints/matching_arguments.feature
+++ b/features/setting_constraints/matching_arguments.feature
@@ -145,12 +145,12 @@ Feature: Matching arguments
 
         it "passes when the expectation is true" do
           expect(dbl).to receive(:foo).with(a_b_c_equals_5)
-          dbl.foo({ :a => { :b=> { :c => 5 } } })
+          dbl.foo({ :a => { :b => { :c => 5 } } })
         end
 
         it "fails when the expectation is false" do
           expect(dbl).to receive(:foo).with(a_b_c_equals_5)
-          dbl.foo({ :a => { :b=> { :c => 3 } } })
+          dbl.foo({ :a => { :b => { :c => 3 } } })
         end
       end
       """
@@ -158,7 +158,7 @@ Feature: Matching arguments
     Then it should fail with the following output:
       | 2 examples, 1 failure                                         |
       |                                                               |
-      | Failure/Error: dbl.foo({ :a => { :b=> { :c => 3 } } })        |
+      | Failure/Error: dbl.foo({ :a => { :b => { :c => 3 } } })       |
       | #<Double (anonymous)> received :foo with unexpected arguments |
       | expected: (satisfy expression `data[:a][:b][:c] == 5`)        |
       |      got: ({:a=>{:b=>{:c=>3}}})                               |

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,6 +21,17 @@ Before do
   end
 end
 
+Before('@ripper') do |scenario|
+  unless RSpec::Support::RubyFeatures.ripper_supported?
+    warn "Skipping scenario due to lack of Ripper support"
+    if Cucumber::VERSION.to_f >= 3.0
+      skip_this_scenario
+    else
+      scenario.skip_invoke!
+    end
+  end
+end
+
 Before('@kw-arguments') do |scenario|
   unless RSpec::Support::RubyFeatures.kw_args_supported?
     warn "Skipping scenario due to lack of keyword argument support"


### PR DESCRIPTION
This is the combination I've been looking for, but that has eluded me for years.

The [readme](https://github.com/rspec/rspec-mocks#argument-matchers) and the table in the  [relish docs](https://relishapp.com/rspec/rspec-mocks/v/3-11/docs/setting-constraints/matching-arguments) both mention that any matcher can be used, but it never occurred to me to combine `with` with `satisfy`.

I've added 2 example usages to the readme and added a Cucumber story to document this combination.

The [documentation](https://www.rubydoc.info/gems/rspec-expectations/3.11.0/RSpec/Matchers#satisfy-instance_method) for `satisfy` suggest to write a custom matcher, but that feels over the top for many one-off situations.