### PR TITLE
Fix build for Ruby 3.4.0 preview 1

### DIFF
--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -68,7 +68,7 @@ module RSpec
       #   counter.count # => 3
       #   counter.count # => 3
       #   # etc
-      def and_return(first_value, *values)
+      def and_return(first_value, *values, &_block)
         raise_already_invoked_error_if_necessary(__method__)
         if negative?
           raise "`and_return` is not supported with negative message expectations"
@@ -106,7 +106,7 @@ module RSpec
       #   api.get_foo # => :a_foo
       #   api.get_foo # => :a_foo
       #   # etc
-      def and_invoke(first_proc, *procs)
+      def and_invoke(first_proc, *procs, &_block)
         raise_already_invoked_error_if_necessary(__method__)
         if negative?
           raise "`and_invoke` is not supported with negative message expectations"

--- a/lib/rspec/mocks/syntax.rb
+++ b/lib/rspec/mocks/syntax.rb
@@ -115,7 +115,7 @@ module RSpec
             Matchers::Receive.new(method_name, block)
           end
 
-          def receive_messages(message_return_value_hash)
+          def receive_messages(message_return_value_hash, &_block)
             matcher = Matchers::ReceiveMessages.new(message_return_value_hash)
             matcher.warn_about_block if block_given?
             matcher

--- a/spec/rspec/mocks/stub_spec.rb
+++ b/spec/rspec/mocks/stub_spec.rb
@@ -87,12 +87,12 @@ module RSpec
 
       it "remains private when it stubs a private instance method" do
         allow(@instance).to receive(:existing_private_instance_method).and_return(1)
-        expect { @instance.existing_private_instance_method }.to raise_error NoMethodError, /private method `existing_private_instance_method/
+        expect { @instance.existing_private_instance_method }.to raise_error NoMethodError, /private method [`']existing_private_instance_method/
       end
 
       it "remains private when it stubs a private class method" do
         allow(@class).to receive(:existing_private_class_method).and_return(1)
-        expect { @class.existing_private_class_method }.to raise_error NoMethodError, /private method `existing_private_class_method/
+        expect { @class.existing_private_class_method }.to raise_error NoMethodError, /private method [`']existing_private_class_method/
       end
 
       context "using `with`" do

--- a/spec/rspec/mocks/verifying_doubles/class_double_with_class_not_loaded_spec.rb
+++ b/spec/rspec/mocks/verifying_doubles/class_double_with_class_not_loaded_spec.rb
@@ -46,7 +46,7 @@ module RSpec
         it 'can mock private module methods' do
           double = Module.new
           allow(double).to receive(:use)
-          expect { double.use }.to raise_error(/private method `use' called/)
+          expect { double.use }.to raise_error(/private method [`']use' called/)
 
           double = class_double("NonloadedClass")
           expect(double).to receive(:use).and_return(:ok)


### PR DESCRIPTION
Ruby head is currently Ruby 3.4 and has a couple of changes which issue warnings this PR:

- Removes some warnings about block paramters being unused, even though ironically, they are
- Relaxes some checks around formatting
