### PR TITLE
chore: Fix some typos

### DIFF
--- a/features/basics/spies.feature
+++ b/features/basics/spies.feature
@@ -89,7 +89,7 @@ Feature: Spies
   Scenario: Set constraints using the fluent interface
     Given a file named "setting_constraints_spec.rb" with:
       """ruby
-      RSpec.describe "An invitiation" do
+      RSpec.describe "An invitation" do
         let(:invitation) { spy("invitation") }
 
         before do
@@ -120,12 +120,12 @@ Feature: Spies
     Then it should fail with the following output:
       | 4 examples, 2 failures                                                                              |
       |                                                                                                     |
-      |  1) An invitiation fails when a count constraint is not satisfied                                   |
+      |  1) An invitation fails when a count constraint is not satisfied                                    |
       |     Failure/Error: expect(invitation).to have_received(:deliver).at_least(3).times                  |
       |       (Double "invitation").deliver(*(any args))                                                    |
       |           expected: at least 3 times with any arguments                                             |
       |           received: 2 times with any arguments                                                      |
       |                                                                                                     |
-      |  2) An invitiation fails when an order constraint is not satisifed                                  |
+      |  2) An invitation fails when an order constraint is not satisifed                                   |
       |     Failure/Error: expect(invitation).to have_received(:deliver).with("foo@example.com").ordered    |
       |       #<Double "invitation"> received :deliver out of order                                         |

--- a/features/basics/spies.feature
+++ b/features/basics/spies.feature
@@ -101,7 +101,7 @@ Feature: Spies
           expect(invitation).to have_received(:deliver).twice
         end
 
-        it "passes when an order constraint is satisifed" do
+        it "passes when an order constraint is satisfied" do
           expect(invitation).to have_received(:deliver).with("foo@example.com").ordered
           expect(invitation).to have_received(:deliver).with("bar@example.com").ordered
         end
@@ -110,7 +110,7 @@ Feature: Spies
           expect(invitation).to have_received(:deliver).at_least(3).times
         end
 
-        it "fails when an order constraint is not satisifed" do
+        it "fails when an order constraint is not satisfied" do
           expect(invitation).to have_received(:deliver).with("bar@example.com").ordered
           expect(invitation).to have_received(:deliver).with("foo@example.com").ordered
         end
@@ -126,6 +126,6 @@ Feature: Spies
       |           expected: at least 3 times with any arguments                                             |
       |           received: 2 times with any arguments                                                      |
       |                                                                                                     |
-      |  2) An invitation fails when an order constraint is not satisifed                                   |
+      |  2) An invitation fails when an order constraint is not satisfied                                   |
       |     Failure/Error: expect(invitation).to have_received(:deliver).with("foo@example.com").ordered    |
       |       #<Double "invitation"> received :deliver out of order                                         |

--- a/features/configuring_responses/block_implementation.feature
+++ b/features/configuring_responses/block_implementation.feature
@@ -3,7 +3,7 @@ Feature: Block implementation
   When you pass a block, RSpec will use your block as the implementation of the method. Any
   arguments (or a block) provided by the caller will be yielded to your block implementation.
   This feature is extremely flexible, and supports many use cases that are not directly
-  supported by the more declaritive fluent interface.
+  supported by the more declarative fluent interface.
 
   You can pass a block to any of the fluent interface methods:
 

--- a/features/old_syntax/any_instance.feature
+++ b/features/old_syntax/any_instance.feature
@@ -37,7 +37,7 @@ Feature: `any_instance`
     Given a file named "spec/example_spec.rb" with:
       """ruby
       RSpec.describe "Stubbing multiple methods with any_instance" do
-        it "returns the specified values for the givne messages" do
+        it "returns the specified values for the given messages" do
           Object.any_instance.stub(:foo => 'foo', :bar => 'bar')
 
           o = Object.new

