### PR TITLE
Prevent missing chains from failing the expectation when dealing with super/sub classes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ Bug Fixes:
 * Change check to detect frozen objects to rescue errors rather than
   pre-empting by checking `frozen?` due to some objects mis-behaving.
   (Keegan Roth, #1401)
+* Prevent unfulfilled expectations using `expect_any_instance_of` across a class
+  inheritance boundary from raising rather than failing. (Jon Rowe, #1496)
 
 ### 3.12.0 / 2022-10-26
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.11.2...v3.12.0)

--- a/lib/rspec/mocks/any_instance/message_chains.rb
+++ b/lib/rspec/mocks/any_instance/message_chains.rb
@@ -49,7 +49,7 @@ module RSpec
         # @private
         def unfulfilled_expectations
           @chains_by_method_name.map do |method_name, chains|
-            method_name.to_s if ExpectationChain === chains.last unless chains.last.expectation_fulfilled?
+            method_name.to_s if ExpectationChain === chains.last && !chains.last.expectation_fulfilled?
           end.compact
         end
 

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -133,7 +133,7 @@ module RSpec
 
         context "behaves as 'every instance'" do
           let(:super_class) { Class.new { def foo; 'bar'; end } }
-          let(:sub_class)   { Class.new(super_class) }
+          let(:sub_class)   { Class.new(super_class) { def bar; 'foo'; end } }
 
           it "stubs every instance in the spec" do
             allow_any_instance_of(klass).to receive(:foo).and_return(result = Object.new)
@@ -158,6 +158,15 @@ module RSpec
             allow_any_instance_of(super_class).to receive(:foo)
             allow_any_instance_of(sub_class).to receive(:foo).and_return('baz')
             expect(sub_class.new.foo).to eq('baz')
+          end
+
+          it 'handles stubbing on a sub class when a super class is stubbed differently' do
+            expect_any_instance_of(super_class).to receive(:foo)
+            expect_any_instance_of(sub_class).to receive(:bar).and_return('baz')
+            expect(sub_class.new.bar).to eq('baz')
+            expect {
+              verify_all
+            }.to fail_with "Exactly one instance should have received the following message(s) but didn't: foo"
           end
 
           it 'handles method restoration on subclasses' do


### PR DESCRIPTION
Fixes #1496 