### PR TITLE
Reduce recorder memory usage

### DIFF
--- a/benchmarks/allocations/2_lambda_ref_find.rb
+++ b/benchmarks/allocations/2_lambda_ref_find.rb
@@ -1,0 +1,118 @@
+require 'memory_profiler'
+
+n = 10_000
+
+def find_with_proc(argument)
+  lambda do |lambda_arg|
+    lambda_arg == argument
+  end
+end
+
+def find(argument, lambda_arg)
+  lambda_arg == argument
+end
+
+puts "#{n} items - ruby #{RUBY_VERSION}"
+
+puts
+puts "find_with_proc"
+
+MemoryProfiler.report do
+  100.times do
+  1.upto(n).select(&find_with_proc(50))
+  end
+end.pretty_print
+
+puts
+puts "find"
+
+MemoryProfiler.report do
+  100.times do
+    1.upto(n).select { find(50, _1) }
+  end
+end.pretty_print
+
+# $ ruby benchmarks/allocations/2_lambda_ref_find.rb
+# 10000 items - ruby 3.2.2
+#
+# find_with_proc
+# Total allocated: 29600 bytes (400 objects)
+# Total retained:  0 bytes (0 objects)
+#
+# allocated memory by gem
+# -----------------------------------
+#      29600  other
+#
+# allocated memory by file
+# -----------------------------------
+#      29600  benchmarks/allocations/2_lambda_ref_find.rb
+#
+# allocated memory by location
+# -----------------------------------
+#      21600  benchmarks/allocations/2_lambda_ref_find.rb:22
+#       8000  benchmarks/allocations/2_lambda_ref_find.rb:6
+#
+# allocated memory by class
+# -----------------------------------
+#      13600  Enumerator
+#       8000  Array
+#       8000  Proc
+#
+# allocated objects by gem
+# -----------------------------------
+#        400  other
+#
+# allocated objects by file
+# -----------------------------------
+#        400  benchmarks/allocations/2_lambda_ref_find.rb
+#
+# allocated objects by location
+# -----------------------------------
+#        300  benchmarks/allocations/2_lambda_ref_find.rb:22
+#        100  benchmarks/allocations/2_lambda_ref_find.rb:6
+#
+# allocated objects by class
+# -----------------------------------
+#        200  Array
+#        100  Enumerator
+#        100  Proc
+#
+#
+# find
+# Total allocated: 21600 bytes (300 objects)
+# Total retained:  0 bytes (0 objects)
+#
+# allocated memory by gem
+# -----------------------------------
+#      21600  other
+#
+# allocated memory by file
+# -----------------------------------
+#      21600  benchmarks/allocations/2_lambda_ref_find.rb
+#
+# allocated memory by location
+# -----------------------------------
+#      21600  benchmarks/allocations/2_lambda_ref_find.rb:31
+#
+# allocated memory by class
+# -----------------------------------
+#      13600  Enumerator
+#       8000  Array
+#
+# allocated objects by gem
+# -----------------------------------
+#        300  other
+#
+# allocated objects by file
+# -----------------------------------
+#        300  benchmarks/allocations/2_lambda_ref_find.rb
+#
+# allocated objects by location
+# -----------------------------------
+#        300  benchmarks/allocations/2_lambda_ref_find.rb:31
+#
+# allocated objects by class
+# -----------------------------------
+#        200  Array
+#        100  Enumerator
+#

--- a/benchmarks/allocations/lambda_vs_block_with_select.rb
+++ b/benchmarks/allocations/lambda_vs_block_with_select.rb
@@ -19,7 +19,7 @@ puts "find_with_proc"
 
 MemoryProfiler.report do
   100.times do
-  1.upto(n).select(&find_with_proc(50))
+    1.upto(n).select(&find_with_proc(50))
   end
 end.pretty_print
 
@@ -28,7 +28,7 @@ puts "find"
 
 MemoryProfiler.report do
   100.times do
-    1.upto(n).select { find(50, _1) }
+    1.upto(n).select { |i| find(50, i) }
   end
 end.pretty_print
 
@@ -115,4 +115,3 @@ end.pretty_print
 # -----------------------------------
 #        200  Array
 #        100  Enumerator
-#

--- a/lib/rspec/mocks/any_instance/recorder.rb
+++ b/lib/rspec/mocks/any_instance/recorder.rb
@@ -156,21 +156,23 @@ module RSpec
 
       private
 
-        def ancestor_is_an_observer?(method_name)
-          lambda do |ancestor|
-            unless ancestor == @klass
-              ::RSpec::Mocks.space.
-                any_instance_recorder_for(ancestor).already_observing?(method_name)
-            end
-          end
+        def ancestor_is_an_observer?(ancestor, method_name)
+          return if ancestor == @klass
+
+          ::RSpec::Mocks.space.
+            any_instance_recorder_for(ancestor).already_observing?(method_name)
         end
 
         def super_class_observers_for(method_name)
-          @klass.ancestors.select(&ancestor_is_an_observer?(method_name))
+          @klass.ancestors.select do |ancestor|
+            ancestor_is_an_observer?(ancestor, method_name)
+          end
         end
 
         def super_class_observing?(method_name)
-          @klass.ancestors.any?(&ancestor_is_an_observer?(method_name))
+          @klass.ancestors.any? do |ancestor|
+            ancestor_is_an_observer?(ancestor, method_name)
+          end
         end
 
         def normalize_chain(*args)


### PR DESCRIPTION
Before this change in my test suite:

```sh
allocated memory by gem
-----------------------------------
 450.63 MB  rspec-mocks-3.11.0
 250.91 MB  activesupport-5.2.8.1
 247.35 MB  activerecord-5.2.8.1
```

After this change in my test suite:

```sh
allocated memory by gem
-----------------------------------
 250.92 MB  activesupport-5.2.8.1
 247.36 MB  activerecord-5.2.8.1
 198.83 MB  rspec-mocks-3.11.0
```