### PR TITLE
Fixup argument forwarding on ruby-3.2

### DIFF
--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -160,6 +160,7 @@ module RSpec
         validate_arguments!(args)
         super
       end
+      ruby2_keywords :proxy_method_invoked if respond_to?(:ruby2_keywords, true)
 
       def validate_arguments!(actual_args)
         @method_reference.with_signature do |signature|


### PR DESCRIPTION
Fixes #1495
close #1497

Depends on https://github.com/rspec/rspec-support/pull/553