### PR TITLE
Don't convert keywords to hash in #send for verifying doubles on Ruby 3

### DIFF
--- a/lib/rspec/mocks/verifying_double.rb
+++ b/lib/rspec/mocks/verifying_double.rb
@@ -42,11 +42,13 @@ module RSpec
       ensure
         @__sending_message = nil
       end
+      ruby2_keywords :__send__ if respond_to?(:ruby2_keywords, true)
       $VERBOSE = old
 
       def send(name, *args, &block)
         __send__(name, *args, &block)
       end
+      ruby2_keywords :send if respond_to?(:ruby2_keywords, true)
 
       def initialize(doubled_module, *args)
         @doubled_module = doubled_module

--- a/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
@@ -143,6 +143,15 @@ module RSpec
                 dbl.kw_args_method(1, {:required_arg => 2, :optional_arg => 3})
               end
             end
+
+            context "when using `send`" do
+              let(:dbl) { instance_double(Class.new { eval "def m(k:); end" }) }
+
+              it "matches against keyword arguments" do
+                expect(dbl).to receive(:m).with(:k => 1)
+                dbl.send(:m, :k => 1)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
The current re-implementation of `send` on verifying doubles uses `*args` by itself. Everything works fine on `main` for Ruby 2 or lower, but on Ruby 3 this converts keyword arguments to a Hash element inside the `args` array, which then gets passed to `__send__` and then `super` and (correctly) causes a failure when the method gets a Hash instead of keywords.

Without this patch, the new test passes on Ruby 2.7.6 and fails on Ruby 3.1.2:
```
Failures:

  1) Expected argument verification (when `#with` is called) when doubling a loaded class for a method with keyword args when using `send` matches against keyword arguments
     Failure/Error: dbl.send(:m, :k => 1)
     
       #<InstanceDouble(#<Class:0x00007fbd16cf1ba8>) (anonymous)> received :m with unexpected arguments
         expected: ({:k=>1}) (keyword arguments)
              got: ({:k=>1}) (options hash)
       Diff:
```

With this patch, all tests pass on all Ruby versions.