### PR TITLE
Fix argument forwarding for "receive" with Ruby 3.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.2'
           - '3.1'
           - '3.0'
           - 2.7

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ Bug Fixes:
 * Prevent a misleading error message when using `allow(...).not_to` with
   unsupported matchers. (Phil Pirozhkov, #1503)
 * Fix mocking keyword args for `have_received` with a block. (Adam Steel, #1508)
+* Fix mocking keyword args for `received` with Ruby 3.2.0. (Slava Kardakov,
+  Benoit Tigeot, Phil Pirozhkov, Benoit Daloze, #1514)
 
 ### 3.12.0 / 2022-10-26
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.11.2...v3.12.0)

--- a/lib/rspec/mocks/argument_list_matcher.rb
+++ b/lib/rspec/mocks/argument_list_matcher.rb
@@ -61,7 +61,9 @@ module RSpec
         return false if expected_args.size != actual_args.size
 
         if RUBY_VERSION >= "3"
-          # if both arguments end with Hashes, and if one is a keyword hash and the other is not, they don't match
+          # If the expectation was set with keywords, while the actual method was called with a positional hash argument, they don't match.
+          # If the expectation was set without keywords, e.g., with({a: 1}), then it fine to call it with either foo(a: 1) or foo({a: 1}).
+          # This corresponds to Ruby semantics, as if the method was def foo(options).
           if Hash === expected_args.last && Hash === actual_args.last
             if !Hash.ruby2_keywords_hash?(actual_args.last) && Hash.ruby2_keywords_hash?(expected_args.last)
               return false

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -160,6 +160,7 @@ module RSpec
         validate_arguments!(args)
         super
       end
+      ruby2_keywords :proxy_method_invoked if respond_to?(:ruby2_keywords, true)
 
       def validate_arguments!(actual_args)
         @method_reference.with_signature do |signature|

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -388,7 +388,7 @@ module RSpec
         end
 
         if RUBY_VERSION >= "3"
-          it "fails to matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 3.0 or later", :reset => true do
+          it "fails to match against a hash submitted as a positional argument and received as keyword arguments in Ruby 3.0 or later", :reset => true do
             opts = {:a => "a", :b => "b"}
             expect(a_double).to receive(:random_call).with(:a => "a", :b => "b")
             expect do

--- a/spec/rspec/mocks/stub_implementation_spec.rb
+++ b/spec/rspec/mocks/stub_implementation_spec.rb
@@ -92,6 +92,20 @@ module RSpec
         include_context "with isolated configuration"
         before { RSpec::Mocks.configuration.verify_partial_doubles = true }
         include_examples "stubbing `new` on class objects"
+
+        if RSpec::Support::RubyFeatures.required_kw_args_supported?
+          binding.eval(<<-RUBY, __FILE__, __LINE__)
+          it "handles keyword arguments correctly" do
+            klass = Class.new do
+              def initialize(kw:)
+              end
+            end
+
+            allow(klass).to receive(:new).and_call_original
+            klass.new(kw: 42)
+          end
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
It seems there is place where arguments forwarding is not ok.

I continued the work started by @pirj on https://github.com/rspec/rspec-mocks/pull/1497

fixes #1497 
fixes #1502 
fixes #1495 
fixes #1513
fixes #1512

Related:
  - https://github.com/rspec/rspec-mocks/issues/1513#issuecomment-1368473138
  - https://github.com/rspec/rspec-mocks/issues/1495