### PR TITLE
Allow assertion that Array#reverse is not called

### DIFF
--- a/lib/rspec/mocks/space.rb
+++ b/lib/rspec/mocks/space.rb
@@ -77,9 +77,9 @@ module RSpec
 
       def reset_all
         proxies.each_value { |proxy| proxy.reset }
-        @constant_mutators.reverse.each { |mut| mut.idempotently_reset }
         any_instance_recorders.each_value { |recorder| recorder.stop_all_observation! }
         any_instance_recorders.clear
+        @constant_mutators.reverse.each { |mut| mut.idempotently_reset }
       end
 
       def register_constant_mutator(mutator)

--- a/spec/rspec/mocks/space_spec.rb
+++ b/spec/rspec/mocks/space_spec.rb
@@ -57,6 +57,10 @@ module RSpec::Mocks
 
         expect(resets).to match_array([:dbl_1, :dbl_2])
       end
+
+      it "allows Array#reverse to be stubbed" do
+        expect_any_instance_of(Array).to_not receive(:reverse)
+      end
     end
 
     describe "#proxies_of(klass)" do

--- a/spec/rspec/mocks/space_spec.rb
+++ b/spec/rspec/mocks/space_spec.rb
@@ -59,6 +59,8 @@ module RSpec::Mocks
       end
 
       it "allows Array#reverse to be stubbed" do
+        # This is a regression check solved in rspec/rspec-mocks#1533 previously
+        # this was not possible without a change to the implementation
         expect_any_instance_of(Array).to_not receive(:reverse)
       end
     end


### PR DESCRIPTION
An `expect_any_instance_of(Array).to_not receive(:reverse)` will always fail because RSpec calls `Array#reverse` as part of its `reset_all` cleanup method, triggering the recorder before it is reset. This PR resolves the issue by clearing the recorders in `reset_all` before `Array#reverse` is called.

Fixes #1532 