### PR TITLE
Allow successful mocking of Mutex#synchronize

### DIFF
--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -9,7 +9,7 @@ module RSpec
         end
       end
 
-      unless defined?(Mutex)
+      unless defined?(Proxy::Mutex)
         Support.require_rspec_support 'mutex'
         Mutex = Support::Mutex
       end

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -1,3 +1,5 @@
+RSpec::Support.require_rspec_support 'mutex'
+
 module RSpec
   module Mocks
     # @private
@@ -7,11 +9,6 @@ module RSpec
         def ==(expectation)
           expectation.orig_object == object && expectation.matches?(message, *args)
         end
-      end
-
-      unless defined?(Proxy::Mutex)
-        Support.require_rspec_support 'mutex'
-        Mutex = Support::Mutex
       end
 
       # @private

--- a/lib/rspec/mocks/proxy.rb
+++ b/lib/rspec/mocks/proxy.rb
@@ -27,7 +27,7 @@ module RSpec
         @order_group = order_group
         @error_generator = ErrorGenerator.new(object)
         @messages_received = []
-        @messages_received_mutex = Mutex.new
+        @messages_received_mutex = Support::Mutex.new
         @options = options
         @null_object = false
         @method_doubles = Hash.new { |h, k| h[k] = MethodDouble.new(@object, k, self) }

--- a/spec/rspec/mocks/mutex_spec.rb
+++ b/spec/rspec/mocks/mutex_spec.rb
@@ -1,0 +1,18 @@
+module RSpec
+  module Mocks
+    RSpec.describe "Mocking Mutex" do
+      let(:mocked_mutex) { instance_double(Mutex) }
+      before do
+        allow(Mutex).to receive(:new).and_return(mocked_mutex)
+        allow(mocked_mutex).to receive(:synchronize).and_yield
+      end
+
+      it "successfully yields" do
+        called = false
+        mutex = Mutex.new
+        mutex.synchronize { called = true }
+        expect(called).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes the issue described in https://github.com/rspec/rspec-mocks/issues/1574, which might have other presentations.

Fundamentally, it appears that the Mutex used by `RSpec::Mocks::Proxy` is not necessarily using the 'stashed' original `Mutex` implementation. I believe that this problem will happen only when the _first_ mock attempted is a mock of the Mutex class, as that's when the Proxy instance gets created with its `@messages_received_mutex` instance (though I'm unsure how often Proxy is recreated).

This PR should fix #1574, but I'm not confident that the spec I've included is appropriate, or in the right place.