### PR TITLE
Use a more common matcher name method to support other matchers

### DIFF
--- a/lib/rspec/mocks/matchers/have_received.rb
+++ b/lib/rspec/mocks/matchers/have_received.rb
@@ -16,7 +16,7 @@ module RSpec
           @subject = nil
         end
 
-        def name
+        def matcher_name
           "have_received"
         end
 

--- a/lib/rspec/mocks/matchers/receive.rb
+++ b/lib/rspec/mocks/matchers/receive.rb
@@ -13,7 +13,7 @@ module RSpec
           @recorded_customizations = []
         end
 
-        def name
+        def matcher_name
           "receive"
         end
 

--- a/lib/rspec/mocks/matchers/receive_message_chain.rb
+++ b/lib/rspec/mocks/matchers/receive_message_chain.rb
@@ -20,7 +20,7 @@ module RSpec
           end
         end
 
-        def name
+        def matcher_name
           "receive_message_chain"
         end
 

--- a/lib/rspec/mocks/matchers/receive_messages.rb
+++ b/lib/rspec/mocks/matchers/receive_messages.rb
@@ -10,7 +10,7 @@ module RSpec
           @backtrace_line = CallerFilter.first_non_rspec_line
         end
 
-        def name
+        def matcher_name
           "receive_messages"
         end
 

--- a/lib/rspec/mocks/targets.rb
+++ b/lib/rspec/mocks/targets.rb
@@ -54,7 +54,7 @@ module RSpec
 
       def raise_negation_unsupported(method_name, matcher)
         raise NegationUnsupportedError,
-              "`#{expression}(...).#{method_name} #{matcher.name}` is not supported since it " \
+              "`#{expression}(...).#{method_name} #{matcher.matcher_name}` is not supported since it " \
               "doesn't really make sense. What would it even mean?"
       end
     end

--- a/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_spec.rb
@@ -641,6 +641,12 @@ module RSpec
             expect(3).to eq(3)
           end
         end
+
+        it 'with a nonsense allowance it fails with a reasonable error message' do
+          expect {
+            allow(true).not_to be_nil
+          }.to raise_error(start_with("`allow(...).not_to be_nil` is not supported since it doesn't really make sense"))
+        end
       end
 
       context "when rspec-expectations is included in the test framework last" do


### PR DESCRIPTION
Previously,

```ruby
    allow(true).not_to be_nil
```

failed with:

```
#<NoMethodError: undefined method `name' for #<RSpec::Matchers::BuiltIn::BeNil:0x00007f844b43a798>> with backtrace:
```
 
`matcher_name` is what we use in `rspec-expectations` https://github.com/rspec/rspec-expectations/blob/43bf64b01f8356979ffbc373b2e81d2ab1389b29/lib/rspec/matchers/built_in/base_matcher.rb#L107