### PR TITLE
Extend and_invoke docs

### DIFF
--- a/features/configuring_responses/mixed_responses.feature
+++ b/features/configuring_responses/mixed_responses.feature
@@ -24,7 +24,7 @@ Feature: Mixed responses
      When I run `rspec raises_and_then_returns.rb`
      Then the examples should all pass
 
-  Scenario: Yielding
+  Scenario: Block arguments
     Given a file named "yields_and_raises.rb" with:
       """ruby
       RSpec.describe "when the method is called multiple times" do

--- a/features/configuring_responses/mixed_responses.feature
+++ b/features/configuring_responses/mixed_responses.feature
@@ -4,12 +4,9 @@ Feature: Mixed responses
   callables to have different behavior for consecutive calls. The final callable will continue to be
   called if the message is received additional times.
 
-  Note: The invoked callable will be invoked with the calls arguments, so it is recommended to
-  use a `lambda` or similar with the same arity as your method but you can use a `proc` if you
-  do not care about arity (e.g. when raising).
-
-  Note: You can also use `and_invoke` to yield. In this case, use a `proc` with a `&block`
-  parameter.
+  Note: The invoked callable will be supplied the calls arguments, including any blocks (so `yield`
+  et al will be supported). It is recommended to use a `lambda` or similar with the same arity
+  as your method but you can use a `proc` if you do not care about arity(e.g. when raising).
 
   Scenario: Mixed responses
     Given a file named "raises_and_then_returns.rb" with:

--- a/features/configuring_responses/mixed_responses.feature
+++ b/features/configuring_responses/mixed_responses.feature
@@ -8,6 +8,9 @@ Feature: Mixed responses
   use a `lambda` or similar with the same arity as your method but you can use a `proc` if you
   do not care about arity (e.g. when raising).
 
+  Note: You can also use `and_invoke` to yield. In this case, use a `proc` with a `&block`
+  parameter.
+
   Scenario: Mixed responses
     Given a file named "raises_and_then_returns.rb" with:
       """ruby
@@ -22,4 +25,23 @@ Feature: Mixed responses
       end
       """
      When I run `rspec raises_and_then_returns.rb`
+     Then the examples should all pass
+
+  Scenario: Yielding
+    Given a file named "yields_and_raises.rb" with:
+      """ruby
+      RSpec.describe "when the method is called multiple times" do
+        it "yields and then later raises" do
+          dbl = double
+          allow(dbl).to receive(:foo).and_invoke(
+            proc { |&block| block.call("foo") },
+            proc { raise "failure" }
+          )
+
+          dbl.foo { |yielded| expect(yielded).to eq("foo") }
+          expect { dbl.foo }.to raise_error("failure")
+        end
+      end
+      """
+     When I run `rspec yields_and_raises.rb`
      Then the examples should all pass


### PR DESCRIPTION
There's no other way certain things can be done.

It came handy the other day when I needed to add a spec for something that runs in a loop, to end the loop conditionally.
It's helpful to mix raising exceptions with yielding, too.

```ruby
  class Sut
    def main_loop
      until requested_stop?
        abc.foo { |bar| puts bar }
      end
    end
  end

  class Abc
    # ...
    def foo(&_block)
      bar = baz.baz
      yield bar
    end
  end
```

```
# spec
    abc = Abc.new
    main_loop = Sut.new(abc)
    allow(abc).to receive(:foo)
                             .and_invoke(
                               proc { |&block|
                                 main_loop.stop!
                                 block.call("bar") # NOTE: yield isn't available here
                               }
                             )
  
    main_loop.run
```