### PR TITLE
fix stubbing with allow_any_instance_of when #with is monkey patched by Rails

### DIFF
--- a/lib/rspec/mocks/any_instance/proxy.rb
+++ b/lib/rspec/mocks/any_instance/proxy.rb
@@ -83,6 +83,14 @@ module RSpec
         end
       end
 
+      unless defined?(BasicObject)
+        class BasicObject
+          (instance_methods.map(&:to_sym) - [:__send__, :!, :instance_eval, :==, :instance_exec, :!=, :equal?, :__id__, :__binding__, :object_id]).each do |method|
+            undef_method method
+          end
+        end
+      end
+
       # @private
       # Delegates messages to each of the given targets in order to
       # provide the fluent interface that is available off of message
@@ -91,13 +99,7 @@ module RSpec
       # `targets` will typically contain 1 of the `AnyInstance::Recorder`
       # return values and N `MessageExpectation` instances (one per instance
       # of the `any_instance` klass).
-      class FluentInterfaceProxy < defined?(BasicObject) ? BasicObject : Object
-        if superclass == ::Object
-          (instance_methods.map(&:to_sym) - [:__send__, :!, :instance_eval, :==, :instance_exec, :!=, :equal?, :__id__, :__binding__, :object_id]).each do |method|
-            undef_method method
-          end
-        end
-
+      class FluentInterfaceProxy < BasicObject
         def initialize(targets)
           @targets = targets
         end

--- a/lib/rspec/mocks/any_instance/proxy.rb
+++ b/lib/rspec/mocks/any_instance/proxy.rb
@@ -85,6 +85,7 @@ module RSpec
 
       unless defined?(BasicObject)
         class BasicObject
+          # Remove all methods except those expected to be defined on BasicObject
           (instance_methods.map(&:to_sym) - [:__send__, :"!", :instance_eval, :==, :instance_exec, :"!=", :equal?, :__id__, :__binding__, :object_id]).each do |method|
             undef_method method
           end

--- a/lib/rspec/mocks/any_instance/proxy.rb
+++ b/lib/rspec/mocks/any_instance/proxy.rb
@@ -91,12 +91,12 @@ module RSpec
       # `targets` will typically contain 1 of the `AnyInstance::Recorder`
       # return values and N `MessageExpectation` instances (one per instance
       # of the `any_instance` klass).
-      class FluentInterfaceProxy
+      class FluentInterfaceProxy < BasicObject
         def initialize(targets)
           @targets = targets
         end
 
-        if RUBY_VERSION.to_f > 1.8
+        if ::RUBY_VERSION.to_f > 1.8
           def respond_to_missing?(method_name, include_private=false)
             super || @targets.first.respond_to?(method_name, include_private)
           end

--- a/lib/rspec/mocks/any_instance/proxy.rb
+++ b/lib/rspec/mocks/any_instance/proxy.rb
@@ -91,7 +91,13 @@ module RSpec
       # `targets` will typically contain 1 of the `AnyInstance::Recorder`
       # return values and N `MessageExpectation` instances (one per instance
       # of the `any_instance` klass).
-      class FluentInterfaceProxy < BasicObject
+      class FluentInterfaceProxy < defined?(BasicObject) ? BasicObject : Object
+        if superclass == ::Object
+          (instance_methods.map(&:to_sym) - [:__send__, :!, :instance_eval, :==, :instance_exec, :!=, :equal?, :__id__, :__binding__, :object_id]).each do |method|
+            undef_method method
+          end
+        end
+
         def initialize(targets)
           @targets = targets
         end

--- a/lib/rspec/mocks/any_instance/proxy.rb
+++ b/lib/rspec/mocks/any_instance/proxy.rb
@@ -85,7 +85,7 @@ module RSpec
 
       unless defined?(BasicObject)
         class BasicObject
-          (instance_methods.map(&:to_sym) - [:__send__, :!, :instance_eval, :==, :instance_exec, :!=, :equal?, :__id__, :__binding__, :object_id]).each do |method|
+          (instance_methods.map(&:to_sym) - [:__send__, :"!", :instance_eval, :==, :instance_exec, :"!=", :equal?, :__id__, :__binding__, :object_id]).each do |method|
             undef_method method
           end
         end

--- a/spec/integration/rails_support_spec.rb
+++ b/spec/integration/rails_support_spec.rb
@@ -33,4 +33,31 @@ RSpec.describe "Supporting Rails monkey patches", :type => :aruba do
     expect(last_command_started).to have_output(/0 failures/)
     expect(last_command_started).to have_exit_status(0)
   end
+
+  it "works mocking any instance when Rails has monkey patched #with" do
+    write_file(
+      "spec/with_monkey_patch_spec.rb",
+      """
+      class Object
+        # Rails monkey patches in **kwargs but this is a good analogy
+        def with
+        end
+      end
+
+      RSpec.describe do
+        specify do
+          klass = Class.new
+          allow_any_instance_of(klass).to receive(:bar).with(:y) { 2 }
+
+          expect(klass.new.bar(:y)).to eq 2
+        end
+      end
+      """
+    )
+
+    run_command("bundle exec rspec spec/with_monkey_patch_spec.rb")
+
+    expect(last_command_started).to have_output(/0 failures/)
+    expect(last_command_started).to have_exit_status(0)
+  end
 end


### PR DESCRIPTION
When stubbing with `allow_any_instance_of` and using the Rails monkey patch `with`, the `with` method is define on `FluentInterfaceProxy` so it is not being correctly delegated to the target.

By using BasicObject, FluentInterfaceProxy doesn't inherit any monkey patches that Rails or other libraries make on Object and so is better able to delegate the method calls.

