### PR TITLE
Fix mocking keyword args via block implementation in Ruby 3.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Bug Fixes:
   inheritance boundary from raising rather than failing. (Jon Rowe, #1496)
 * Prevent a misleading error message when using `allow(...).not_to` with
   unsupported matchers. (Phil Pirozhkov, #1503)
+* Fix mocking keyword args for `have_received` with a block. (Adam Steel, #1508)
 
 ### 3.12.0 / 2022-10-26
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.11.2...v3.12.0)

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -192,6 +192,7 @@ module RSpec
           @messages_received << [message, args, block]
         end
       end
+      ruby2_keywords :record_message_received if respond_to?(:ruby2_keywords, true)
 
       # @private
       def message_received(message, *args, &block)

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -107,6 +107,20 @@ module RSpec
           }.to_not raise_error
         end
 
+        if RSpec::Support::RubyFeatures.required_kw_args_supported?
+          it "passes if expectations against yielded keyword arguments pass" do
+            binding.eval(<<-RUBY, __FILE__, __LINE__)
+              dbl = double(:foo => nil)
+              yielded = []
+              dbl.foo(a: 1)
+              expect(dbl).to have_received(:foo) do |a:|
+                yielded << a
+              end
+              _expect(yielded).to eq([1])
+            RUBY
+          end
+        end
+
         it "fails if expectations against the yielded arguments fail" do
           dbl = double(:foo => nil)
           dbl.foo(43)


### PR DESCRIPTION
👀 Check out first commit and switch Ruby versions 3.1.1 -> 3.20 to see passing -> failing spec, then check out second commit to see specs pass in both.

Default flag `ruby2_keywords` was declared a Ruby 3.0 bug and removed
in Ruby 3.2. All methods that take `*args` that we also want to use to
support keyword args must be explicitly instrumented via the
`ruby2_keywords` method.

https://github.com/ruby/ruby/blob/07c19cf551e58e1b82af5efeb0047f10588fff9f/NEWS.md