### PR TITLE
Receive: only avoid overriding own methods

### DIFF
--- a/lib/rspec/mocks/matchers/receive.rb
+++ b/lib/rspec/mocks/matchers/receive.rb
@@ -55,8 +55,9 @@ module RSpec
           setup_any_instance_method_substitute(subject, :stub, block)
         end
 
+        own_methods = (instance_methods - superclass.instance_methods)
         MessageExpectation.public_instance_methods(false).each do |method|
-          next if method_defined?(method)
+          next if own_methods.include?(method)
 
           define_method(method) do |*args, &block|
             @recorded_customizations << ExpectationCustomization.new(method, args, block)


### PR DESCRIPTION
Fix: https://github.com/rspec/rspec-mocks/issues/1530

My understanding of this `next if method_defined?` check that there since this class was added in 08ec2e80325a5959ac13b113a0175d28aca352a8 is that it's to prevent accidentally overriding Matcher or own methods.

If my understanding is correct, then we should ignore methods inherited from `Object`.