### PR TITLE
Improve error generator

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -269,13 +269,19 @@ module RSpec
         expected_args = format_args(expectation.expected_args)
         actual_args = format_received_args(args_for_multiple_calls)
 
-        if RSpec::Support::RubyFeatures.distincts_kw_args_from_positional_hash? && expected_args == actual_args
+        if RSpec::Support::RubyFeatures.distincts_kw_args_from_positional_hash?
           expected_hash = expectation.expected_args.last
           actual_hash = args_for_multiple_calls.last.last
           if Hash === expected_hash && Hash === actual_hash &&
             (Hash.ruby2_keywords_hash?(expected_hash) != Hash.ruby2_keywords_hash?(actual_hash))
-            actual_args += Hash.ruby2_keywords_hash?(actual_hash) ? " (keyword arguments)" : " (options hash)"
-            expected_args += Hash.ruby2_keywords_hash?(expected_hash) ? " (keyword arguments)" : " (options hash)"
+
+            actual_description = Hash.ruby2_keywords_hash?(actual_hash) ? " (keyword arguments)" : " (options hash)"
+            expected_description = Hash.ruby2_keywords_hash?(expected_hash) ? " (keyword arguments)" : " (options hash)"
+
+            if actual_description != expected_description
+              actual_args += actual_description
+              expected_args += expected_description
+            end
           end
         end
 
@@ -284,7 +290,7 @@ module RSpec
         if args_for_multiple_calls.one?
           diff = diff_message(expectation.expected_args, args_for_multiple_calls.first)
           if RSpec::Mocks.configuration.color?
-            message << "\nDiff:#{diff}" unless diff.gsub(/\e\[\d+m/,'').strip.empty?
+            message << "\nDiff:#{diff}" unless diff.gsub(/\e\[\d+m/, '').strip.empty?
           else
             message << "\nDiff:#{diff}" unless diff.strip.empty?
           end

--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -283,7 +283,11 @@ module RSpec
 
         if args_for_multiple_calls.one?
           diff = diff_message(expectation.expected_args, args_for_multiple_calls.first)
-          message << "\nDiff:#{diff}" unless diff.strip.empty?
+          if RSpec::Mocks.configuration.color?
+            message << "\nDiff:#{diff}" unless diff.gsub(/\e\[\d+m/,'').strip.empty?
+          else
+            message << "\nDiff:#{diff}" unless diff.strip.empty?
+          end
         end
 
         message

--- a/spec/rspec/mocks/diffing_spec.rb
+++ b/spec/rspec/mocks/diffing_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
       with_unfulfilled_double do |d|
         expect(d).to receive(:foo).with(expected_hash)
         expect {
-          d.foo(:bad => :hash)
+          d.foo({:bad => :hash})
         }.to fail_with(/\A#<Double "double"> received :foo with unexpected arguments\n  expected: \(#{hash_regex_inspect expected_hash}\)\n       got: \(#{hash_regex_inspect actual_hash}\)\nDiff:\n@@ #{Regexp.escape one_line_header} @@\n\-\[#{hash_regex_inspect expected_hash}\]\n\+\[#{hash_regex_inspect actual_hash}\]\n\z/)
       end
     end

--- a/spec/rspec/mocks/diffing_spec.rb
+++ b/spec/rspec/mocks/diffing_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe "Diffs printed when arguments don't match" do
       end
     end
 
+    it "does not print a diff when differ returns a string of only whitespace when colour is enabled" do
+      allow(RSpec::Mocks.configuration).to receive(:color?) { true }
+      differ = instance_double(RSpec::Support::Differ, :diff => "\e[0m\n  \t\e[0m")
+      allow(RSpec::Support::Differ).to receive_messages(:new => differ)
+
+      with_unfulfilled_double do |d|
+        expect(d).to receive(:foo).with("some string\nline2")
+        expect {
+          d.foo("this other string")
+        }.to fail_with(a_string_excluding("Diff:"))
+      end
+    end
+
     it "prints a diff of the strings for individual mismatched multi-line string arguments" do
       with_unfulfilled_double do |d|
         expect(d).to receive(:foo).with("some string\nline2")

--- a/spec/rspec/mocks/diffing_spec.rb
+++ b/spec/rspec/mocks/diffing_spec.rb
@@ -128,6 +128,32 @@ RSpec.describe "Diffs printed when arguments don't match" do
             end
           end
         RUBY
+
+        eval <<-'RUBY', nil, __FILE__, __LINE__ + 1
+          it "prints a diff when the positional argument doesnt match" do
+            with_unfulfilled_double do |d|
+              input = Class.new
+
+              expected_input = input.new()
+              actual_input = input.new()
+
+              expect(d).to receive(:foo).with(expected_input, one: 1)
+
+              expect {
+                options = { one: 1 }
+                d.foo(actual_input, options)
+              }.to fail_with(
+                "#<Double \"double\"> received :foo with unexpected arguments\n" \
+                "  expected: (#{expected_input.inspect}, {:one=>1}) (keyword arguments)\n" \
+                "       got: (#{actual_input.inspect}, {:one=>1}) (options hash)\n" \
+                "Diff:\n" \
+                "@@ -1 +1 @@\n" \
+                "-[#{expected_input.inspect}, {:one=>1}]\n" \
+                "+[#{actual_input.inspect}, {:one=>1}]\n"
+              )
+            end
+          end
+        RUBY
       end
     end
 
@@ -167,6 +193,30 @@ RSpec.describe "Diffs printed when arguments don't match" do
               "#{d.inspect} received :foo with unexpected arguments\n" \
               "  expected: (:positional, {:keyword=>1}) (keyword arguments)\n" \
               "       got: (:positional, {:keyword=>1}) (options hash)"
+            )
+          end
+        RUBY
+
+        eval <<-'RUBY', nil, __FILE__, __LINE__ + 1
+          it "prints a diff when the positional argument doesnt match" do
+            input = Class.new
+
+            expected_input = input.new()
+            actual_input = input.new()
+
+            expect(d).to receive(:foo).with(expected_input, one: 1)
+
+            expect {
+              options = { one: 1 }
+              d.foo(actual_input, options)
+            }.to fail_with(
+              "#{d.inspect} received :foo with unexpected arguments\n" \
+              "  expected: (#{expected_input.inspect}, {:one=>1}) (keyword arguments)\n" \
+              "       got: (#{actual_input.inspect}, {:one=>1}) (options hash)\n" \
+              "Diff:\n" \
+              "@@ -1 +1 @@\n" \
+              "-[#{expected_input.inspect}, {:one=>1}]\n" \
+              "+[#{actual_input.inspect}, {:one=>1}]\n"
             )
           end
         RUBY


### PR DESCRIPTION
The previous implementation of our keyword vs hash highlight only added the difference when arguments matched, this leads to confusion because the argument matcher check this in reverse (e.g. if the keywords / vs hash doesn't match it fast fails) meaning that RSpec can be ambiguous about whats failing to be more consitent we can show the extra diff information all the time if they mis match.

As an aside this PR also fixes an inconsitency with our empty diff "trim" logic where colourisation would produce an empty:

```
Diff:
```

As well as this the PR improves the specs by adding partial double checks as well (as given the keyword semantics these can exhibit different behaviour).

Fixes #1504