### PR TITLE
Ensure backtraces start at user code, not rspec-mocks code

### DIFF
--- a/lib/rspec/mocks/error_generator.rb
+++ b/lib/rspec/mocks/error_generator.rb
@@ -328,8 +328,22 @@ module RSpec
       def __raise(message, backtrace_line=nil, source_id=nil)
         message = opts[:message] unless opts[:message].nil?
         exception = RSpec::Mocks::MockExpectationError.new(message)
+        filter_backtrace!(exception)
         prepend_to_backtrace(exception, backtrace_line) if backtrace_line
         notify exception, :source_id => source_id
+      end
+
+      def filter_backtrace!(exception)
+        backtrace = exception.backtrace || caller
+        source = backtrace.rindex { |l| l =~ /#{File::SEPARATOR}rspec-mocks(-[^#{File::SEPARATOR}]+)?#{File::SEPARATOR}/ }
+
+        unless source.nil?
+          backtrace = backtrace[(source+1)..-1]
+        end
+
+        unless backtrace.empty?
+          exception.set_backtrace(backtrace)
+        end
       end
 
       if RSpec::Support::Ruby.jruby?


### PR DESCRIPTION
This will ensure all exceptions generated by rspec-mocks have the first line of their backtraces pointing to the user's code where the error happened.

Addresses #1592 