--- a/features/verifying_doubles/dynamic_classes.feature
+++ b/features/verifying_doubles/dynamic_classes.feature
@@ -66,7 +66,7 @@ Feature: Dynamic classes
     When I run `rspec spec/user_spec.rb`
     Then the output should contain "1 example, 1 failure"
 
-  Scenario: workaround with explict definitions
+  Scenario: workaround with explicit definitions
 
     Given a file named "lib/user.rb" with:
       """ruby

--- a/features/verifying_doubles/partial_doubles.feature
+++ b/features/verifying_doubles/partial_doubles.feature
@@ -25,7 +25,7 @@ Feature: Partial doubles
       RSpec.describe '#save_user' do
         it 'renders message on success' do
           user = User.new
-          expect(user).to receive(:saave).and_return(true) # Typo in name
+          expect(user).to receive(:save).and_return(true) # Typo in name
           expect(save_user(user)).to eq("saved!")
         end
       end

--- a/features/verifying_doubles/partial_doubles.feature
+++ b/features/verifying_doubles/partial_doubles.feature
@@ -25,7 +25,7 @@ Feature: Partial doubles
       RSpec.describe '#save_user' do
         it 'renders message on success' do
           user = User.new
-          expect(user).to receive(:save).and_return(true) # Typo in name
+          expect(user).to receive(:wave).and_return(true) # Typo in name
           expect(save_user(user)).to eq("saved!")
         end
       end

--- a/lib/rspec/mocks/any_instance/proxy.rb
+++ b/lib/rspec/mocks/any_instance/proxy.rb
@@ -10,7 +10,7 @@ module RSpec
       #
       # This proxy sits in front of the recorder and delegates both to it
       # and to the `RSpec::Mocks::Proxy` for each already mocked or stubbed
-      # instance of the class, in order to propogates changes to the instances.
+      # instance of the class, in order to propagates changes to the instances.
       #
       # Note that unlike `RSpec::Mocks::Proxy`, this proxy class is stateless
       # and is not persisted in `RSpec::Mocks.space`.

--- a/lib/rspec/mocks/minitest_integration.rb
+++ b/lib/rspec/mocks/minitest_integration.rb
@@ -37,7 +37,7 @@ if defined?(::Minitest::Expectation)
     # not want to here (or else we would interfere with rspec-expectations' definition).
   else
     # ...otherwise, define those methods now. If `rspec/expectations/minitest_integration`
-    # is loaded after this file, it'll overide the defintion here.
+    # is loaded after this file, it'll override the defintion here.
     Minitest::Expectation.class_eval do
       include RSpec::Mocks::ExpectationTargetMethods
 

--- a/lib/rspec/mocks/minitest_integration.rb
+++ b/lib/rspec/mocks/minitest_integration.rb
@@ -37,7 +37,7 @@ if defined?(::Minitest::Expectation)
     # not want to here (or else we would interfere with rspec-expectations' definition).
   else
     # ...otherwise, define those methods now. If `rspec/expectations/minitest_integration`
-    # is loaded after this file, it'll override the defintion here.
+    # is loaded after this file, it'll override the definition here.
     Minitest::Expectation.class_eval do
       include RSpec::Mocks::ExpectationTargetMethods
 

--- a/lib/rspec/mocks/mutate_const.rb
+++ b/lib/rspec/mocks/mutate_const.rb
@@ -81,7 +81,7 @@ module RSpec
       # Queries rspec-mocks to find out information about the named constant.
       #
       # @param [String] name the name of the constant
-      # @return [Constant] an object contaning information about the named
+      # @return [Constant] an object containing information about the named
       #   constant.
       def self.original(name)
         mutator = ::RSpec::Mocks.space.constant_mutator_for(name)

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -147,12 +147,12 @@ module RSpec
       end
 
       def add_expectation(*args, &block)
-        # explict params necessary for 1.8.7 see #626
+        # explicit params necessary for 1.8.7 see #626
         super(*args, &block).tap { |x| x.method_reference = @method_reference }
       end
 
       def add_stub(*args, &block)
-        # explict params necessary for 1.8.7 see #626
+        # explicit params necessary for 1.8.7 see #626
         super(*args, &block).tap { |x| x.method_reference = @method_reference }
       end
 

--- a/lib/rspec/mocks/verifying_proxy.rb
+++ b/lib/rspec/mocks/verifying_proxy.rb
@@ -57,7 +57,7 @@ module RSpec
     # A verifying proxy mostly acts like a normal proxy, except that it
     # contains extra logic to try and determine the validity of any expectation
     # set on it. This includes whether or not methods have been defined and the
-    # validatiy of arguments on method calls.
+    # validity of arguments on method calls.
     #
     # In all other ways this behaves like a normal proxy. It only adds the
     # verification behaviour to specific methods then delegates to the parent

--- a/spec/rspec/mocks/any_instance_spec.rb
+++ b/spec/rspec/mocks/any_instance_spec.rb
@@ -424,7 +424,7 @@ module RSpec
           expect(obj.existing_method).to eq(:existing_method_return_value)
         end
 
-        it "removes stubs from sub class after invokation when super class was originally stubbed" do
+        it "removes stubs from sub class after Invocation when super class was originally stubbed" do
           allow_any_instance_of(klass).to receive(:existing_method).and_return(:any_instance_value)
           obj = Class.new(klass).new
           expect(obj.existing_method).to eq(:any_instance_value)

--- a/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/spec/rspec/mocks/argument_matchers_spec.rb
@@ -295,7 +295,7 @@ module RSpec
         end
       end
 
-      context "handling arbitary matchers" do
+      context "handling arbitrary matchers" do
         it "matches any arbitrary object using #===" do
           matcher = double
           expect(matcher).to receive(:===).with(4).and_return(true)

--- a/spec/rspec/mocks/array_including_matcher_spec.rb
+++ b/spec/rspec/mocks/array_including_matcher_spec.rb
@@ -57,7 +57,7 @@ module RSpec
             expect(array_including(1, 2, 3, 4, 5)).not_to be === [1, 2]
           end
 
-          it "fails when passed a composed matcher is pased and not satisfied" do
+          it "fails when passed a composed matcher is passed and not satisfied" do
             with_unfulfilled_double do |dbl|
               expect {
                 klass = Class.new

--- a/spec/rspec/mocks/double_spec.rb
+++ b/spec/rspec/mocks/double_spec.rb
@@ -323,7 +323,7 @@ module RSpec
         @double.foo(:arg) { :bar }
       end
 
-      it "passes proc to stub block without an argurment" do
+      it "passes proc to stub block without an argument" do
         allow(@double).to receive(:foo) { |&block| expect(block.call).to eq(:bar) }
         @double.foo { :bar }
       end

--- a/spec/rspec/mocks/failure_notification_spec.rb
+++ b/spec/rspec/mocks/failure_notification_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Failure notification" do
     expect(error.backtrace.first).to match(/#{File.basename(__FILE__)}:#{expected_from_line}/)
   end
 
-  it "does not allow a double to miscount the number of times a message was recevied when a failure is notified in an alternate way" do
+  it "does not allow a double to miscount the number of times a message was received when a failure is notified in an alternate way" do
     dbl = double("Foo")
     expect(dbl).not_to receive(:bar)
 

--- a/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -492,7 +492,7 @@ module RSpec
             }.to raise_error(/received :two out of order/m)
           end
 
-          it "fails with at most receive counts when recieved out of order", :ordered_and_vague_counts_unsupported do
+          it "fails with at most receive counts when received out of order", :ordered_and_vague_counts_unsupported do
             the_dbl.one
             the_dbl.two
             the_dbl.one
@@ -503,7 +503,7 @@ module RSpec
             }.to raise_error(/received :two out of order/m)
           end
 
-          it "fails with at least receive counts when recieved out of order", :ordered_and_vague_counts_unsupported do
+          it "fails with at least receive counts when received out of order", :ordered_and_vague_counts_unsupported do
             the_dbl.one
             the_dbl.two
             the_dbl.one

--- a/spec/rspec/mocks/matchers/receive_message_chain_spec.rb
+++ b/spec/rspec/mocks/matchers/receive_message_chain_spec.rb
@@ -43,7 +43,7 @@ module RSpec::Mocks::Matchers
         expect(object.to_a.length).to eq(3)
       end
 
-      it "gives the { } block prescedence over the do block" do
+      it "gives the { } block precedence over the do block" do
         allow(object).to receive_message_chain(:to_a, :length) { 3 } do
           4
         end

--- a/spec/rspec/mocks/precise_counts_spec.rb
+++ b/spec/rspec/mocks/precise_counts_spec.rb
@@ -45,7 +45,7 @@ module RSpec
         verify @double
       end
 
-      it "passes mutiple calls with different args" do
+      it "passes multiple calls with different args" do
         expect(@double).to receive(:do_something).once.with(1)
         expect(@double).to receive(:do_something).once.with(2)
         @double.do_something(1)

--- a/spec/rspec/mocks/should_syntax_spec.rb
+++ b/spec/rspec/mocks/should_syntax_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe "Using the legacy should syntax" do
           expect(obj.existing_method).to eq(:existing_method_return_value)
         end
 
-        it "removes stubs from sub class after invokation when super class was originally stubbed" do
+        it "removes stubs from sub class after Invocation when super class was originally stubbed" do
           klass.any_instance.stub(:existing_method).and_return(:any_instance_value)
           obj = Class.new(klass).new
           expect(obj.existing_method).to eq(:any_instance_value)

--- a/spec/rspec/mocks/space_spec.rb
+++ b/spec/rspec/mocks/space_spec.rb
@@ -138,7 +138,7 @@ module RSpec::Mocks
           expect(get_proxy(space, obj1)).not_to equal(get_proxy(space, obj2))
         end
 
-        it 'can stil return a proxy from a parent context' do
+        it 'can still return a proxy from a parent context' do
           proxy    = get_proxy(space, Object)
           subspace = space.new_scope
 
@@ -183,7 +183,7 @@ module RSpec::Mocks
         expect(the_space.constant_mutator_for("Foo")).not_to equal(the_space.constant_mutator_for("Bar"))
       end
 
-      it 'can stil return a mutator from a parent context' do
+      it 'can still return a mutator from a parent context' do
         the_space = RSpec::Mocks.space
 
         stub_const("Foo", 3)
@@ -203,7 +203,7 @@ module RSpec::Mocks
         expect(space.any_instance_recorder_for(String)).not_to equal(space.any_instance_recorder_for(Symbol))
       end
 
-      it 'can stil return a recorder from a parent context' do
+      it 'can still return a recorder from a parent context' do
         recorder = space.any_instance_recorder_for(String)
         subspace = space.new_scope
 

--- a/spec/rspec/mocks/verifying_doubles/method_visibility_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/method_visibility_spec.rb
@@ -101,7 +101,7 @@ module RSpec
         double = yield
 
         expect {
-          # send bypasses visbility, so we use eval instead.
+          # send bypasses visibility, so we use eval instead.
           eval("double.#{method_name}")
         }.to raise_error(NoMethodError, a_message_indicating_visibility_violation(method_name, visibility))
 


### PR DESCRIPTION
This PR is fix some typos.

- s/invitiation/invitation/
- s/satisifed/satisfied/
- s/declaritive/declarative/
- s/givne/given/
- s/explict/explicit/
- s/saave/save/
- s/propogates/propagates/
- s/overide/override/
- s/defintion/definition/
- s/contaning/containing/
- s/validatiy/validity/
- s/invokation/Invocation/
- s/arbitary/arbitrary/
- s/pased/passed/
- s/argurment/argument/
- s/recevied/received/
- s/recieved/received/
- s/prescedence/precedence/
- s/mutiple/multiple/
- s/stil/still/
- s/visbility/visibility/