### PR TITLE
Support keyword arguments with and_invoke

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 ### Development
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.13.1...main)
 
+Bug Fixes:
+
+* Support keyword arguments in callables passed to `and_invoke`. (Jon Rowe, #1595)
+
 ### 3.13.1 / 2024-05-08
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.13.0...v3.13.1)
 

--- a/lib/rspec/mocks/message_expectation.rb
+++ b/lib/rspec/mocks/message_expectation.rb
@@ -748,6 +748,7 @@ module RSpec
 
         proc.call(*args, &block)
       end
+      ruby2_keywords(:call) if respond_to?(:ruby2_keywords, true)
     end
 
     # Represents a configured implementation. Takes into account

--- a/spec/rspec/mocks/and_invoke_spec.rb
+++ b/spec/rspec/mocks/and_invoke_spec.rb
@@ -39,6 +39,18 @@ module RSpec
           expect(dbl.square_then_cube(2)).to eq 4
           expect(dbl.square_then_cube(2)).to eq 8
         end
+
+        if RSpec::Support::RubyFeatures.kw_args_supported?
+          binding.eval(<<-RUBY, __FILE__, __LINE__)
+          it 'passes keyword arguments into the callable' do
+            expect(dbl).to receive(:square_then_cube).and_invoke(lambda { |i: 1| i ** 2 },
+                                                                 lambda { |i: 1| i ** 3 })
+
+            expect(dbl.square_then_cube(i: 2)).to eq 4
+            expect(dbl.square_then_cube(i: 2)).to eq 8
+          end
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
Another spot where we haven't declared that we are passing through arguments that may contain keyword hashes, should fix #1594 